### PR TITLE
Allow sampling multiple patches from the same stack

### DIFF
--- a/viscy/cli/cli.py
+++ b/viscy/cli/cli.py
@@ -21,7 +21,6 @@ class VSLightningCLI(LightningCLI):
         return subcommands
 
     def add_arguments_to_parser(self, parser):
-        parser.link_arguments("data.batch_size", "model.batch_size")
         parser.link_arguments("data.yx_patch_size", "model.example_input_yx_shape")
         parser.link_arguments("model.model_config.architecture", "data.architecture")
         parser.set_defaults(

--- a/viscy/light/data.py
+++ b/viscy/light/data.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import math
 import os
@@ -53,17 +51,6 @@ def _search_int_in_str(pattern: str, file_name: str) -> str:
         raise ValueError(f"Cannot find pattern {pattern} in {file_name}.")
 
 
-def _collate_samples(batch: Sequence[Sample]) -> Sample:
-    elemment = batch[0]
-    collated = {}
-    for key in elemment.keys():
-        data: list[list[torch.Tensor]] = [sample[key] for sample in batch]
-        collated[key] = collate_meta_tensor(
-            [im for imgs in data for im in imgs]
-        )
-    return collated
-
-
 class ChannelMap(TypedDict, total=False):
     source: Union[str, Sequence[str]]
     # optional
@@ -76,6 +63,15 @@ class Sample(TypedDict, total=False):
     source: Union[torch.Tensor, Sequence[torch.Tensor]]
     target: Union[torch.Tensor, Sequence[torch.Tensor]]
     labels: Union[torch.Tensor, Sequence[torch.Tensor]]
+
+
+def _collate_samples(batch: Sequence[Sample]) -> Sample:
+    elemment = batch[0]
+    collated = {}
+    for key in elemment.keys():
+        data: list[list[torch.Tensor]] = [sample[key] for sample in batch]
+        collated[key] = collate_meta_tensor([im for imgs in data for im in imgs])
+    return collated
 
 
 class NormalizeSampled(MapTransform, InvertibleTransform):

--- a/viscy/light/data.py
+++ b/viscy/light/data.py
@@ -190,6 +190,9 @@ class SlidingWindowDataset(Dataset):
     def _stack_channels(
         self, sample_images: list[dict[str, torch.Tensor]], key: str
     ) -> torch.Tensor:
+        if not isinstance(sample_images, list):
+            return torch.stack([sample_images[ch][0] for ch in self.channels[key]])
+        # training time
         return [
             torch.stack([im[ch][0] for ch in self.channels[key]])
             for im in sample_images

--- a/viscy/scripts/network_diagram.py
+++ b/viscy/scripts/network_diagram.py
@@ -13,7 +13,6 @@ model = VSUNet(
         "backbone": "convnextv2_femto",
         "stem_kernel_size": (3, 4, 4),
     },
-    batch_size=32,
 )
 # %%
 model_graph = draw_graph(


### PR DESCRIPTION
@mattersoflight and I had a discussion about potential data utilization problem when only sampling one patch from a stack at each training step. While with longer training schedule, all ROIs will still get sampled, this does waste a lot of I/O bandwidth, since most of the data loaded from disk is not used in the batch. This problem becomes more prominent when the stack depth increases, where even local NVME pools cannot keep the GPU fed with data.

This PR implements a new data module argument `train_patches_per_stack`, allowing sampling multiple patches from a single stack, effective only in training. The batch size has to be divisible by this number for collation to work. When I/O-bound, this can greatly speed up data-loading. Below is a test of single-precision batch tensor with size (32, 2, 5, 2048, 2048), worker number equals number of batches loaded (all 5 batches loaded in parallel, sharing I/O bandwidth). Data is stored on a Lustre server in the local infiniband network, and cache is warmed up by running the test several times before recording the result. Increasing `train_patches_per_stack` results in decreased total time. However the decrease is sub-linear, as the bottleneck shifts to compute.

```
train_patches_per_stack=1: 15869 function calls (15786 primitive calls) in 89.330 seconds
train_patches_per_stack=2: 13055 function calls (12972 primitive calls) in 49.898 seconds
train_patches_per_stack=4: 14321 function calls (14238 primitive calls) in 33.688 seconds
train_patches_per_stack=8: 14110 function calls (14027 primitive calls) in 24.769 seconds
```

However the `train_patches_per_stack` cannot be arbitrarily large. Sampling too many patches from the same stack reduces the variance of the batch, effectively reducing the batch size (in terms of statistical power). Also the chance of sampling background will increase. In practice this should be evaluated with batch size to avoid having too few stacks for a batch.

Below is the first 16 samples of the same batch when `train_patches_per_stack=4` showing some 'batch effect' for samples from the same stack.

![image](https://github.com/mehta-lab/VisCy/assets/67518483/3f6571c7-f0cb-4a5c-8a88-f12ba2cd2758)
