### PR TITLE
Example script for parsing CLI config files in Python

### DIFF
--- a/viscy/scripts/reuse_config.py
+++ b/viscy/scripts/reuse_config.py
@@ -1,0 +1,43 @@
+"""Script showing how to parse a config file in python with LightningCLI."""
+
+# %%
+from typing import Optional
+
+from viscy.cli.cli import HCSDataModule, VSLightningCLI, VSTrainer, VSUNet
+
+
+class PlaceholderPredictTrainer(VSTrainer):
+    def predict(self, ckpt_path: Optional[str] = None, *args, **kwargs):
+        pass
+
+
+# %%
+stage = "predict"
+
+args = [
+    stage,
+    "--config",
+    "/hpc/projects/comp.micro/mantis/2023_08_18_A549_CellMask/3-registration/prediction/predict.yml",
+]
+
+
+# %%
+cli = VSLightningCLI(
+    model_class=VSUNet,
+    trainer_class=PlaceholderPredictTrainer,
+    datamodule_class=HCSDataModule,
+    save_config_callback=None,
+    args=args,
+)
+
+# %%
+dm = cli.datamodule
+dm.setup(stage)
+
+dl = dm.predict_dataloader()
+
+# %%
+for batch in dl:
+    print(batch)
+    break
+# %%

--- a/viscy/scripts/reuse_config.py
+++ b/viscy/scripts/reuse_config.py
@@ -14,11 +14,7 @@ class PlaceholderPredictTrainer(VSTrainer):
 # %%
 stage = "predict"
 
-args = [
-    stage,
-    "--config",
-    "/hpc/projects/comp.micro/mantis/2023_08_18_A549_CellMask/3-registration/prediction/predict.yml",
-]
+args = [stage, "--config", "predict.yml"]
 
 
 # %%


### PR DESCRIPTION
Shows how to subclass the trainer with a placeholder method so the CLI parser can be reused.

Adapted from https://github.com/Lightning-AI/lightning/issues/12302#issuecomment-1110425635.

What we actually want is probably https://github.com/Lightning-AI/lightning/pull/18105.