### PR TITLE
checkpoint as a model config parameter for warmup cosine learning rates

### DIFF
--- a/examples/configs/fit_example.yml
+++ b/examples/configs/fit_example.yml
@@ -23,7 +23,7 @@ model:
   loss_function: null
   lr: 0.001
   schedule: Constant
-  chkpt_path: null
+  ckpt_path: null
   log_batches_per_epoch: 8
   log_samples_per_batch: 1
 data:

--- a/examples/configs/fit_example.yml
+++ b/examples/configs/fit_example.yml
@@ -23,6 +23,7 @@ model:
   loss_function: null
   lr: 0.001
   schedule: Constant
+  chkpt_path: null
   log_batches_per_epoch: 8
   log_samples_per_batch: 1
 data:

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -122,7 +122,7 @@ class VSUNet(LightningModule):
         loss_function: Union[nn.Module, MixedLoss] = None,
         lr: float = 1e-3,
         schedule: Literal["WarmupCosine", "Constant"] = "Constant",
-        chkpt_path: str = None,
+        ckpt_path: str = None,
         log_batches_per_epoch: int = 8,
         log_samples_per_batch: int = 1,
         example_input_yx_shape: Sequence[int] = (256, 256),
@@ -163,9 +163,10 @@ class VSUNet(LightningModule):
         self.test_cellpose_model_path = test_cellpose_model_path
         self.test_cellpose_diameter = test_cellpose_diameter
         self.test_evaluate_cellpose = test_evaluate_cellpose
-        if chkpt_path is not None:
+
+        if ckpt_path is not None:
             self.load_state_dict(
-                torch.load(chkpt_path)["state_dict"]
+                torch.load(ckpt_path)["state_dict"]
             )  # loading only weights
 
     def forward(self, x) -> torch.Tensor:

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -121,6 +121,7 @@ class VSUNet(LightningModule):
         loss_function: Union[nn.Module, MixedLoss] = None,
         lr: float = 1e-3,
         schedule: Literal["WarmupCosine", "Constant"] = "Constant",
+        chkpt_path: str = None,
         log_batches_per_epoch: int = 8,
         log_samples_per_batch: int = 1,
         example_input_yx_shape: Sequence[int] = (256, 256),
@@ -144,6 +145,8 @@ class VSUNet(LightningModule):
         self.schedule = schedule
         self.log_batches_per_epoch = log_batches_per_epoch
         self.log_samples_per_batch = log_samples_per_batch
+        if chkpt_path is not None:
+            self.model.load_state_dict(torch.load(chkpt_path)["state_dict"])
         self.training_step_outputs = []
         self.validation_step_outputs = []
         # required to log the graph

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -96,6 +96,7 @@ class VSUNet(LightningModule):
     :param float lr: learning rate in training, defaults to 1e-3
     :param Literal['WarmupCosine', 'Constant'] schedule:
         learning rate scheduler, defaults to "Constant"
+    :param str chkpt_path: path to the checkpoint to load weights, defaults to None
     :param int log_batches_per_epoch:
         number of batches to log each training/validation epoch,
         has to be smaller than steps per epoch, defaults to 8
@@ -146,7 +147,9 @@ class VSUNet(LightningModule):
         self.log_batches_per_epoch = log_batches_per_epoch
         self.log_samples_per_batch = log_samples_per_batch
         if chkpt_path is not None:
-            self.model.load_state_dict(torch.load(chkpt_path)["state_dict"])
+            self.model.load_state_dict(
+                torch.load(chkpt_path)["state_dict"], strict=False
+            )  # loading only weights
         self.training_step_outputs = []
         self.validation_step_outputs = []
         # required to log the graph

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -146,10 +146,7 @@ class VSUNet(LightningModule):
         self.schedule = schedule
         self.log_batches_per_epoch = log_batches_per_epoch
         self.log_samples_per_batch = log_samples_per_batch
-        if chkpt_path is not None:
-            self.model.load_state_dict(
-                torch.load(chkpt_path)["state_dict"], strict=False
-            )  # loading only weights
+
         self.training_step_outputs = []
         self.validation_step_outputs = []
         # required to log the graph
@@ -166,6 +163,10 @@ class VSUNet(LightningModule):
         self.test_cellpose_model_path = test_cellpose_model_path
         self.test_cellpose_diameter = test_cellpose_diameter
         self.test_evaluate_cellpose = test_evaluate_cellpose
+        if chkpt_path is not None:
+            self.load_state_dict(
+                torch.load(chkpt_path)["state_dict"]
+            )  # loading only weights
 
     def forward(self, x) -> torch.Tensor:
         return self.model(x)

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -146,7 +146,6 @@ class VSUNet(LightningModule):
         self.schedule = schedule
         self.log_batches_per_epoch = log_batches_per_epoch
         self.log_samples_per_batch = log_samples_per_batch
-
         self.training_step_outputs = []
         self.validation_step_outputs = []
         # required to log the graph


### PR DESCRIPTION
This PR adds the an extra parameter for the CLI to provide the checkpoint path to be loaded such that is compatible when using warmup cosine learning rates. By default, the lightning CLI has a `ckpt_path`, but this loads the previous checkpoint's learning rate as well as the weights. When using the latter option, the re-training for next model starts as a 'sine' function rather than cosine. 
