### PR TITLE
Fix 3D to 2D prediction with UNeXt2 model

### DIFF
--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -29,7 +29,7 @@ from viscy.data.hcs import Sample
 from viscy.evaluation.evaluation_metrics import mean_average_precision, ms_ssim_25d
 from viscy.unet.networks.fcmae import FullyConvolutionalMAE
 from viscy.unet.networks.Unet2D import Unet2d
-from viscy.unet.networks.Unet21D import Unet21d
+from viscy.unet.networks.Unet21D import Unet22d
 from viscy.unet.networks.Unet25D import Unet25d
 
 try:
@@ -40,9 +40,7 @@ except ImportError:
 
 _UNET_ARCHITECTURE = {
     "2D": Unet2d,
-    "2.1D": Unet21d,
-    # same class with out_stack_depth > 1
-    "2.2D": Unet21d,
+    "2.2D": Unet22d,
     "2.5D": Unet25d,
     "fcmae": FullyConvolutionalMAE,
 }
@@ -139,8 +137,6 @@ class VSUNet(LightningModule):
             raise ValueError(
                 f"Architecture {architecture} not in {_UNET_ARCHITECTURE.keys()}"
             )
-        if architecture == "2.2D":
-            model_config["out_stack_depth"] = model_config["in_stack_depth"]
         self.model = net_class(**model_config)
         # TODO: handle num_outputs in metrics
         # self.out_channels = self.model.terminal_block.out_filters

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -29,7 +29,7 @@ from viscy.data.hcs import Sample
 from viscy.evaluation.evaluation_metrics import mean_average_precision, ms_ssim_25d
 from viscy.unet.networks.fcmae import FullyConvolutionalMAE
 from viscy.unet.networks.Unet2D import Unet2d
-from viscy.unet.networks.Unet21D import Unet22d
+from viscy.unet.networks.Unet22D import Unet22d
 from viscy.unet.networks.Unet25D import Unet25d
 
 try:

--- a/viscy/scripts/network_diagram.py
+++ b/viscy/scripts/network_diagram.py
@@ -44,29 +44,30 @@ graph25d = model_graph.visual_graph
 graph25d
 
 # %%
-# 2.1D UNet without upsampling in Z.
+# 3D->2D
 model = VSUNet(
-    architecture="2.1D",
+    architecture="2.2D",
     model_config={
         "in_channels": 2,
-        "out_channels": 1,
-        "in_stack_depth": 9,
+        "out_channels": 3,
+        "in_stack_depth": 5,
+        "out_stack_depth": 1,
         "backbone": "convnextv2_tiny",
-        "stem_kernel_size": (3, 1, 1),
         "decoder_mode": "pixelshuffle",
+        "stem_kernel_size": (5, 4, 4),
     },
 )
 
 model_graph = draw_graph(
     model,
     model.example_input_array,
-    graph_name="2.1D UNet",
+    graph_name="2.2D UNet",
     roll=True,
     depth=3,
 )
 
-graph21d = model_graph.visual_graph
-graph21d
+model_graph.visual_graph
+
 # %%
 # 2.1D UNet with upsampling in Z.
 model = VSUNet(

--- a/viscy/unet/networks/Unet21D.py
+++ b/viscy/unet/networks/Unet21D.py
@@ -346,7 +346,13 @@ class Unet21d(nn.Module):
             upsample_pre_conv="default" if decoder_upsample_pre_conv else None,
         )
         if out_stack_depth == 1:
-            self.head = UnsqueezeHead()
+            self.head = ShufflelHead(
+                in_channels=decoder_channels[-1],
+                out_channels=out_channels,
+                out_stack_depth=out_stack_depth,
+                xy_scaling=stem_kernel_size[-1],
+                pool=head_pool,
+            )
         else:
             self.head = PixelToVoxelHead(
                 decoder_channels[-1],

--- a/viscy/unet/networks/Unet22D.py
+++ b/viscy/unet/networks/Unet22D.py
@@ -214,37 +214,6 @@ class UnsqueezeHead(nn.Module):
         return x
 
 
-class ShufflelHead(nn.Module):
-    """Shuffle (B, C * D * S**2, H, W) feature map to (B, C, D, H*S, W*S) output."""
-
-    def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        out_stack_depth: int = 5,
-        xy_scaling: int = 4,
-        pool: bool = False,
-    ) -> None:
-        super().__init__()
-        self.out_channels = out_channels
-        self.out_stack_depth = out_stack_depth
-        self.upsample = UpSample(
-            spatial_dims=2,
-            in_channels=in_channels,
-            out_channels=out_stack_depth * out_channels,
-            scale_factor=xy_scaling,
-            mode="pixelshuffle",
-            pre_conv=None,
-            apply_pad_pool=pool,
-        )
-
-    def forward(self, x: Tensor) -> Tensor:
-        x = self.upsample(x)
-        b, _, h, w = x.shape
-        x = x.reshape(b, self.out_channels, self.out_stack_depth, h, w)
-        return x
-
-
 class Unet2dDecoder(nn.Module):
     def __init__(
         self,

--- a/viscy/unet/networks/Unet22D.py
+++ b/viscy/unet/networks/Unet22D.py
@@ -316,7 +316,7 @@ class Unet22d(nn.Module):
         # replace first convolution layer with a projection tokenizer
         multi_scale_encoder.stem_0 = nn.Identity()
         self.encoder_stages = multi_scale_encoder
-        self.stem = Conv21dStem(
+        self.stem = Conv22dStem(
             in_channels, num_channels[0], stem_kernel_size, in_stack_depth
         )
         decoder_channels = num_channels

--- a/viscy/unet/networks/Unet22D.py
+++ b/viscy/unet/networks/Unet22D.py
@@ -64,7 +64,7 @@ def _get_convnext_stage(
     return stage
 
 
-class Conv21dStem(nn.Module):
+class Conv22dStem(nn.Module):
     """Stem for 2.1D networks."""
 
     def __init__(

--- a/viscy/unet/networks/fcmae.py
+++ b/viscy/unet/networks/fcmae.py
@@ -18,7 +18,7 @@ from timm.models.convnext import (
 )
 from torch import BoolTensor, Size, Tensor, nn
 
-from viscy.unet.networks.Unet21D import PixelToVoxelHead, Unet2dDecoder, UnsqueezeHead
+from viscy.unet.networks.Unet22D import PixelToVoxelHead, Unet2dDecoder, UnsqueezeHead
 
 
 def _init_weights(module: nn.Module) -> None:


### PR DESCRIPTION
Removed the "2.1D" architecture and made the output stack depth of "2.2D" configurable between 2D and 3D.

Fix #78.