### PR TITLE
Test time augmentations

### DIFF
--- a/viscy/data/ctmc_v1.py
+++ b/viscy/data/ctmc_v1.py
@@ -10,7 +10,6 @@ from viscy.data.typing import Sample
 
 
 class CTMCv1ValidationDataset(SlidingWindowDataset):
-
     def __len__(self, subsample_rate: int = 30) -> int:
         # sample every 30th frame in the videos
         return super().__len__() // self.subsample_rate

--- a/viscy/data/hcs.py
+++ b/viscy/data/hcs.py
@@ -311,7 +311,6 @@ class HCSDataModule(LightningDataModule):
         yx_patch_size: tuple[int, int] = (256, 256),
         normalizations: list[MapTransform] = [],
         augmentations: list[MapTransform] = [],
-        test_time_augmentations: list[MapTransform] = [],
         caching: bool = False,
         ground_truth_masks: Optional[Path] = None,
     ):
@@ -327,7 +326,6 @@ class HCSDataModule(LightningDataModule):
         self.yx_patch_size = yx_patch_size
         self.normalizations = normalizations
         self.augmentations = augmentations
-        self.test_time_augmentations = test_time_augmentations
         self.caching = caching
         self.ground_truth_masks = ground_truth_masks
         self.prepare_data_per_node = True
@@ -477,7 +475,7 @@ class HCSDataModule(LightningDataModule):
             positions = [plate[fov_name]]
         elif isinstance(dataset, Plate):
             positions = [p for _, p in dataset.positions()]
-        predict_transform = Compose(self.normalizations, self.test_time_augmentations)
+        predict_transform = Compose(self.normalizations)
         self.predict_dataset = SlidingWindowDataset(
             positions=positions,
             transform=predict_transform,

--- a/viscy/data/hcs.py
+++ b/viscy/data/hcs.py
@@ -311,6 +311,7 @@ class HCSDataModule(LightningDataModule):
         yx_patch_size: tuple[int, int] = (256, 256),
         normalizations: list[MapTransform] = [],
         augmentations: list[MapTransform] = [],
+        test_time_augmentations: list[MapTransform] = [],
         caching: bool = False,
         ground_truth_masks: Optional[Path] = None,
     ):
@@ -326,6 +327,7 @@ class HCSDataModule(LightningDataModule):
         self.yx_patch_size = yx_patch_size
         self.normalizations = normalizations
         self.augmentations = augmentations
+        self.test_time_augmentations = test_time_augmentations
         self.caching = caching
         self.ground_truth_masks = ground_truth_masks
         self.prepare_data_per_node = True
@@ -453,7 +455,10 @@ class HCSDataModule(LightningDataModule):
                 **dataset_settings,
             )
 
-    def _setup_predict(self, dataset_settings: dict):
+    def _setup_predict(
+        self,
+        dataset_settings: dict,
+    ):
         """Set up the predict stage."""
         # track metadata for inverting transform
         set_track_meta(True)
@@ -472,7 +477,7 @@ class HCSDataModule(LightningDataModule):
             positions = [plate[fov_name]]
         elif isinstance(dataset, Plate):
             positions = [p for _, p in dataset.positions()]
-        predict_transform = Compose(self.normalizations)
+        predict_transform = Compose(self.normalizations, self.test_time_augmentations)
         self.predict_dataset = SlidingWindowDataset(
             positions=positions,
             transform=predict_transform,

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -8,7 +8,7 @@ from imageio import imwrite
 from lightning.pytorch import LightningModule
 from matplotlib.pyplot import get_cmap
 from monai.optimizers import WarmupCosineSchedule
-from monai.transforms import DivisiblePad
+from monai.transforms import DivisiblePad, Rotate90d, Compose, Rotate90
 from skimage.exposure import rescale_intensity
 from torch import Tensor, nn
 from torch.nn import functional as F
@@ -31,6 +31,7 @@ from viscy.unet.networks.fcmae import FullyConvolutionalMAE
 from viscy.unet.networks.Unet2D import Unet2d
 from viscy.unet.networks.Unet25D import Unet25d
 from viscy.unet.networks.unext2 import UNeXt2
+
 
 try:
     from cellpose.models import CellposeModel
@@ -130,6 +131,8 @@ class VSUNet(LightningModule):
         test_cellpose_model_path: str = None,
         test_cellpose_diameter: float = None,
         test_evaluate_cellpose: bool = False,
+        test_time_augmentations: bool = True,
+        tta_type: Literal["mean", "median"] = "mean",
     ) -> None:
         super().__init__()
         net_class = _UNET_ARCHITECTURE.get(architecture)
@@ -162,6 +165,8 @@ class VSUNet(LightningModule):
         self.test_cellpose_model_path = test_cellpose_model_path
         self.test_cellpose_diameter = test_cellpose_diameter
         self.test_evaluate_cellpose = test_evaluate_cellpose
+        self.test_time_augmentations = test_time_augmentations
+        self.tta_type = tta_type
         self.freeze_encoder = freeze_encoder
         if ckpt_path is not None:
             self.load_state_dict(
@@ -315,26 +320,48 @@ class VSUNet(LightningModule):
         )
 
     def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0):
-        source = self._predict_pad(batch["source"])
+        # source = self._predict_pad(batch["source"])
+        source = batch["source"]
+        down_factor = 2**self.model.num_blocks
+        # self._predict_pad = DivisiblePad((0, 0, down_factor, down_factor))
 
-        # Test time augmentations
-        if (
-            batch.test_time_augmentations is not None
-            or len(batch.test_time_augmentations) > 0
-        ):
+        if self.test_time_augmentations:
+            # FIXME hardcoded rotations
+
+            test_time_augmentations_list = []
+            for i in range(4):
+                test_time_augmentations_list.append(
+                    Compose(
+                        DivisiblePad((0, 0, down_factor, down_factor)),
+                        Rotate90(k=i, spatial_axes=(2, 3)),
+                    )
+                )
+            test_time_augmentations_list_inv = test_time_augmentations_list[::-1]
+
+            # Test time augmentations
             predictions = []
-            for augmentation in batch.test_time_augmentations:
+            for aug, de_aug in zip(
+                test_time_augmentations_list, test_time_augmentations_list_inv
+            ):
+                # Augment
+                augmented = aug(source)
                 # Apply the augmentation and predict
-                augmented_prediction = self.forward(augmentation(source))
+                augmented_prediction = self.forward(augmented)
                 # Invert the augmentation
-                augmented_prediction = Invertd(augmented_prediction)
-                predictions.append(augmented_prediction)
+                de_augmented_prediction = aug.inverse(augmented_prediction)
+                predictions.append(de_augmented_prediction)
             # Average the predictions
-            prediction = torch.stack(predictions).mean(dim=0)
-        else:
-            prediction = self.forward(source)
+            if self.tta_type == "mean":
+                prediction = torch.stack(predictions).mean(dim=0)
+            elif self.tta_type == "median":
+                prediction = torch.stack(predictions).median(dim=0)
 
-        return self._predict_pad.inverse(prediction)
+        else:
+            source = self._predict_pad(source)
+            prediction = self.forward(source)
+            prediction = self._predict_pad.inverse(prediction)
+
+        return prediction
 
     def on_train_epoch_end(self):
         self._log_samples("train_samples", self.training_step_outputs)

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -319,42 +319,58 @@ class VSUNet(LightningModule):
             on_epoch=False,
         )
 
+    # def rotate_volume(self, tensor, k, spatial_axes):
+    #     rotate = Rotate90(k=k, spatial_axes=spatial_axes)
+    #     rotated_tensor = torch.empty_like(tensor)
+    #     for b in range(tensor.shape[0]):  # iterate over batch
+    #         for c in range(tensor.shape[1]):  # iterate over channels
+    #             rotated_tensor[b, c] = rotate(tensor[b, c])
+    #     return rotated_tensor
+
+    def rotate_volume(self, tensor, k, spatial_axes):
+        rotate = Rotate90(k=k, spatial_axes=spatial_axes)
+        rotated_tensor = torch.empty_like(tensor)
+        for b in range(tensor.shape[0]):  # iterate over batch
+            rotated_tensor[b] = rotate(tensor[b])
+        return rotated_tensor
+
     def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0):
-        # source = self._predict_pad(batch["source"])
         source = batch["source"]
-        down_factor = 2**self.model.num_blocks
-        # self._predict_pad = DivisiblePad((0, 0, down_factor, down_factor))
+        # source = self._predict_pad(source)  # Apply padding
 
         if self.test_time_augmentations:
-            # FIXME hardcoded rotations
-
             test_time_augmentations_list = []
             for i in range(4):
                 test_time_augmentations_list.append(
                     Compose(
-                        DivisiblePad((0, 0, down_factor, down_factor)),
-                        Rotate90(k=i, spatial_axes=(2, 3)),
+                        [lambda x, i=i: self.rotate_volume(x, k=i, spatial_axes=(1, 2))]
                     )
                 )
-            test_time_augmentations_list_inv = test_time_augmentations_list[::-1]
 
-            # Test time augmentations
+            test_time_augmentations_list_inv = [
+                Compose(
+                    [lambda x, i=i: self.rotate_volume(x, k=4 - i, spatial_axes=(1, 2))]
+                )
+                for i in range(4)
+            ]
             predictions = []
             for aug, de_aug in zip(
                 test_time_augmentations_list, test_time_augmentations_list_inv
             ):
-                # Augment
                 augmented = aug(source)
-                # Apply the augmentation and predict
+                augmented = self._predict_pad(augmented)
                 augmented_prediction = self.forward(augmented)
-                # Invert the augmentation
-                de_augmented_prediction = aug.inverse(augmented_prediction)
+                # Undo rotation and padding
+                de_augmented_prediction = self._predict_pad.inverse(
+                    augmented_prediction
+                )
+                de_augmented_prediction = de_aug(de_augmented_prediction)
                 predictions.append(de_augmented_prediction)
-            # Average the predictions
+
             if self.tta_type == "mean":
                 prediction = torch.stack(predictions).mean(dim=0)
             elif self.tta_type == "median":
-                prediction = torch.stack(predictions).median(dim=0)
+                prediction = torch.stack(predictions).median(dim=0).values
 
         else:
             source = self._predict_pad(source)

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -327,28 +327,9 @@ class VSUNet(LightningModule):
         source = batch["source"]
 
         if self.test_time_augmentations:
-            # test_time_augmentations_list = []
-            # for i in range(4):
-            #     test_time_augmentations_list.append(
-            #         Compose(
-            #             [
-            #                 lambda x, i=i: self._rotate_volume(
-            #                     x, k=i, spatial_axes=(1, 2)
-            #                 )
-            #             ]
-            #         )
-            #     )
+            # Save the yx coords to crop post rotations
+            self._get_original_shape_yx(source)
 
-            # test_time_augmentations_list_inv = [
-            #     Compose(
-            #         [
-            #             lambda x, i=i: self._rotate_volume(
-            #                 x, k=4 - i, spatial_axes=(1, 2)
-            #             )
-            #         ]
-            #     )
-            #     for i in range(4)
-            # ]
             predictions = []
             # for aug, de_aug in zip(
             #     test_time_augmentations_list, test_time_augmentations_list_inv
@@ -378,9 +359,9 @@ class VSUNet(LightningModule):
                 torch.cuda.empty_cache()  #
 
             if self.tta_type == "mean":
-                prediction = torch.stack(predictions).mean(dim=0)
+                prediction = torch.stack(predictions).cpu().mean(dim=0)
             elif self.tta_type == "median":
-                prediction = torch.stack(predictions).median(dim=0).values
+                prediction = torch.stack(predictions).cpu().median(dim=0).values
             # Put back to GPU
             prediction = prediction.to(source.device)
 
@@ -431,7 +412,7 @@ class VSUNet(LightningModule):
         The inverse of this transform crops the prediction to original shape.
         """
         down_factor = 2**self.model.num_blocks
-        self._original_shape = None
+        self._original_shape_yx = None
         self._predict_pad = DivisiblePad((0, 0, down_factor, down_factor))
 
     def configure_optimizers(self):
@@ -482,9 +463,6 @@ class VSUNet(LightningModule):
         max_dim = max(tensor.shape[-2], tensor.shape[-1])
         pad_transform = DivisiblePad((0, 0, max_dim, max_dim))
         padded_tensor = pad_transform(tensor)
-        original_shape = tensor.shape[-2:]
-
-        self._original_shape = original_shape  # Store H, W of the input tensor
 
         # Rotation
         rotated_tensor = []
@@ -498,16 +476,20 @@ class VSUNet(LightningModule):
         # # Cropping to original shape
         return rotated_tensor
 
+    def _get_original_shape_yx(self, tensor: Tensor) -> tuple[int]:
+        self._original_shape_yx = tensor.shape[-2:]
+        return self._original_shape_yx
+
     def _crop_to_original(self, tensor: Tensor) -> Tensor:
-        if self._original_shape is None:
+        if self._original_shape_yx is None:
             raise RuntimeError(
                 "Original shape not recorded. Ensure _pad_input is called before _crop_to_original."
             )
-        original_h, original_w = self._original_shape
-        pad_h = (tensor.shape[-2] - original_h) // 2
-        pad_w = (tensor.shape[-1] - original_w) // 2
+        original_y, original_x = self._original_shape_yx
+        pad_y = (tensor.shape[-2] - original_y) // 2
+        pad_x = (tensor.shape[-1] - original_x) // 2
         cropped_tensor = tensor[
-            ..., pad_h : pad_h + original_h, pad_w : pad_w + original_w
+            ..., pad_y : pad_y + original_y, pad_x : pad_x + original_x
         ]
         return cropped_tensor
 

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -32,7 +32,6 @@ from viscy.unet.networks.Unet2D import Unet2d
 from viscy.unet.networks.Unet25D import Unet25d
 from viscy.unet.networks.unext2 import UNeXt2
 
-
 try:
     from cellpose.models import CellposeModel
 except ImportError:

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -8,7 +8,7 @@ from imageio import imwrite
 from lightning.pytorch import LightningModule
 from matplotlib.pyplot import get_cmap
 from monai.optimizers import WarmupCosineSchedule
-from monai.transforms import DivisiblePad, Rotate90d, Compose, Rotate90
+from monai.transforms import DivisiblePad, Compose, Rotate90
 from skimage.exposure import rescale_intensity
 from torch import Tensor, nn
 from torch.nn import functional as F
@@ -114,6 +114,10 @@ class VSUNet(LightningModule):
     :param bool test_evaluate_cellpose:
         evaluate the performance of the CellPose model instead of the trained model
         in test stage, defaults to False
+    :param bool test_time_augmentations:
+        apply test time augmentations in test stage, defaults to False
+    :param Literal['mean', 'median'] tta_type:
+        type of test time augmentations aggregation, defaults to "mean"
     """
 
     def __init__(
@@ -131,7 +135,7 @@ class VSUNet(LightningModule):
         test_cellpose_model_path: str = None,
         test_cellpose_diameter: float = None,
         test_evaluate_cellpose: bool = False,
-        test_time_augmentations: bool = True,
+        test_time_augmentations: bool = False,
         tta_type: Literal["mean", "median"] = "mean",
     ) -> None:
         super().__init__()
@@ -319,58 +323,66 @@ class VSUNet(LightningModule):
             on_epoch=False,
         )
 
-    # def rotate_volume(self, tensor, k, spatial_axes):
-    #     rotate = Rotate90(k=k, spatial_axes=spatial_axes)
-    #     rotated_tensor = torch.empty_like(tensor)
-    #     for b in range(tensor.shape[0]):  # iterate over batch
-    #         for c in range(tensor.shape[1]):  # iterate over channels
-    #             rotated_tensor[b, c] = rotate(tensor[b, c])
-    #     return rotated_tensor
-
-    def rotate_volume(self, tensor, k, spatial_axes):
-        rotate = Rotate90(k=k, spatial_axes=spatial_axes)
-        rotated_tensor = torch.empty_like(tensor)
-        for b in range(tensor.shape[0]):  # iterate over batch
-            rotated_tensor[b] = rotate(tensor[b])
-        return rotated_tensor
-
     def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0):
         source = batch["source"]
-        # source = self._predict_pad(source)  # Apply padding
 
         if self.test_time_augmentations:
-            test_time_augmentations_list = []
-            for i in range(4):
-                test_time_augmentations_list.append(
-                    Compose(
-                        [lambda x, i=i: self.rotate_volume(x, k=i, spatial_axes=(1, 2))]
-                    )
-                )
+            # test_time_augmentations_list = []
+            # for i in range(4):
+            #     test_time_augmentations_list.append(
+            #         Compose(
+            #             [
+            #                 lambda x, i=i: self._rotate_volume(
+            #                     x, k=i, spatial_axes=(1, 2)
+            #                 )
+            #             ]
+            #         )
+            #     )
 
-            test_time_augmentations_list_inv = [
-                Compose(
-                    [lambda x, i=i: self.rotate_volume(x, k=4 - i, spatial_axes=(1, 2))]
-                )
-                for i in range(4)
-            ]
+            # test_time_augmentations_list_inv = [
+            #     Compose(
+            #         [
+            #             lambda x, i=i: self._rotate_volume(
+            #                 x, k=4 - i, spatial_axes=(1, 2)
+            #             )
+            #         ]
+            #     )
+            #     for i in range(4)
+            # ]
             predictions = []
-            for aug, de_aug in zip(
-                test_time_augmentations_list, test_time_augmentations_list_inv
-            ):
-                augmented = aug(source)
+            # for aug, de_aug in zip(
+            #     test_time_augmentations_list, test_time_augmentations_list_inv
+            # ):
+            for i in range(4):
+                augmented = self._rotate_volume(source, k=i, spatial_axes=(1, 2))
                 augmented = self._predict_pad(augmented)
+                # predict and move to CPU
                 augmented_prediction = self.forward(augmented)
-                # Undo rotation and padding
                 de_augmented_prediction = self._predict_pad.inverse(
                     augmented_prediction
                 )
-                de_augmented_prediction = de_aug(de_augmented_prediction)
-                predictions.append(de_augmented_prediction)
+                de_augmented_prediction = self._rotate_volume(
+                    de_augmented_prediction, k=4 - i, spatial_axes=(1, 2)
+                )
+                de_augmented_prediction = self._crop_to_original(
+                    de_augmented_prediction
+                )
+
+                # Undo rotation and padding
+                predictions.append(de_augmented_prediction.cpu())
+                del (
+                    augmented,
+                    augmented_prediction,
+                    de_augmented_prediction,
+                )
+                torch.cuda.empty_cache()  #
 
             if self.tta_type == "mean":
                 prediction = torch.stack(predictions).mean(dim=0)
             elif self.tta_type == "median":
                 prediction = torch.stack(predictions).median(dim=0).values
+            # Put back to GPU
+            prediction = prediction.to(source.device)
 
         else:
             source = self._predict_pad(source)
@@ -419,6 +431,7 @@ class VSUNet(LightningModule):
         The inverse of this transform crops the prediction to original shape.
         """
         down_factor = 2**self.model.num_blocks
+        self._original_shape = None
         self._predict_pad = DivisiblePad((0, 0, down_factor, down_factor))
 
     def configure_optimizers(self):
@@ -463,6 +476,40 @@ class VSUNet(LightningModule):
         self.logger.experiment.add_image(
             key, grid, self.current_epoch, dataformats="HWC"
         )
+
+    def _rotate_volume(self, tensor: Tensor, k: int, spatial_axes: tuple) -> Tensor:
+        # Padding to ensure square shape
+        max_dim = max(tensor.shape[-2], tensor.shape[-1])
+        pad_transform = DivisiblePad((0, 0, max_dim, max_dim))
+        padded_tensor = pad_transform(tensor)
+        original_shape = tensor.shape[-2:]
+
+        self._original_shape = original_shape  # Store H, W of the input tensor
+
+        # Rotation
+        rotated_tensor = []
+        rotate = Rotate90(k=k, spatial_axes=spatial_axes)
+        for b in range(padded_tensor.shape[0]):  # iterate over batch
+            rotated_tensor.append(rotate(padded_tensor[b]))
+
+        # Stack the list of tensors back into a single tensor
+        rotated_tensor = torch.stack(rotated_tensor)
+        del padded_tensor
+        # # Cropping to original shape
+        return rotated_tensor
+
+    def _crop_to_original(self, tensor: Tensor) -> Tensor:
+        if self._original_shape is None:
+            raise RuntimeError(
+                "Original shape not recorded. Ensure _pad_input is called before _crop_to_original."
+            )
+        original_h, original_w = self._original_shape
+        pad_h = (tensor.shape[-2] - original_h) // 2
+        pad_w = (tensor.shape[-1] - original_w) // 2
+        cropped_tensor = tensor[
+            ..., pad_h : pad_h + original_h, pad_w : pad_w + original_w
+        ]
+        return cropped_tensor
 
 
 class FcmaeUNet(VSUNet):

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -316,7 +316,25 @@ class VSUNet(LightningModule):
 
     def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0):
         source = self._predict_pad(batch["source"])
-        return self._predict_pad.inverse(self.forward(source))
+
+        # Test time augmentations
+        if (
+            batch.test_time_augmentations is not None
+            or len(batch.test_time_augmentations) > 0
+        ):
+            predictions = []
+            for augmentation in batch.test_time_augmentations:
+                # Apply the augmentation and predict
+                augmented_prediction = self.forward(augmentation(source))
+                # Invert the augmentation
+                augmented_prediction = Invertd(augmented_prediction)
+                predictions.append(augmented_prediction)
+            # Average the predictions
+            prediction = torch.stack(predictions).mean(dim=0)
+        else:
+            prediction = self.forward(source)
+
+        return self._predict_pad.inverse(prediction)
 
     def on_train_epoch_end(self):
         self._log_samples("train_samples", self.training_step_outputs)

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -32,6 +32,7 @@ from viscy.unet.networks.Unet2D import Unet2d
 from viscy.unet.networks.Unet25D import Unet25d
 from viscy.unet.networks.unext2 import UNeXt2
 
+
 try:
     from cellpose.models import CellposeModel
 except ImportError:

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -24,6 +24,7 @@ from torchmetrics.functional import (
     r2_score,
     structural_similarity_index_measure,
 )
+
 from viscy.data.hcs import Sample
 from viscy.evaluation.evaluation_metrics import mean_average_precision, ms_ssim_25d
 from viscy.unet.networks.fcmae import FullyConvolutionalMAE

--- a/viscy/light/engine.py
+++ b/viscy/light/engine.py
@@ -325,9 +325,8 @@ class VSUNet(LightningModule):
 
     def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0):
         source = batch["source"]
-
         if self.test_time_augmentations:
-            self.perform_test_time_augmentations(source)
+            prediction = self.perform_test_time_augmentations(source)
         else:
             source = self._predict_pad(source)
             prediction = self.forward(source)

--- a/viscy/light/predict_writer.py
+++ b/viscy/light/predict_writer.py
@@ -10,7 +10,6 @@ from iohub.ngff_meta import TransformationMeta
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter
 from numpy.typing import DTypeLike, NDArray
-
 from viscy.data.hcs import HCSDataModule, Sample
 
 __all__ = ["HCSPredictionWriter"]

--- a/viscy/light/predict_writer.py
+++ b/viscy/light/predict_writer.py
@@ -33,6 +33,30 @@ def _resize_image(image: ImageArray, t_index: int, z_slice: slice) -> None:
 
 
 def _blend_in(old_stack: NDArray, new_stack: NDArray, z_slice: slice) -> NDArray:
+    """
+    Blend a new stack of images into an old stack over a specified range of slices.
+
+    This function blends the `new_stack` of images into the `old_stack` over the range
+    specified by `z_slice`. The blending is done using a weighted average where the
+    weights are determined by the position within the range of slices. If the start
+    of `z_slice` is 0, the function returns the `new_stack` unchanged.
+
+    Parameters:
+    ----------
+    old_stack : NDArray
+        The original stack of images to be blended.
+    new_stack : NDArray
+        The new stack of images to blend into the original stack.
+    z_slice : slice
+        A slice object indicating the range of slices over which to perform the blending.
+        The start and stop attributes of the slice determine the range.
+
+    Returns:
+    -------
+    NDArray
+        The blended stack of images. If `z_slice.start` is 0, returns `new_stack` unchanged.
+    """
+
     if z_slice.start == 0:
         return new_stack
     depth = z_slice.stop - z_slice.start

--- a/viscy/light/predict_writer.py
+++ b/viscy/light/predict_writer.py
@@ -10,6 +10,7 @@ from iohub.ngff_meta import TransformationMeta
 from lightning.pytorch import LightningModule, Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter
 from numpy.typing import DTypeLike, NDArray
+
 from viscy.data.hcs import HCSDataModule, Sample
 
 __all__ = ["HCSPredictionWriter"]

--- a/viscy/utils/image_utils.py
+++ b/viscy/utils/image_utils.py
@@ -21,7 +21,9 @@ def im_bit_convert(im, bit=16, norm=False, limit=[]):
             / (limit[1] - limit[0] + sys.float_info.epsilon)
             * (2**bit - 1)
         )
-    im = np.clip(im, 0, 2**bit - 1)  # clip the values to avoid wrap-around by np.astype
+    im = np.clip(
+        im, 0, 2**bit - 1
+    )  # clip the values to avoid wrap-around by np.astype
     if bit == 8:
         im = im.astype(np.uint8, copy=False)  # convert to 8 bit
     else:

--- a/viscy/utils/image_utils.py
+++ b/viscy/utils/image_utils.py
@@ -21,9 +21,7 @@ def im_bit_convert(im, bit=16, norm=False, limit=[]):
             / (limit[1] - limit[0] + sys.float_info.epsilon)
             * (2**bit - 1)
         )
-    im = np.clip(
-        im, 0, 2**bit - 1
-    )  # clip the values to avoid wrap-around by np.astype
+    im = np.clip(im, 0, 2**bit - 1)  # clip the values to avoid wrap-around by np.astype
     if bit == 8:
         im = im.astype(np.uint8, copy=False)  # convert to 8 bit
     else:


### PR DESCRIPTION
This PR adds the test time augmentations to the prediction steps.
These are currently hardcoded to be rotations of (0,90,180 and 270 deg) by setting the `trainer.test_time_augmentation=True`

Ideally, we want this to be added during training the paper suggests so that we are rotationally invariant. 



