### PR TITLE
add resnet50 to ContrastiveEncoder

### DIFF
--- a/applications/contrastive_phenotyping/training_script.py
+++ b/applications/contrastive_phenotyping/training_script.py
@@ -1,6 +1,7 @@
 # %% Imports and paths.
 import os
 import torch
+# add path
 from viscy.light.engine import ContrastiveModule
 from viscy.unet.networks.unext2 import UNeXt2Stem
 from viscy.representation.contrastive import ContrastiveEncoder
@@ -14,10 +15,8 @@ model_dir = top_dir / "infection_classification/models/infection_score"
 %load_ext autoreload
 %autoreload 2
 # %% Initialize the model and log the graph.
-contra_model = ContrastiveEncoder(backbone = "convnext_tiny")
+contra_model = ContrastiveEncoder(backbone = "convnext_tiny") # other options: convnext_tiny resnet50
 print(contra_model)
-
-# %% 
 model_graph = torchview.draw_graph(
     contra_model,
     torch.randn(1, 2, 15, 224, 224),
@@ -26,6 +25,20 @@ model_graph = torchview.draw_graph(
 )
 # Print the image of the model.
 model_graph.visual_graph
+
+# %% Initialize a resent50 model and log the graph.
+contra_model = ContrastiveEncoder(backbone = "resnet50", in_stack_depth = 16, stem_kernel_size = (4, 3, 3)) # note that the resnet first layer takes 64 channels (so we can't have multiples of 3)
+print(contra_model)
+model_graph = torchview.draw_graph(
+    contra_model,
+    torch.randn(1, 2, 16, 224, 224),
+    depth=3,  # adjust depth to zoom in.
+    device="cpu",
+)
+# Print the image of the model.
+model_graph.resize_graph(scale=2.5)
+model_graph.visual_graph
+
 
 # %% Initiatlize the lightning module and view the model.
 contrastive_module = ContrastiveModule()

--- a/applications/contrastive_phenotyping/training_script_resnet.py
+++ b/applications/contrastive_phenotyping/training_script_resnet.py
@@ -1,7 +1,6 @@
 # %% Imports and paths.
 import os
 import torch
-# add path
 from viscy.light.engine import ContrastiveModule
 from viscy.unet.networks.unext2 import UNeXt2Stem
 from viscy.representation.contrastive import ContrastiveEncoder

--- a/viscy/representation/contrastive.py
+++ b/viscy/representation/contrastive.py
@@ -1,8 +1,8 @@
 import timm
-from viscy.unet.networks.unext2 import UNeXt2Stem
-
 import torch.nn as nn
-import torch.nn.functional as F
+
+from viscy.unet.networks.resnet import resnetStem
+from viscy.unet.networks.unext2 import UNeXt2Stem
 
 
 class ContrastiveEncoder(nn.Module):
@@ -87,7 +87,36 @@ class ContrastiveEncoder(nn.Module):
             """
         elif "resnet" in backbone:
             # Adapt stem and projection head of resnet here.
-            pass
+            # replace the stem designed for RGB images with a stem designed to handle 3D multi-channel input.
+            in_channels_encoder = self.model.conv1.out_channels
+            stem = resnetStem(
+                in_channels=in_channels,
+                out_channels=in_channels_encoder,
+                kernel_size=stem_kernel_size,
+                in_stack_depth=in_stack_depth,
+            )
+            self.model.conv1 = stem
+
+            self.model.fc = nn.Sequential(
+                self.model.fc,
+                nn.ReLU(inplace=True),
+                nn.Linear(4 * embedding_len, embedding_len),
+            )
+            """ 
+            head of resnet
+            -------------------
+            (global_pool): SelectAdaptivePool2d(pool_type=avg, flatten=Flatten(start_dim=1, end_dim=-1))
+            (fc): Linear(in_features=2048, out_features=1024, bias=True)
+
+
+            head of resnet for contrastive learning
+            ----------------------------
+            (global_pool): SelectAdaptivePool2d(pool_type=avg, flatten=Flatten(start_dim=1, end_dim=-1))
+            (fc): Sequential(
+            (0): Linear(in_features=2048, out_features=1024, bias=True)
+            (1): ReLU(inplace=True)
+            (2): Linear(in_features=1024, out_features=256, bias=True)
+            """
 
     def forward(self, x):
         return self.model(x)

--- a/viscy/unet/networks/resnet.py
+++ b/viscy/unet/networks/resnet.py
@@ -1,0 +1,28 @@
+from torch import Tensor, nn
+
+
+class resnetStem(nn.Module):
+    """Stem for ResNet networks to handle 3D multi-channel input."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: tuple[int, int, int],
+        in_stack_depth: int,
+    ) -> None:
+        super().__init__()
+        ratio = in_stack_depth // kernel_size[0]
+        self.conv = nn.Conv3d(
+            in_channels=in_channels,
+            out_channels=out_channels // ratio,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+        )
+
+    def forward(self, x: Tensor):
+        x = self.conv(x)
+        b, c, d, h, w = x.shape
+        # project Z/depth into channels
+        # return a view when possible (contiguous)
+        return x.reshape(b, c * d, h, w)


### PR DESCRIPTION
- initialize resnet50 using timm  (the classical resent50 matches best with dynacontrast's resnet50)
- recycled the stem from convnext
- replaced fc with projection head, see viscy/representation/contrastive.py

Here is a side-by-side comparison of the model view, the timm-resnet50 model is close-enough compared with dynacontrast-resnet50.  Therefore we can use the resnet50 to approximate a model baseline that matches dynacontrast
![image](https://github.com/mehta-lab/VisCy/assets/4129442/4ba01691-ae1a-4514-9fe8-24e2081e15b9)
