### PR TITLE
Sample positive and negative samples with a time offset for the triplet contrastive task

### DIFF
--- a/applications/contrastive_phenotyping/contrastive_cli/fit_ctc_mps.yml
+++ b/applications/contrastive_phenotyping/contrastive_cli/fit_ctc_mps.yml
@@ -1,0 +1,113 @@
+# See help here on how to configure hyper-parameters with config files:
+# https://lightning.ai/docs/pytorch/stable/cli/lightning_cli_advanced.html
+seed_everything: 42
+trainer:
+  accelerator: gpu
+  strategy: auto
+  devices: 1
+  num_nodes: 1
+  precision: 32-true
+  logger:
+    class_path: lightning.pytorch.loggers.TensorBoardLogger
+    # Nesting the logger config like this is equivalent to
+    # supplying the following argument to `lightning.pytorch.Trainer`:
+    # logger=TensorBoardLogger(
+    #     "/hpc/projects/intracellular_dashboard/viral-sensor/infection_classification/models/contrastive_tune_augmentations",
+    #     log_graph=True,
+    #     version="vanilla",
+    # )
+    init_args:
+      save_dir: /Users/ziwen.liu/Projects/test-time
+      # this is the name of the experiment.
+      # The logs will be saved in `save_dir/lightning_logs/version`
+      version: time_interval_1
+      log_graph: True
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/val
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+  fast_dev_run: false
+  max_epochs: 100
+  log_every_n_steps: 10
+  enable_checkpointing: true
+  inference_mode: true
+  use_distributed_sampler: true
+  # synchronize batchnorm parameters across multiple GPUs.
+  # important for contrastive learning to normalize the tensors across the whole batch.
+  sync_batchnorm: true
+model:
+  encoder:
+    class_path: viscy.representation.contrastive.ContrastiveEncoder
+    init_args:
+      backbone: convnext_tiny
+      in_channels: 1
+      in_stack_depth: 1
+      stem_kernel_size: [1, 4, 4]
+      stem_stride: [1, 4, 4]
+      embedding_dim: 768
+      projection_dim: 32
+      drop_path_rate: 0.0
+  loss_function:
+    class_path: torch.nn.TripletMarginLoss
+    init_args:
+      margin: 0.5
+  lr: 0.0002
+  log_batches_per_epoch: 3
+  log_samples_per_batch: 2
+  example_input_array_shape: [1, 1, 1, 128, 128]
+data:
+  data_path: /Users/ziwen.liu/Downloads/Hela_CTC.zarr
+  tracks_path: /Users/ziwen.liu/Downloads/Hela_CTC.zarr
+  source_channel:
+    - DIC
+  z_range: [0, 1]
+  batch_size: 16
+  num_workers: 4
+  initial_yx_patch_size: [256, 256]
+  final_yx_patch_size: [128, 128]
+  time_interval: 1
+  normalizations:
+    - class_path: viscy.transforms.NormalizeSampled
+      init_args:
+        keys: [DIC]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy.transforms.RandAffined
+      init_args:
+        keys: [DIC]
+        prob: 0.8
+        scale_range: [0, 0.2, 0.2]
+        rotate_range: [3.14, 0.0, 0.0]
+        shear_range: [0.0, 0.01, 0.01]
+        padding_mode: zeros
+    - class_path: viscy.transforms.RandAdjustContrastd
+      init_args:
+        keys: [DIC]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy.transforms.RandScaleIntensityd
+      init_args:
+        keys: [DIC]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy.transforms.RandGaussianSmoothd
+      init_args:
+        keys: [DIC]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0.0, 0.0]
+    - class_path: viscy.transforms.RandGaussianNoised
+      init_args:
+        keys: [DIC]
+        prob: 0.5
+        mean: 0.0
+        std: 0.2

--- a/applications/contrastive_phenotyping/contrastive_cli/predict_ctc_mps.yml
+++ b/applications/contrastive_phenotyping/contrastive_cli/predict_ctc_mps.yml
@@ -1,0 +1,44 @@
+seed_everything: 42
+trainer:
+  accelerator: gpu
+  strategy: auto
+  devices: auto
+  num_nodes: 1
+  precision: 32-true
+  callbacks:
+    - class_path: viscy.representation.embedding_writer.EmbeddingWriter
+      init_args:
+        output_path: /Users/ziwen.liu/Projects/test-time/predict/time_interval_1.zarr
+  inference_mode: true
+model:
+  encoder:
+    class_path: viscy.representation.contrastive.ContrastiveEncoder
+    init_args:
+      backbone: convnext_tiny
+      in_channels: 1
+      in_stack_depth: 1
+      stem_kernel_size: [1, 4, 4]
+      stem_stride: [1, 4, 4]
+      embedding_dim: 768
+      projection_dim: 32
+      drop_path_rate: 0.0
+  example_input_array_shape: [1, 1, 1, 128, 128]
+data:
+  data_path: /Users/ziwen.liu/Downloads/Hela_CTC.zarr
+  tracks_path: /Users/ziwen.liu/Downloads/Hela_CTC.zarr
+  source_channel: DIC
+  z_range: [0, 1]
+  batch_size: 16
+  num_workers: 4
+  initial_yx_patch_size: [128, 128]
+  final_yx_patch_size: [128, 128]
+  time_interval: 1
+  normalizations:
+    - class_path: viscy.transforms.NormalizeSampled
+      init_args:
+        keys: [DIC]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+return_predictions: false
+ckpt_path: /Users/ziwen.liu/Projects/test-time/lightning_logs/time_interval_1/checkpoints/last.ckpt

--- a/viscy/data/triplet.py
+++ b/viscy/data/triplet.py
@@ -390,15 +390,18 @@ class TripletDataModule(HCSDataModule):
         val_positions = positions[num_train_fovs:]
         train_tracks_tables = tracks_tables[:num_train_fovs]
         val_tracks_tables = tracks_tables[num_train_fovs:]
-
-        print(f"Number of training FOVs: {len(train_positions)}")
-        print(f"Number of validation FOVs: {len(val_positions)}")
-
+        _logger.debug(f"Number of training FOVs: {len(train_positions)}")
+        _logger.debug(f"Number of validation FOVs: {len(val_positions)}")
+        anchor_transform = (
+            no_aug_transform
+            if (self.time_interval == "any" or self.time_interval == 0)
+            else augment_transform
+        )
         self.train_dataset = TripletDataset(
             positions=train_positions,
             tracks_tables=train_tracks_tables,
             initial_yx_patch_size=self.initial_yx_patch_size,
-            anchor_transform=no_aug_transform,
+            anchor_transform=anchor_transform,
             positive_transform=augment_transform,
             negative_transform=augment_transform,
             fit=True,
@@ -409,7 +412,7 @@ class TripletDataModule(HCSDataModule):
             positions=val_positions,
             tracks_tables=val_tracks_tables,
             initial_yx_patch_size=self.initial_yx_patch_size,
-            anchor_transform=no_aug_transform,
+            anchor_transform=anchor_transform,
             positive_transform=augment_transform,
             negative_transform=augment_transform,
             fit=True,


### PR DESCRIPTION
Sampling strategy for triplet contrastive learning is now configured with `viscy.data.triplet.TripletDataModule(time_interval=...)`.

1. `time_interval == "any"`
Same as before this PR. The positive sample is the augmented version of the anchor, and the negative sample is any other patch from a different track.
If each node (`id`) in the tracking result is assigned a different `track_id`, this reduces to the classical patch-wise contrastive learning without tracking information.
2. `isinstance(time_interval, int) == True`
For time interval $\tau$, the positive sample of anchor at time point $t$ is sampled from the same track at time point $t + \tau$, and the negative example is sampled from a different track also at time point $t + \tau$. Example log from CTC's DIC-D2DH-HeLa dataset (anchor, positive, negative):

![image](https://github.com/user-attachments/assets/ddd3bc52-9f1b-49c7-9dc5-29c23dbe673c)

Closes #123.