### PR TITLE
Adding a caching dataloader for 3D dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "CZ Biohub SF", email = "compmicro@czbiohub.org" }]
 dependencies = [
     "iohub==0.1.0",
-    "torch>=2.1.2",
+    "torch>=2.4.1",
     "timm>=0.9.5",
     "tensorboard>=2.13.0",
     "lightning>=2.3.0",

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -117,7 +117,8 @@ class CachedDataset(Dataset):
         if norm_meta is not None:
             sample_images["norm_meta"] = norm_meta
         if self.transform:
-            sample_images = self.transform(sample_images)
+            # FIX ME: check why the transforms return a list?
+            sample_images = self.transform(sample_images)[0]
         if "weight" in sample_images:
             del sample_images["weight"]
         sample = {
@@ -185,6 +186,11 @@ class CachedDataModule(LightningDataModule):
             raise NotImplementedError(f"Stage {stage} is not supported")
 
     def _train_transform(self) -> list[Callable]:
+        """ Set the train augmentations
+
+        
+        """
+
         if self.augmentations:
             for aug in self.augmentations:
                 if isinstance(aug, MultiSampleTrait):
@@ -197,6 +203,10 @@ class CachedDataModule(LightningDataModule):
                             f"transform type {type(aug)}."
                         )
                     self.train_patches_per_stack = num_samples
+        else:
+            self.augmentations=[]
+        
+        _logger.info(f'Training augmentations: {self.augmentations}')
         return list(self.augmentations)
 
     def _fit_transform(self) -> tuple[Compose, Compose]:

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -96,6 +96,7 @@ class CachedDataset(Dataset):
             self.total_ch_names.extend(self.channels["target"])
             self.total_ch_idx.extend(self.target_ch_idx)
         self._position_mapping()
+<<<<<<< HEAD
 
         self.cache_order = []
         self.cache_record = torch.zeros(len(self.positions))
@@ -103,15 +104,18 @@ class CachedDataset(Dataset):
 
         # Caching the dataset as two separate arrays
         # self._init_cache_dataset()
+=======
+        self.cache_dict = {}
+>>>>>>> parent of 8c13f49 (replacing dictionary with single array)
 
     def _position_mapping(self) -> None:
         self.position_keys = []
-        self.position_shape_tczyx= (1,1,1,1,1)
         self.norm_meta_dict = {}
 
         for pos in self.positions:
             self.position_keys.append(pos.data.name)
             self.norm_meta_dict[str(pos.data.name)] = _read_norm_meta(pos)
+<<<<<<< HEAD
         self.position_shape_zyx = pos.data.shape[-3:]
         self._cache_dtype  = numpy_to_torch_dtype.get(pos.data.dtype, torch.float32)  # Default to torch.float32 if not found     
 
@@ -133,6 +137,17 @@ class CachedDataset(Dataset):
                 data = data.astype(np.float32)
             self.cache[i]= torch.from_numpy(data)
             del data            
+=======
+
+    def _cache_dataset(self, index: int, channel_index: list[int], t: int = 0) -> None:
+        # Add the position to the cached_dict
+        # TODO: hardcoding to t=0
+        self.cache_dict[str(self.position_keys[index])] = torch.from_numpy(
+            self.positions[index]
+            .data.oindex[slice(t, t + 1), channel_index, :]
+            .astype(np.float32)
+        )
+>>>>>>> parent of 8c13f49 (replacing dictionary with single array)
 
     def _get_weight_map(self, position: Position) -> Tensor:
         # Get the weight map from the position for the MONAI weightedcrop transform
@@ -147,6 +162,7 @@ class CachedDataset(Dataset):
         ch_names = self.total_ch_names
         
         # Check if the sample is in the cache else add it
+<<<<<<< HEAD
         # if self.cache_record[index]== 0:
         #     # Flip the bit
         #     self.cache_record[index]=1
@@ -171,6 +187,16 @@ class CachedDataset(Dataset):
         _logger.info(f'Getting sample {index} from cache')
         sample_id = self.position_keys[index]
         images = self.cache[index].unbind(dim=1)
+=======
+        # Split the tensor into the channels
+        sample_id = self.position_keys[index]
+        if sample_id not in self.cache_dict:
+            logging.info(f"Adding {sample_id} to cache")
+            self._cache_dataset(index, channel_index=ch_idx)
+
+        # Get the sample from the cache
+        images = self.cache_dict[sample_id].unbind(dim=1)
+>>>>>>> parent of 8c13f49 (replacing dictionary with single array)
         norm_meta = self.norm_meta_dict[str(sample_id)]
 
         sample_images = {k: v for k, v in zip(ch_names, images)}
@@ -252,6 +278,7 @@ class CachedDataModule(LightningDataModule):
 
     def _train_transform(self) -> list[Callable]:
         """ Set the train augmentations
+
         
         """
 

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -32,7 +32,9 @@ def _stack_channels(
     if not isinstance(sample_images, list):
         return torch.stack([sample_images[ch][0] for ch in channels[key]])
     # training time
+    # sample_images is a list['Phase3D'].shape = (1,3,256,256)
     return [torch.stack([im[ch][0] for ch in channels[key]]) for im in sample_images]
+
 
 
 class CachedDataset(Dataset):
@@ -149,6 +151,7 @@ class CachedDataModule(LightningDataModule):
         normalizations: list[MapTransform] = [],
         augmentations: list[MapTransform] = [],
         z_window_size: int = 1,
+        timeout: int = 600,
     ):
         super().__init__()
         self.data_path = data_path
@@ -162,6 +165,7 @@ class CachedDataModule(LightningDataModule):
         self.normalizations = normalizations
         self.augmentations = augmentations
         self.z_window_size = z_window_size
+        self.timeout = timeout
 
     @property
     def _base_dataset_settings(self) -> dict[str, dict[str, list[str]] | int]:
@@ -253,6 +257,7 @@ class CachedDataModule(LightningDataModule):
             num_workers=self.num_workers,
             persistent_workers=bool(self.num_workers),
             shuffle=True,
+            timeout=self.timeout
         )
 
     def val_dataloader(self) -> DataLoader:
@@ -262,4 +267,5 @@ class CachedDataModule(LightningDataModule):
             num_workers=self.num_workers,
             persistent_workers=bool(self.num_workers),
             shuffle=False,
+            timeout=self.timeout
         )

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -224,7 +224,7 @@ class CachedDataModule(LightningDataModule):
         )
         val_transform = Compose(self.normalizations + final_crop)
         return train_transform, val_transform
-    
+
     def _set_fit_global_state(self, num_positions: int) -> torch.Tensor:
         # disable metadata tracking in MONAI for performance
         set_track_meta(False)

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -1,32 +1,22 @@
 import logging
-import math
-import os
-import re
-import tempfile
-from pathlib import Path
 from typing import Callable, Literal, Sequence
 
 import numpy as np
 import torch
-import zarr
-from imageio import imread
-from iohub.ngff import ImageArray, Plate, Position, open_ome_zarr
+from iohub.ngff import Position, open_ome_zarr
 from lightning.pytorch import LightningDataModule
 from monai.data import set_track_meta
-from monai.data.utils import collate_meta_tensor
 from monai.transforms import (
     CenterSpatialCropd,
     Compose,
     MapTransform,
     MultiSampleTrait,
-    RandAffined,
 )
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
-from viscy.data.typing import ChannelMap, DictTransform, HCSStackIndex, NormMeta, Sample
 from viscy.data.hcs import _read_norm_meta
-from tqdm import tqdm
+from viscy.data.typing import ChannelMap, DictTransform, Sample
 
 _logger = logging.getLogger("lightning.pytorch")
 

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -1,0 +1,207 @@
+import logging
+import math
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Callable, Literal, Sequence
+
+import numpy as np
+import torch
+import zarr
+from imageio import imread
+from iohub.ngff import ImageArray, Plate, Position, open_ome_zarr
+from lightning.pytorch import LightningDataModule
+from monai.data import set_track_meta
+from monai.data.utils import collate_meta_tensor
+from monai.transforms import (
+    CenterSpatialCropd,
+    Compose,
+    MapTransform,
+    MultiSampleTrait,
+    RandAffined,
+)
+from torch import Tensor
+from torch.utils.data import DataLoader, Dataset
+
+from viscy.data.typing import ChannelMap, DictTransform, HCSStackIndex, NormMeta, Sample
+from viscy.data.hcs import _read_norm_meta
+from tqdm import tqdm
+
+_logger = logging.getLogger("lightning.pytorch")
+
+# TODO: cache the norm metadata when caching the dataset
+
+
+def _stack_channels(
+    sample_images: list[dict[str, Tensor]] | dict[str, Tensor],
+    channels: ChannelMap,
+    key: str,
+) -> Tensor | list[Tensor]:
+    """Stack single-channel images into a multi-channel tensor."""
+    if not isinstance(sample_images, list):
+        return torch.stack([sample_images[ch][0] for ch in channels[key]])
+    # training time
+    return [torch.stack([im[ch][0] for ch in channels[key]]) for im in sample_images]
+
+
+class CachedDataset(Dataset):
+    """
+    A dataset that caches the data in RAM.
+    It relies on the `__getitem__` method to load the data on the 1st epoch.
+    """
+
+    def __init__(
+        self,
+        positions: list[Position],
+        channels: ChannelMap,
+        transform: DictTransform | None = None,
+    ):
+        super().__init__()
+        self.positions = positions
+        self.channels = channels
+        self.transform = transform
+
+        self.source_ch_idx = [
+            positions[0].get_channel_index(c) for c in channels["source"]
+        ]
+        self.target_ch_idx = (
+            [positions[0].get_channel_index(c) for c in channels["target"]]
+            if "target" in channels
+            else None
+        )
+        self._position_mapping()
+        self.cache_dict = {}
+
+    def _position_mapping(self) -> None:
+        self.position_keys = []
+        self.norm_meta_dict = {}
+
+        for pos in self.positions:
+            self.position_keys.append(pos.data.name)
+            self.norm_meta_dict[str(pos.data.name)] = _read_norm_meta(pos)
+
+    def _cache_dataset(self, index: int, channel_index: list[int], t: int = 0) -> None:
+        # Add the position to the cached_dict
+        # TODO: hardcoding to t=0
+        self.cache_dict[str(self.position_keys[index])] = torch.from_numpy(
+            self.positions[index]
+            .data.oindex[slice(t, t + 1), channel_index, :]
+            .astype(np.float32)
+        )
+
+    def _get_weight_map(self, position: Position) -> Tensor:
+        # Get the weight map from the position for the MONAI weightedcrop transform
+        raise NotImplementedError
+
+    def __len__(self) -> int:
+        return len(self.positions)
+
+    def __getitem__(self, index: int) -> Sample:
+
+        ch_names = self.channels["source"].copy()
+        ch_idx = self.source_ch_idx.copy()
+        if self.target_ch_idx is not None:
+            ch_names.extend(self.channels["target"])
+            ch_idx.extend(self.target_ch_idx)
+
+        # Check if the sample is in the cache else add it
+        # Split the tensor into the channels
+        sample_id = self.position_keys[index]
+        if sample_id not in self.cache_dict:
+            logging.debug(f"Adding {sample_id} to cache")
+            self._cache_dataset(index, channel_index=ch_idx)
+
+        # Get the sample from the cache
+        images = self.cache_dict[sample_id].unbind(dim=1)
+        norm_meta = self.norm_meta_dict[str(sample_id)]
+
+        sample_images = {k: v for k, v in zip(ch_names, images)}
+
+        if self.target_ch_idx is not None:
+            # FIXME: this uses the first target channel as weight for performance
+            # since adding a reference to a tensor does not copy
+            # maybe write a weight map in preprocessing to use more information?
+            sample_images["weight"] = sample_images[self.channels["target"][0]]
+        if norm_meta is not None:
+            sample_images["norm_meta"] = norm_meta
+        if self.transform:
+            sample_images = self.transform(sample_images)
+        if "weight" in sample_images:
+            del sample_images["weight"]
+        sample = {
+            "index": sample_id,
+            "source": _stack_channels(sample_images, self.channels, "source"),
+            "norm_meta": norm_meta,
+        }
+        if self.target_ch_idx is not None:
+            sample["target"] = _stack_channels(sample_images, self.channels, "target")
+        return sample
+
+    def _load_sample(self, position: Position) -> Sample:
+        source, target = self.channel_map.source, self.channel_map.target
+        source_data = self._load_channel_data(position, source)
+        target_data = self._load_channel_data(position, target)
+        sample = {"source": source_data, "target": target_data}
+        return sample
+
+
+class CachedDataloader(LightningDataModule):
+    def __init__(
+        self,
+        data_path: str,
+        source_channel: str | Sequence[str],
+        target_channel: str | Sequence[str],
+        split_ratio: float = 0.8,
+        batch_size: int = 16,
+        num_workers: int = 8,
+        architecture: Literal["2D", "UNeXt2", "2.5D", "3D", "fcmae"] = "UNeXt2",
+        yx_patch_size: tuple[int, int] = (256, 256),
+        normalizations: list[MapTransform] = [],
+        augmentations: list[MapTransform] = [],
+    ):
+        super().__init__()
+        self.data_path = data_path
+        self.source_channel = source_channel
+        self.target_channel = target_channel
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.target_2d = False if architecture in ["UNeXt2", "3D", "fcmae"] else True
+        self.split_ratio = split_ratio
+        self.yx_patch_size = yx_patch_size
+        self.normalizations = normalizations
+        self.augmentations = augmentations
+
+    @property
+    def _base_dataset_settings(self) -> dict[str, dict[str, list[str]] | int]:
+        return {
+            "channels": {"source": self.source_channel},
+        }
+
+    def setup(self, stage: Literal["fit", "validate", "test", "predict"]) -> None:
+        dataset_settings = self._base_dataset_settings
+        if stage in ("fit", "validate"):
+            self._setup_fit(dataset_settings)
+        elif stage == "test":
+            self._setup_test(dataset_settings)
+        elif stage == "predict":
+            self._setup_predict(dataset_settings)
+        else:
+            raise NotImplementedError(f"Stage {stage} is not supported")
+
+    def _setup_fit(self, dataset_settings: dict) -> None:
+        """
+        Setup the train and validation datasets.
+        """
+        train_transform, val_transform = self._fit_transform()
+        dataset_settings["channels"]["target"] = self.target_channel
+        # Load the plate
+        plate = open_ome_zarr(self.data_path)
+
+        pass
+
+    def _setup_test(self) -> None:
+        pass
+
+    def _setup_val(self) -> None:
+        pass


### PR DESCRIPTION
## Summary
This PR adds a dataloader that caches the datasets in RAM and avoids using the `SliceWindowDataset()`. Here we cache the dataset on epoch 1. Ideally, the datasets fit within the 2TBs available per node. One can use `btop` to inspect the resource usage.

The z-slicing for the volumes is set as a parameter `num_z_slices`. We leave the slicing to the configurable MONAI transforms. 

## Testing
### Working 
- [x] Tested the `hcs_ram.CachedDataset`
- [x] Tested `hcs_ram.CacheDataModule`
- [x] Tested running `UNeXt2` with a small toy dataset locally (M1) and `gpu-sm02` nodes.
- [x] Running the model with `dev_mode=True`, which runs the model for 1 epoch.

### Not Working 
- Running UNeXt2 with the actual datasets (500GB+) using one GPU (H100), one node
- Running UNeXt2 with the actual datasets (500GB+) using 4 GPU (H100), one node
