### PR TITLE
Use sklearn's logistic regression for linear probing

### DIFF
--- a/applications/contrastive_phenotyping/evaluation/grad_attr.py
+++ b/applications/contrastive_phenotyping/evaluation/grad_attr.py
@@ -10,13 +10,15 @@ from cmap import Colormap
 from lightning.pytorch import seed_everything
 from skimage.exposure import rescale_intensity
 from sklearn.linear_model import LogisticRegression
-from sklearn.preprocessing import StandardScaler
 
 from viscy.data.triplet import TripletDataModule
 from viscy.representation.embedding_writer import read_embedding_dataset
 from viscy.representation.engine import ContrastiveEncoder, ContrastiveModule
 from viscy.representation.evaluation import load_annotation
-from viscy.representation.lca import linear_from_binary_logistic_regression
+from viscy.representation.lca import (
+    AssembledClassifier,
+    linear_from_binary_logistic_regression,
+)
 from viscy.transforms import NormalizeSampled, ScaleIntensityRangePercentilesd
 
 # %%
@@ -99,22 +101,6 @@ logistic_regression.fit(embeddings, infection_binary)
 
 # %%
 linear_classifier = linear_from_binary_logistic_regression(logistic_regression)
-
-
-# %%
-class AssembledClassifier(torch.nn.Module):
-    def __init__(self, model, classifier):
-        super().__init__()
-        self.model = model
-        self.classifier = classifier
-
-    def forward(self, x):
-        x = self.model.stem(x)
-        x = self.model.encoder(x)
-        x = self.classifier(x)
-        return x
-
-
 assembled_classifier = AssembledClassifier(model.model, linear_classifier).eval().cpu()
 
 # %%

--- a/applications/contrastive_phenotyping/evaluation/linear_probing.py
+++ b/applications/contrastive_phenotyping/evaluation/linear_probing.py
@@ -1,16 +1,13 @@
 # %% Imports
 from pathlib import Path
-from tempfile import TemporaryDirectory
-
-import pandas as pd
-from lightning.pytorch import Trainer
-from lightning.pytorch.loggers import CSVLogger
 
 from viscy.representation.embedding_writer import read_embedding_dataset
 from viscy.representation.evaluation import load_annotation
-from viscy.representation.lca import train_and_test_linear_classifier
+from viscy.representation.lca import fit_logistic_regression
 
 # %%
+TRAIN_FOVS = ["/A/3/7", "/A/3/8", "/A/3/9", "/B/4/7", "/B/4/8"]
+
 path_embedding = Path(
     "/hpc/projects/intracellular_dashboard/viral-sensor/infection_classification/models/time_sampling_strategies/time_interval/predict/feb_test_time_interval_1_epoch_178.zarr"
 )
@@ -33,27 +30,14 @@ infection = load_annotation(
 infection
 
 # %%
-temp_dir = TemporaryDirectory()
-log_path = Path(temp_dir.name)
-
-train_and_test_linear_classifier(
-    features.to_numpy(),
-    infection.cat.codes.values,
-    num_classes=3,
-    trainer=Trainer(max_epochs=60, logger=CSVLogger(log_path), log_every_n_steps=1),
-    split_ratio=(0.4, 0.2, 0.4),
-    batch_size=2**14,
-    lr=0.001,
+log_reg = fit_logistic_regression(
+    features,
+    infection,
+    train_fovs=TRAIN_FOVS,
+    remove_background_class=True,
+    scale_features=False,
+    class_weight="balanced",
+    solver="liblinear",
 )
 
-# plot loss curves to check if training converged/overfitted
-# adjust number of epochs if necessary
-losses = pd.read_csv(
-    log_path / "lightning_logs" / "version_0" / "metrics.csv", index_col="epoch"
-)
-losses = pd.merge(
-    losses["loss/train"].dropna(), losses["loss/val"].dropna(), on="epoch"
-)
-losses.plot()
-temp_dir.cleanup()
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,15 @@ metrics = [
 ]
 examples = ["napari", "jupyter", "jupytext"]
 
-visual = ["ipykernel", "graphviz", "torchview", "seaborn", "plotly", "nbformat"]
+visual = [
+    "ipykernel",
+    "graphviz",
+    "torchview",
+    "seaborn",
+    "plotly",
+    "nbformat",
+    "cmap",
+]
 
 dev = [
     "pytest",

--- a/tests/representation/test_lca.py
+++ b/tests/representation/test_lca.py
@@ -1,6 +1,12 @@
 import numpy as np
+import torch
+from sklearn.linear_model import LogisticRegression
 
-from viscy.representation.lca import Trainer, train_and_test_linear_classifier
+from viscy.representation.lca import (
+    Trainer,
+    linear_from_binary_logistic_regression,
+    train_and_test_linear_classifier,
+)
 
 
 def test_train_and_test_linear_classifier(caplog):
@@ -17,3 +23,21 @@ def test_train_and_test_linear_classifier(caplog):
         )
     assert "accuracy_macro" in caplog.text
     assert "f1_weighted" in caplog.text
+
+
+def test_linear_from_logistic_regression():
+    """
+    Test ``linear_from_logistic_regression``.
+    Check that the logits from the logistic regression
+    and the linear model are almost equal.
+    """
+    rand_data = np.random.rand(100, 8)
+    rand_labels = np.random.randint(0, 2, size=(100))
+    logistic_regression = LogisticRegression().fit(rand_data, rand_labels)
+    linear_model = linear_from_binary_logistic_regression(logistic_regression)
+    logistic_logits = logistic_regression.decision_function(rand_data)
+    with torch.inference_mode():
+        torch_logits = (
+            linear_model(torch.from_numpy(rand_data).float()).squeeze().numpy()
+        )
+    np.testing.assert_allclose(logistic_logits, torch_logits, rtol=1e-3)

--- a/tests/representation/test_lca.py
+++ b/tests/representation/test_lca.py
@@ -2,27 +2,7 @@ import numpy as np
 import torch
 from sklearn.linear_model import LogisticRegression
 
-from viscy.representation.lca import (
-    Trainer,
-    linear_from_binary_logistic_regression,
-    train_and_test_linear_classifier,
-)
-
-
-def test_train_and_test_linear_classifier(caplog):
-    """Test ``train_and_test_linear_classifier``."""
-    embeddings = np.random.rand(10, 8)
-    labels = np.random.randint(0, 2, 10)
-    with caplog.at_level("INFO"):
-        train_and_test_linear_classifier(
-            embeddings,
-            labels,
-            num_classes=3,
-            trainer=Trainer(fast_dev_run=True),
-            batch_size=4,
-        )
-    assert "accuracy_macro" in caplog.text
-    assert "f1_weighted" in caplog.text
+from viscy.representation.lca import linear_from_binary_logistic_regression
 
 
 def test_linear_from_logistic_regression():

--- a/viscy/representation/lca.py
+++ b/viscy/representation/lca.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from lightning.pytorch import LightningDataModule, LightningModule, Trainer
 from numpy.typing import NDArray
+from sklearn.linear_model import LogisticRegression
 from torch import Tensor, optim
 from torch.utils.data import DataLoader, TensorDataset
 from torchmetrics.functional.classification import (
@@ -17,6 +18,18 @@ from torchmetrics.functional.classification import (
 )
 
 _logger = logging.getLogger("lightning.pytorch")
+
+
+def linear_from_binary_logistic_regression(
+    logistic_regression: LogisticRegression,
+) -> nn.Linear:
+    weights = torch.from_numpy(logistic_regression.coef_).float()
+    bias = torch.from_numpy(logistic_regression.intercept_).float()
+    model = nn.Linear(in_features=weights.shape[1], out_features=1)
+    model.weight.data = weights
+    model.bias.data = bias
+    model.eval()
+    return model
 
 
 def _test_metrics(preds: Tensor, target: Tensor, num_classes: int) -> dict[str, float]:

--- a/viscy/representation/lca.py
+++ b/viscy/representation/lca.py
@@ -17,6 +17,8 @@ from torchmetrics.functional.classification import (
     multiclass_f1_score,
 )
 
+from viscy.representation.contrastive import ContrastiveEncoder
+
 _logger = logging.getLogger("lightning.pytorch")
 
 
@@ -30,6 +32,19 @@ def linear_from_binary_logistic_regression(
     model.bias.data = bias
     model.eval()
     return model
+
+
+class AssembledClassifier(torch.nn.Module):
+    def __init__(self, model: ContrastiveEncoder, classifier: nn.Linear) -> None:
+        super().__init__()
+        self.model = model
+        self.classifier = classifier
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.model.stem(x)
+        x = self.model.encoder(x)
+        x = self.classifier(x)
+        return x
 
 
 def _test_metrics(preds: Tensor, target: Tensor, num_classes: int) -> dict[str, float]:

--- a/viscy/representation/lca.py
+++ b/viscy/representation/lca.py
@@ -35,14 +35,14 @@ def linear_from_binary_logistic_regression(
 
 
 class AssembledClassifier(torch.nn.Module):
-    def __init__(self, model: ContrastiveEncoder, classifier: nn.Linear) -> None:
+    def __init__(self, backbone: ContrastiveEncoder, classifier: nn.Linear) -> None:
         super().__init__()
-        self.model = model
+        self.backbone = backbone
         self.classifier = classifier
 
     def forward(self, x: Tensor) -> Tensor:
-        x = self.model.stem(x)
-        x = self.model.encoder(x)
+        x = self.backbone.stem(x)
+        x = self.backbone.encoder(x)
         x = self.classifier(x)
         return x
 


### PR DESCRIPTION
Optimizing the logistic regression model in sklearn (max-entropy) is the exact same function and objective as optimizing a linear layer with cross-entropy-with-logit loss in torch. The only differences are least-squares vs SGD, and weight regularization. Therefore, by copying the weights and bias from a sklearn model to a torch linear layer, we can use the same deterministic optimization for evaluating classification performance and model interpretation methods that require gradients.

I also include a test case to verify the above: the logits produced by the sklearn and torch models are almost equal (with relative tolerance 0.001).