### PR TITLE
Bump torch to 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { file = "LICENSE" }
 authors = [{ name = "CZ Biohub SF", email = "compmicro@czbiohub.org" }]
 dependencies = [
     "iohub==0.1.0",
-    "torch>=2.1.2",
+    "torch>=2.4.1",
     "timm>=0.9.5",
     "tensorboard>=2.13.0",
     "lightning>=2.3.0",

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -224,7 +224,7 @@ class CachedDataModule(LightningDataModule):
         )
         val_transform = Compose(self.normalizations + final_crop)
         return train_transform, val_transform
-    
+
     def _set_fit_global_state(self, num_positions: int) -> torch.Tensor:
         # disable metadata tracking in MONAI for performance
         set_track_meta(False)

--- a/viscy/data/hcs_ram.py
+++ b/viscy/data/hcs_ram.py
@@ -1,32 +1,22 @@
 import logging
-import math
-import os
-import re
-import tempfile
-from pathlib import Path
 from typing import Callable, Literal, Sequence
 
 import numpy as np
 import torch
-import zarr
-from imageio import imread
-from iohub.ngff import ImageArray, Plate, Position, open_ome_zarr
+from iohub.ngff import Position, open_ome_zarr
 from lightning.pytorch import LightningDataModule
 from monai.data import set_track_meta
-from monai.data.utils import collate_meta_tensor
 from monai.transforms import (
     CenterSpatialCropd,
     Compose,
     MapTransform,
     MultiSampleTrait,
-    RandAffined,
 )
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
-from viscy.data.typing import ChannelMap, DictTransform, HCSStackIndex, NormMeta, Sample
 from viscy.data.hcs import _read_norm_meta
-from tqdm import tqdm
+from viscy.data.typing import ChannelMap, DictTransform, Sample
 
 _logger = logging.getLogger("lightning.pytorch")
 


### PR DESCRIPTION
need to update torch>2.4.1  for #151 to be effective. 

Otherwise you get the error:

```
@torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float32)
AttributeError: module 'torch.amp' has no attribute 'custom_fwd'
```