### PR TITLE
Restore global CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dev = [
     "onnxruntime",
 ]
 
+[project.scripts]
+viscy = "viscy.cli:main"
+
 [tool.setuptools]
 packages = ["viscy"]
 

--- a/viscy/cli.py
+++ b/viscy/cli.py
@@ -35,11 +35,21 @@ class VisCyCLI(LightningCLI):
         )
 
 
+def setup_environment() -> None:
+    """
+    Set log level and TF32 precision.
+    """
+    log_level = os.getenv("VISCY_LOG_LEVEL", logging.INFO)
+    logging.getLogger("lightning.pytorch").setLevel(log_level)
+    torch.set_float32_matmul_precision("high")
+
+
 def run_cli(
     cli_class: type[LightningCLI],
     model_class: type[LightningModule],
     datamodule_class: type[LightningDataModule],
     trainer_class: type[VisCyTrainer],
+    **cli_kwargs,
 ) -> None:
     """
     Main Lightning CLI entry point.
@@ -56,9 +66,7 @@ def run_cli(
     trainer_class : type[VisCyTrainer]
         Lightning trainer class
     """
-    log_level = os.getenv("VISCY_LOG_LEVEL", logging.INFO)
-    logging.getLogger("lightning.pytorch").setLevel(log_level)
-    torch.set_float32_matmul_precision("high")
+    setup_environment()
     seed = True
     if "preprocess" in sys.argv:
         seed = False
@@ -69,4 +77,17 @@ def run_cli(
         datamodule_class=datamodule_class,
         trainer_class=trainer_class,
         seed_everything_default=seed,
+        **cli_kwargs,
+    )
+
+
+def main() -> None:
+    """Main CLI with subclass mode enabled."""
+    run_cli(
+        cli_class=VisCyCLI,
+        model_class=LightningModule,
+        datamodule_class=LightningDataModule,
+        trainer_class=VisCyTrainer,
+        subclass_mode_data=True,
+        subclass_mode_model=True,
     )


### PR DESCRIPTION
Use the global `viscy [command]` CLI for multiple tasks (translation/representation/...) and dispatch via dependency injection in the config.

Example config for VSCyto2D prediction:

```
/hpc/projects/intracellular_dashboard/ops/2024_09_19_tracking_accuracy_test/2-VS/tta/test_cli/predict.yml
```