### PR TITLE
Store UMAP embeddings in SSL predictions

### DIFF
--- a/viscy/representation/embedding_writer.py
+++ b/viscy/representation/embedding_writer.py
@@ -91,7 +91,7 @@ class EmbeddingWriter(BasePredictionWriter):
         features = _move_and_stack_embeddings(predictions, "features")
         projections = _move_and_stack_embeddings(predictions, "projections")
         ultrack_indices = pd.concat([pd.DataFrame(p["index"]) for p in predictions])
-        _logger.debug("Computing UMAP embeddings")
+        _logger.info(f"Computing UMAP embeddings for {len(features)} samples.")
         _, umap = _fit_transform_umap(features, n_components=2, normalize=True)
         ultrack_indices["UMAP1"] = umap[:, 0]
         ultrack_indices["UMAP2"] = umap[:, 1]

--- a/viscy/representation/embedding_writer.py
+++ b/viscy/representation/embedding_writer.py
@@ -40,7 +40,7 @@ def _move_and_stack_embeddings(
     predictions: Sequence[ContrastivePrediction], key: str
 ) -> NDArray:
     """Move embeddings to CPU and stack them into a numpy array."""
-    return torch.cat([p["features"].cpu() for p in predictions], dim=0).numpy()
+    return torch.cat([p[key].cpu() for p in predictions], dim=0).numpy()
 
 
 class EmbeddingWriter(BasePredictionWriter):

--- a/viscy/representation/engine.py
+++ b/viscy/representation/engine.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal, Sequence
+from typing import Literal, Sequence, TypedDict
 
 import numpy as np
 import torch
@@ -7,11 +7,17 @@ import torch.nn.functional as F
 from lightning.pytorch import LightningModule
 from torch import Tensor, nn
 
-from viscy.data.typing import TripletSample
+from viscy.data.typing import TrackingIndex, TripletSample
 from viscy.representation.contrastive import ContrastiveEncoder
 from viscy.utils.log_images import detach_sample, render_images
 
 _logger = logging.getLogger("lightning.pytorch")
+
+
+class ContrastivePrediction(TypedDict):
+    features: Tensor
+    projections: Tensor
+    index: TrackingIndex
 
 
 class ContrastiveModule(LightningModule):
@@ -154,7 +160,7 @@ class ContrastiveModule(LightningModule):
 
     def predict_step(
         self, batch: TripletSample, batch_idx, dataloader_idx=0
-    ) -> dict[str, Tensor | dict]:
+    ) -> ContrastivePrediction:
         """Prediction step for extracting embeddings."""
         features, projections = self.model(batch["anchor"])
         return {


### PR DESCRIPTION
Store 2-component UMAP in the prediction Zarr store of `viscy.representation.embedding_writer.EmbeddingWriter`. This is intended to be loaded by the [napari widget](https://github.com/czbiohub-sf/napari-iohub/pull/13) for plotting.

Close #166.