### PR TITLE
Bump MONAI to unpin NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ dependencies = [
     "timm>=0.9.5",
     "tensorboard>=2.13.0",
     "lightning>=2.3.0",
-    "monai>=1.3.1",
+    "monai>=1.4.0",
     "jsonargparse[signatures]>=4.20.1",
     "scikit-image",
     "matplotlib>=3.9.0",
-    "numpy<2",
+    "numpy",
     "xarray",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
MONAI 1.4.0 adds support for NumPy>2.