### PR TITLE
GPU transform for FCMAE pre-training

### DIFF
--- a/viscy/data/combined.py
+++ b/viscy/data/combined.py
@@ -28,7 +28,7 @@ class CombinedDataModule(LightningDataModule):
     train_mode : CombineMode, optional
         mode in training stage, by default CombineMode.MAX_SIZE_CYCLE
     val_mode : CombineMode, optional
-        _description_, by default CombineMode.SEQUENTIAL
+        mode in validation stage, by default CombineMode.SEQUENTIAL
     test_mode : CombineMode, optional
         mode in testing stage, by default CombineMode.SEQUENTIAL
     predict_mode : CombineMode, optional
@@ -86,8 +86,8 @@ class ConcatDataModule(LightningDataModule):
     """
     Concatenate multiple data modules.
 
-    The concatenated data module will have the same batch size and number of workers 
-    as the first data module. Each element will be sampled uniformly regardless of 
+    The concatenated data module will have the same batch size and number of workers
+    as the first data module. Each element will be sampled uniformly regardless of
     their original data module.
 
     Parameters

--- a/viscy/data/combined.py
+++ b/viscy/data/combined.py
@@ -21,11 +21,18 @@ class CombinedDataModule(LightningDataModule):
     """Wrapper for combining multiple data modules.
     For supported modes, see ``lightning.pytorch.utilities.combined_loader``.
 
-    :param Sequence[LightningDataModule] data_modules: data modules to combine
-    :param str train_mode: mode in training stage, defaults to "max_size_cycle"
-    :param str val_mode: mode in validation stage, defaults to "sequential"
-    :param str test_mode: mode in testing stage, defaults to "sequential"
-    :param str predict_mode: mode in prediction stage, defaults to "sequential"
+    Parameters
+    ----------
+    data_modules : Sequence[LightningDataModule]
+        data modules to combine
+    train_mode : CombineMode, optional
+        mode in training stage, by default CombineMode.MAX_SIZE_CYCLE
+    val_mode : CombineMode, optional
+        _description_, by default CombineMode.SEQUENTIAL
+    test_mode : CombineMode, optional
+        mode in testing stage, by default CombineMode.SEQUENTIAL
+    predict_mode : CombineMode, optional
+        mode in prediction stage, by default CombineMode.SEQUENTIAL
     """
 
     def __init__(
@@ -78,10 +85,15 @@ class CombinedDataModule(LightningDataModule):
 class ConcatDataModule(LightningDataModule):
     """
     Concatenate multiple data modules.
-    The concatenated data module will have the same
-    batch size and number of workers as the first data module.
-    Each element will be sampled uniformly regardless of their original data module.
-    :param Sequence[LightningDataModule] data_modules: data modules to concatenate
+
+    The concatenated data module will have the same batch size and number of workers 
+    as the first data module. Each element will be sampled uniformly regardless of 
+    their original data module.
+
+    Parameters
+    ----------
+    data_modules : Sequence[LightningDataModule]
+        Data modules to concatenate.
     """
 
     def __init__(self, data_modules: Sequence[LightningDataModule]):

--- a/viscy/data/ctmc_v1.py
+++ b/viscy/data/ctmc_v1.py
@@ -12,13 +12,31 @@ class CTMCv1DataModule(GPUTransformDataModule):
     Autoregression data module for the CTMCv1 dataset.
     Training and validation datasets are stored in separate HCS OME-Zarr stores.
 
-    :param str | Path train_data_path: Path to the training dataset
-    :param str | Path val_data_path: Path to the validation dataset
-    :param list[MapTransform] train_transforms: List of transforms for training
-    :param list[MapTransform] val_transforms: List of transforms for validation
-    :param int batch_size: Batch size, defaults to 16
-    :param int num_workers: Number of workers, defaults to 8
-    :param str channel_name: Name of the DIC channel, defaults to "DIC"
+    Parameters
+    ----------
+    train_data_path : str or Path
+        Path to the training dataset.
+    val_data_path : str or Path
+        Path to the validation dataset.
+    train_cpu_transforms : list of MapTransform
+        List of CPU transforms for training.
+    val_cpu_transforms : list of MapTransform
+        List of CPU transforms for validation.
+    train_gpu_transforms : list of MapTransform
+        List of GPU transforms for training.
+    val_gpu_transforms : list of MapTransform
+        List of GPU transforms for validation.
+    batch_size : int, optional
+        Batch size, by default 16.
+    num_workers : int, optional
+        Number of dataloading workers, by default 8.
+    val_subsample_ratio : int, optional
+        Skip evert N frames for validation to reduce redundancy in video,
+        by default 30.
+    channel_name : str, optional
+        Name of the DIC channel, by default "DIC".
+    pin_memory : bool, optional
+        Pin memory for dataloaders, by default True.
     """
 
     def __init__(

--- a/viscy/data/gpu_aug.py
+++ b/viscy/data/gpu_aug.py
@@ -55,7 +55,7 @@ class GPUTransformDataModule(ABC, LightningDataModule):
             persistent_workers=True if self.num_workers > 0 else False,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
-            drop_last=True,
+            drop_last=False,
             collate_fn=list_data_collate,
         )
 
@@ -115,7 +115,7 @@ class CachedOmeZarrDataset(Dataset):
         self.transform = transform
 
     def __len__(self) -> int:
-        return len(self._cache_map)
+        return len(self._metadata_map)
 
     def __getitem__(self, idx: int) -> dict[str, Tensor]:
         position, time_idx, norm_meta = self._metadata_map[idx]

--- a/viscy/data/gpu_aug.py
+++ b/viscy/data/gpu_aug.py
@@ -29,6 +29,12 @@ _CacheMetadata = tuple[Position, int, NormMeta | None]
 
 
 class GPUTransformDataModule(ABC, LightningDataModule):
+    train_dataset: Dataset
+    val_dataset: Dataset
+    batch_size: int
+    num_workers: int
+    pin_memory: bool
+
     def _maybe_sampler(
         self, dataset: Dataset, shuffle: bool
     ) -> ShardedDistributedSampler | None:

--- a/viscy/data/gpu_aug.py
+++ b/viscy/data/gpu_aug.py
@@ -99,6 +99,7 @@ class CachedOmeZarrDataset(Dataset):
         cache_map: DictProxy,
         transform: Compose | None = None,
         array_key: str = "0",
+        load_normalization_metadata: bool = True,
     ):
         key = 0
         self._metadata_map: dict[int, _CacheMetadata] = {}
@@ -113,6 +114,7 @@ class CachedOmeZarrDataset(Dataset):
         self.array_key = array_key
         self._cache_map = cache_map
         self.transform = transform
+        self.load_normalization_metadata = load_normalization_metadata
 
     def __len__(self) -> int:
         return len(self._metadata_map)
@@ -132,7 +134,8 @@ class CachedOmeZarrDataset(Dataset):
             _logger.debug(f"Using cached volume for index {idx}")
             volume = cache
         sample = {name: img[None] for name, img in zip(self.channels.keys(), volume)}
-        sample["norm_meta"] = norm_meta
+        if self.load_normalization_metadata:
+            sample["norm_meta"] = norm_meta
         if self.transform:
             sample = self.transform(sample)
         if not isinstance(sample, list):

--- a/viscy/data/gpu_aug.py
+++ b/viscy/data/gpu_aug.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from logging import getLogger
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import torch
+from iohub.ngff import Plate, Position, open_ome_zarr
+from lightning.pytorch import LightningDataModule
+from monai.data.meta_obj import set_track_meta
+from monai.transforms import Compose
+from torch import Tensor
+from torch.multiprocessing import Manager
+from torch.utils.data import DataLoader, Dataset, Subset
+
+from viscy.data.distributed import ShardedDistributedSampler
+from viscy.data.hcs import _ensure_channel_list, _read_norm_meta
+from viscy.data.typing import DictTransform
+
+if TYPE_CHECKING:
+    from multiprocessing.managers import DictProxy
+
+_logger = getLogger("lightning.pytorch")
+
+
+class CachedOmeZarrDataset(Dataset):
+    def __init__(
+        self,
+        positions: list[Position],
+        channel_names: list[str],
+        cache_map: DictProxy,
+        transform: DictTransform | None = None,
+        array_key: str = "0",
+    ):
+        key = 0
+        self._metadata_map = {}
+        for position in positions:
+            img = position[array_key]
+            norm_meta = _read_norm_meta(position)
+            for time_idx in range(img.frames):
+                cache_map[key] = None
+                self._metadata_map[key] = (position, time_idx, norm_meta)
+                key += 1
+        self.channels = {ch: position.get_channel_index(ch) for ch in channel_names}
+        self.array_key = array_key
+        self._cache_map = cache_map
+        self.transform = transform
+
+    def __len__(self) -> int:
+        return len(self._cache_map)
+
+    def __getitem__(self, idx: int) -> Tensor:
+        position, time_idx, norm_meta = self._metadata_map[idx]
+        cache = self._cache_map[idx]
+        if cache is None:
+            _logger.debug(f"Caching for index {idx}")
+            volume = torch.from_numpy(
+                position[self.array_key]
+                .oindex[time_idx, list(self.channels.values())]
+                .astype(np.float32)
+            )
+            self._cache_map[idx] = volume
+        else:
+            _logger.debug(f"Using cached volume for index {idx}")
+            volume = cache
+        sample = {name: img[None] for name, img in zip(self.channels.keys(), volume)}
+        sample["norm_meta"] = norm_meta
+        if self.transform:
+            sample = self.transform(sample)
+        if not isinstance(sample, list):
+            sample = [sample]
+        out_tensors = []
+        for s in sample:
+            s.pop("norm_meta")
+            s_out = torch.cat(list(s.values()))
+            out_tensors.append(s_out)
+        return out_tensors
+
+
+class CachedOmeZarrDataModule(LightningDataModule):
+    def __init__(
+        self,
+        data_path: Path,
+        channels: str | list[str],
+        batch_size: int,
+        num_workers: int,
+        split_ratio: float,
+        transforms: list[DictTransform],
+    ):
+        super().__init__()
+        self.data_path = data_path
+        self.channels = _ensure_channel_list(channels)
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.split_ratio = split_ratio
+        self.transforms = Compose(transforms)
+
+    def _set_fit_global_state(self, num_positions: int) -> list[int]:
+        # disable metadata tracking in MONAI for performance
+        set_track_meta(False)
+        # shuffle positions, randomness is handled globally
+        return torch.randperm(num_positions).tolist()
+
+    def setup(self, stage: Literal["fit", "validate"]) -> None:
+        cache_map = Manager().dict()
+        plate: Plate = open_ome_zarr(self.data_path, mode="r", layout="hcs")
+        positions = [p for _, p in plate.positions()]
+        shuffled_indices = self._set_fit_global_state(len(positions))
+        num_train_fovs = int(len(positions) * self.split_ratio)
+        dataset = CachedOmeZarrDataset(
+            positions, self.channels, cache_map, self.transforms
+        )
+        self.train_dataset = Subset(dataset, shuffled_indices[:num_train_fovs])
+        self.val_dataset = Subset(dataset, shuffled_indices[num_train_fovs:])
+
+    def _maybe_sampler(
+        self, dataset: Dataset, shuffle: bool
+    ) -> ShardedDistributedSampler | None:
+        return (
+            ShardedDistributedSampler(dataset, shuffle=shuffle)
+            if torch.distributed.is_initialized()
+            else None
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        sampler = self._maybe_sampler(self.train_dataset, shuffle=True)
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=False if sampler else True,
+            sampler=sampler,
+            persistent_workers=True if self.num_workers > 0 else False,
+            num_workers=self.num_workers,
+            drop_last=True,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        sampler = self._maybe_sampler(self.val_dataset, shuffle=False)
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            sampler=sampler,
+            persistent_workers=True if self.num_workers > 0 else False,
+            num_workers=self.num_workers,
+            drop_last=False,
+        )

--- a/viscy/data/gpu_aug.py
+++ b/viscy/data/gpu_aug.py
@@ -10,6 +10,7 @@ import torch
 from iohub.ngff import Plate, Position, open_ome_zarr
 from lightning.pytorch import LightningDataModule
 from monai.data.meta_obj import set_track_meta
+from monai.data.utils import list_data_collate
 from monai.transforms.compose import Compose
 from torch import Tensor
 from torch.multiprocessing import Manager
@@ -49,6 +50,7 @@ class GPUTransformDataModule(ABC, LightningDataModule):
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
             drop_last=True,
+            collate_fn=list_data_collate,
         )
 
     def val_dataloader(self) -> DataLoader:
@@ -63,6 +65,7 @@ class GPUTransformDataModule(ABC, LightningDataModule):
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
             drop_last=False,
+            collate_fn=list_data_collate,
         )
 
     @property

--- a/viscy/data/typing.py
+++ b/viscy/data/typing.py
@@ -50,7 +50,7 @@ class Sample(TypedDict, total=False):
     # Instance segmentation masks
     labels: OneOrSeq[Tensor]
     # None: not available
-    norm_meta: NormMeta
+    norm_meta: NormMeta | None
 
 
 class ChannelMap(TypedDict):

--- a/viscy/transforms.py
+++ b/viscy/transforms.py
@@ -2,8 +2,11 @@
 
 from typing import Sequence, Union
 
+import numpy as np
+import torch
 from monai.transforms import (
     MapTransform,
+    MultiSampleTrait,
     RandAdjustContrastd,
     RandAffined,
     RandGaussianNoised,
@@ -15,9 +18,10 @@ from monai.transforms import (
 )
 from monai.transforms.transform import Randomizable
 from numpy.random.mtrand import RandomState as RandomState
+from torch import Tensor
 from typing_extensions import Iterable, Literal
 
-from viscy.data.typing import Sample
+from viscy.data.typing import ChannelMap, Sample
 
 
 class RandWeightedCropd(RandWeightedCropd):
@@ -231,3 +235,53 @@ class RandInvertIntensityd(MapTransform, RandomizableTransform):
     ) -> Randomizable:
         super().set_random_state(seed, state)
         return self
+
+
+class TiledSpatialCropSamplesd(MapTransform, MultiSampleTrait):
+    """
+    Crop multiple tiled ROIs from an image.
+    Used for deterministic cropping in validation.
+    """
+
+    def __init__(
+        self,
+        keys: Union[str, Iterable[str]],
+        roi_size: tuple[int, int, int],
+        num_samples: int,
+    ) -> None:
+        super().__init__(keys, allow_missing_keys=False)
+        self.roi_size = roi_size
+        self.num_samples = num_samples
+
+    def _check_num_samples(self, spatial_size: np.ndarray, offset: int) -> np.ndarray:
+        max_grid_shape = spatial_size // self.roi_size
+        max_num_samples = max_grid_shape.prod()
+        if offset >= max_num_samples:
+            raise ValueError(
+                f"Number of samples {self.num_samples} should be "
+                f"smaller than {max_num_samples}."
+            )
+        grid_idx = np.asarray(np.unravel_index(offset, max_grid_shape))
+        return grid_idx * self.roi_size
+
+    def _crop(self, img: Tensor, offset: int) -> Tensor:
+        spatial_size = np.array(img.shape[-3:])
+        crop_start = self._check_num_samples(spatial_size, offset)
+        crop_end = crop_start + np.array(self.roi_size)
+        return img[
+            ...,
+            crop_start[0] : crop_end[0],
+            crop_start[1] : crop_end[1],
+            crop_start[2] : crop_end[2],
+        ]
+
+    def __call__(self, sample: Sample) -> Sample:
+        results = []
+        for i in range(self.num_samples):
+            result = {}
+            for key in self.keys:
+                result[key] = self._crop(sample[key], i)
+            if "norm_meta" in sample:
+                result["norm_meta"] = sample["norm_meta"]
+            results.append(result)
+        return results

--- a/viscy/transforms.py
+++ b/viscy/transforms.py
@@ -206,6 +206,8 @@ class RandInvertIntensityd(MapTransform, RandomizableTransform):
 
     def __call__(self, sample: Sample) -> Sample:
         self.randomize(None)
+        if not self._do_transform:
+            return sample
         for key in self.keys:
             if key in sample:
                 sample[key] = -sample[key]

--- a/viscy/transforms.py
+++ b/viscy/transforms.py
@@ -16,8 +16,6 @@ from monai.transforms import (
     RandWeightedCropd,
     ScaleIntensityRangePercentilesd,
 )
-from monai.transforms.transform import Randomizable
-from numpy.random.mtrand import RandomState as RandomState
 from torch import Tensor
 from typing_extensions import Iterable, Literal
 
@@ -229,12 +227,6 @@ class RandInvertIntensityd(MapTransform, RandomizableTransform):
             if key in sample:
                 sample[key] = -sample[key]
         return sample
-
-    def set_random_state(
-        self, seed: int | None = None, state: RandomState | None = None
-    ) -> Randomizable:
-        super().set_random_state(seed, state)
-        return self
 
 
 class TiledSpatialCropSamplesd(MapTransform, MultiSampleTrait):

--- a/viscy/transforms.py
+++ b/viscy/transforms.py
@@ -285,3 +285,20 @@ class TiledSpatialCropSamplesd(MapTransform, MultiSampleTrait):
                 result["norm_meta"] = sample["norm_meta"]
             results.append(result)
         return results
+
+
+class StackChannelsd(MapTransform):
+    """Stack source and target channels."""
+
+    def __init__(self, channel_map: ChannelMap) -> None:
+        channel_names = []
+        for channels in channel_map.values():
+            channel_names.extend(channels)
+        super().__init__(channel_names, allow_missing_keys=False)
+        self.channel_map = channel_map
+
+    def __call__(self, sample: Sample) -> Sample:
+        results = {}
+        for key, channels in self.channel_map.items():
+            results[key] = torch.cat([sample[ch] for ch in channels], dim=0)
+        return results

--- a/viscy/transforms.py
+++ b/viscy/transforms.py
@@ -158,11 +158,20 @@ class ScaleIntensityRangePercentilesd(ScaleIntensityRangePercentilesd):
 
 class NormalizeSampled(MapTransform):
     """
-    Normalize the sample
-    :param Union[str, Iterable[str]] keys: keys to normalize
-    :param str fov: fov path with respect to Plate
-    :param str subtrahend: subtrahend for normalization, defaults to "mean"
-    :param str divisor: divisor for normalization, defaults to "std"
+    Normalize the sample.
+
+    Parameters
+    ----------
+    keys : Union[str, Iterable[str]]
+        Keys to normalize.
+    level : {'fov_statistics', 'dataset_statistics'}
+        Level of normalization.
+    subtrahend : str, optional
+        Subtrahend for normalization, defaults to "mean".
+    divisor : str, optional
+        Divisor for normalization, defaults to "std".
+    remove_meta : bool, optional
+        Whether to remove metadata after normalization, defaults to False.
     """
 
     def __init__(
@@ -171,11 +180,13 @@ class NormalizeSampled(MapTransform):
         level: Literal["fov_statistics", "dataset_statistics"],
         subtrahend="mean",
         divisor="std",
+        remove_meta: bool = False,
     ) -> None:
         super().__init__(keys, allow_missing_keys=False)
         self.subtrahend = subtrahend
         self.divisor = divisor
         self.level = level
+        self.remove_meta = remove_meta
 
     # TODO: need to implement the case where the preprocessing already exists
     def __call__(self, sample: Sample) -> Sample:
@@ -184,6 +195,8 @@ class NormalizeSampled(MapTransform):
             subtrahend_val = level_meta[self.subtrahend]
             divisor_val = level_meta[self.divisor] + 1e-8  # avoid div by zero
             sample[key] = (sample[key] - subtrahend_val) / divisor_val
+        if self.remove_meta:
+            sample.pop("norm_meta")
         return sample
 
     def _normalize():

--- a/viscy/translation/engine.py
+++ b/viscy/translation/engine.py
@@ -514,6 +514,7 @@ class FcmaeUNet(VSUNet):
             transformed.extend(dataset_batch)
         return collate_meta_tensor(transformed)["source"]
 
+    @torch.no_grad()
     def val_transform_and_collate(
         self, batch: list[Sample], dataloader_idx: int
     ) -> Tensor:

--- a/viscy/translation/engine.py
+++ b/viscy/translation/engine.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as F
 from imageio import imwrite
 from lightning.pytorch import LightningModule
+from monai.data.utils import collate_meta_tensor
 from monai.optimizers import WarmupCosineSchedule
 from monai.transforms import Compose, DivisiblePad, Rotate90
 from torch import Tensor, nn
@@ -23,6 +24,8 @@ from torchmetrics.functional import (
     structural_similarity_index_measure,
 )
 
+from viscy.data.combined import CombinedDataModule
+from viscy.data.gpu_aug import GPUTransformDataModule
 from viscy.data.typing import Sample
 from viscy.translation.evaluation_metrics import mean_average_precision, ms_ssim_25d
 from viscy.unet.networks.fcmae import FullyConvolutionalMAE
@@ -477,30 +480,53 @@ class FcmaeUNet(VSUNet):
         self.fit_mask_ratio = fit_mask_ratio
         self.train_transforms = Compose(train_transforms)
         self.validation_transforms = Compose(validation_transforms)
+        self.save_hyperparameters()
+
+    def on_fit_start(self):
+        dm = self.trainer.datamodule
+        if not isinstance(dm, CombinedDataModule):
+            raise ValueError(
+                f"Container data module type {type(dm)} "
+                "is not supported for FCMAE training"
+            )
+        for subdm in dm.data_modules:
+            if not isinstance(subdm, GPUTransformDataModule):
+                raise ValueError(
+                    f"Member data module type {type(subdm)} "
+                    "is not supported for FCMAE training"
+                )
+        self.datamodules = dm.data_modules
 
     def forward(self, x: Tensor, mask_ratio: float = 0.0):
         return self.model(x, mask_ratio)
 
-    def forward_fit(self, batch: Tensor) -> tuple[Tensor]:
+    def forward_fit(self, batch: Tensor) -> tuple[Tensor, Tensor, Tensor]:
         pred, mask = self.forward(batch, mask_ratio=self.fit_mask_ratio)
         loss = F.mse_loss(pred, batch, reduction="none")
         loss = (loss.mean(2) * mask).sum() / mask.sum()
         return pred, mask, loss
 
-    def transform_and_collate(self, batch: list[Tensor], transforms: Compose) -> Tensor:
+    @torch.no_grad()
+    def train_transform_and_collate(self, batch: list[dict[Sample]]) -> Tensor:
         transformed = []
-        for sample in batch:
-            for element in sample:
-                transformed.append(transforms(element))
-        return torch.stack(transformed)
+        for dataset_batch, dm in zip(batch, self.datamodules):
+            dataset_batch = dm.train_gpu_transforms(dataset_batch)
+            transformed.extend(dataset_batch)
+        return collate_meta_tensor(transformed)["source"]
 
-    def training_step(self, batch: list[Tensor], batch_idx: int):
-        batch = self.transform_and_collate(batch, self.train_transforms)
-        pred, mask, loss = self.forward_fit(batch)
+    def val_transform_and_collate(
+        self, batch: list[Sample], dataloader_idx: int
+    ) -> Tensor:
+        batch = self.datamodules[dataloader_idx].val_gpu_transforms(batch)
+        return collate_meta_tensor(batch)["source"]
+
+    def training_step(self, batch: list[list[Sample]], batch_idx: int) -> Tensor:
+        x = self.train_transform_and_collate(batch)
+        pred, mask, loss = self.forward_fit(x)
         if batch_idx < self.log_batches_per_epoch:
             self.training_step_outputs.extend(
                 detach_sample(
-                    (batch, batch * mask.unsqueeze(2), pred), self.log_samples_per_batch
+                    (x, x * mask.unsqueeze(2), pred), self.log_samples_per_batch
                 )
             )
         self.log(
@@ -511,25 +537,25 @@ class FcmaeUNet(VSUNet):
             prog_bar=True,
             logger=True,
             sync_dist=True,
-            batch_size=batch.shape[0],
+            batch_size=x.shape[0],
         )
         return loss
 
     def validation_step(
-        self, batch: list[Tensor], batch_idx: int, dataloader_idx: int = 0
-    ):
-        batch = self.transform_and_collate(batch, self.validation_transforms)
-        pred, mask, loss = self.forward_fit(batch)
+        self, batch: list[Sample], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        x = self.val_transform_and_collate(batch, dataloader_idx)
+        pred, mask, loss = self.forward_fit(x)
         if dataloader_idx + 1 > len(self.validation_losses):
             self.validation_losses.append([])
         self.validation_losses[dataloader_idx].append(loss.detach())
         self.log(
-            "loss/val", loss.to(self.device), sync_dist=True, batch_size=batch.shape[0]
+            "loss/val", loss.to(self.device), sync_dist=True, batch_size=x.shape[0]
         )
         if batch_idx < self.log_batches_per_epoch:
             self.validation_step_outputs.extend(
                 detach_sample(
-                    (batch, batch * mask.unsqueeze(2), pred),
+                    (x, x * mask.unsqueeze(2), pred),
                     self.log_samples_per_batch,
                 )
             )


### PR DESCRIPTION
Building on top of #196:
Doing non-trivial augmentations on large imaging volumes has become a bottleneck in training image translation models. By keeping the initial cropping and normalization on the CPU workers, while executing the more heavy transforms (especially the resampling ones) on the GPU, training can be significantly faster.

## Current state of this PR

For 2D FCMAE, reaching the same validation loss is ~7x the speed compared to v0.2. Compare these logs:

```
/hpc/projects/comp.micro/virtual_staining/models/hek-a549-bj5a-20x/lightning_logs/tiny-2x2-fcmae-amp-hek-a549-bj5a-400ep
/hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/test-logs/hek-a549-bj5a-gpu-aug-val-every-10
```

And for 3D FCMAE, the total voxel throughput is ~3x of v0.2, potentially limited by CPU-GPU transfer.

~Caveat: since the transforms are now defined in the lightning module instead of the data module, they are the same for all the dataset.~ (fixed)