### PR TITLE
Rank nearest neighbors in embedding space

### DIFF
--- a/applications/contrastive_phenotyping/evaluation/time_decay_knn.py
+++ b/applications/contrastive_phenotyping/evaluation/time_decay_knn.py
@@ -1,0 +1,95 @@
+# %%
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from viscy.representation.embedding_writer import read_embedding_dataset
+from viscy.representation.evaluation.clustering import (
+    compare_time_offset,
+    cross_dissimilarity,
+    rank_nearest_neighbors,
+    select_block,
+)
+
+# %%
+prediction_path = Path(
+    "/hpc/projects/organelle_phenotyping/ALFI_benchmarking/predictions_final/ALFI_opp_7mins.zarr"
+)
+
+embeddings = read_embedding_dataset(prediction_path)
+features = embeddings["features"]
+
+# %%
+cross_dist = cross_dissimilarity(features.values, metric="cosine")
+rank_fractions = rank_nearest_neighbors(cross_dist, normalize=True)
+
+# %%
+# select a single track in a single fov
+fov = "/0/0/0"
+fov_idx = (features["fov_name"] == fov).values
+
+track_id = 1
+track_idx = (features["track_id"] == track_id).values
+
+fov_and_track_idx = fov_idx & track_idx
+
+single_track_dissimilarity = select_block(cross_dist, fov_and_track_idx)
+single_track_rank_fraction = select_block(rank_fractions, fov_and_track_idx)
+
+piece_wise_dissimilarity = compare_time_offset(
+    single_track_dissimilarity, time_offset=1
+)
+piece_wise_rank_difference = compare_time_offset(
+    single_track_rank_fraction, time_offset=1
+)
+
+# %%
+f = plt.figure(figsize=(8, 12))
+f.suptitle(f"Track {track_id} in FOV {fov}")
+subfigs = f.subfigures(2, 1, height_ratios=[1, 2])
+
+umap = subfigs[0].subplots(1, 1)
+single_cell_features = features.sel(fov_name=fov, track_id=track_id).sortby("t")
+sns.lineplot(
+    x=single_cell_features["UMAP1"],
+    y=single_cell_features["UMAP2"],
+    ax=umap,
+    color="k",
+    alpha=0.5,
+)
+sns.scatterplot(
+    x=features["UMAP1"], y=features["UMAP2"], ax=umap, color="k", s=100, alpha=0.01
+)
+sns.scatterplot(
+    x=single_cell_features["UMAP1"],
+    y=single_cell_features["UMAP2"],
+    hue=single_cell_features["t"],
+    ax=umap,
+    palette="RdYlGn",
+)
+
+f1 = subfigs[1]
+ax = f1.subplots(2, 2)
+
+sns.heatmap(single_track_dissimilarity, ax=ax[0, 0], square=True)
+ax[0, 0].set_title("Cosine dissimilarity")
+ax[0, 0].set_xlabel("Frame")
+ax[0, 0].set_ylabel("Frame")
+
+sns.heatmap(single_track_rank_fraction, ax=ax[0, 1], square=True)
+ax[0, 1].set_title("Column-wise normalized neighborhood distance")
+ax[0, 1].set_xlabel("Frame")
+ax[0, 1].set_ylabel("Frame")
+
+sns.lineplot(piece_wise_dissimilarity, ax=ax[1, 0])
+ax[1, 0].set_title("$1 - \cos{(t_i, t_{i+1})}$")
+ax[1, 0].set_xlabel("Frame")
+ax[1, 0].set_ylabel("Cosine dissimilarity")
+
+sns.lineplot(piece_wise_rank_difference, ax=ax[1, 1])
+ax[1, 1].set_title("Nearest neighbor fraction difference")
+ax[1, 1].set_xlabel("Frame")
+ax[1, 1].set_ylabel("Rank fraction")
+
+# %%

--- a/applications/contrastive_phenotyping/evaluation/time_decay_knn.py
+++ b/applications/contrastive_phenotyping/evaluation/time_decay_knn.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+from sklearn.preprocessing import StandardScaler
 
 from viscy.representation.embedding_writer import read_embedding_dataset
 from viscy.representation.evaluation.clustering import (
@@ -21,7 +22,10 @@ embeddings = read_embedding_dataset(prediction_path)
 features = embeddings["features"]
 
 # %%
-cross_dist = cross_dissimilarity(features.values, metric="cosine")
+scaled_features = StandardScaler().fit_transform(features.values)
+
+# %%
+cross_dist = cross_dissimilarity(scaled_features, metric="cosine")
 rank_fractions = rank_nearest_neighbors(cross_dist, normalize=True)
 
 # %%


### PR DESCRIPTION
An ideal cell state representation has the following properties:

- When the cell state does not change, the neighboring time points of the same cell should have more similar embeddings compared to other cells (continuity)
- When the cell state does change, the embeddings change a lot so that different cell states can be expressed (dynamic range)

We observed these properties for time-regularized models visually in UMAPs. However, Euclidean distances in UMAP space carry no global meaning, so the observations cannot be directly quantified by comparing UMAP values. This PR provides methods to describe the embedding similarities close to how UMAP is computed: each sample is ranked as the $k$-th nearest neighbor for each sample, and the displacement in this neighborhood ($k$ at $t_{i+1}$ for each $t_i$) can then be used to describe the fluctuation of embeddings in a way that preserves latent space topology.

Example from ALFI dataset:

![image](https://github.com/user-attachments/assets/a3c4ac6b-4788-4842-bade-820e17f52f66)
