### PR TITLE
Fix the wrong import name for pairwise_distance_matrix()

### DIFF
--- a/applications/contrastive_phenotyping/evaluation/cosine_dissimilarity_dataset.py
+++ b/applications/contrastive_phenotyping/evaluation/cosine_dissimilarity_dataset.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from viscy.representation.embedding_writer import read_embedding_dataset
 from viscy.representation.evaluation.clustering import (
     compare_time_offset,
-    cross_dissimilarity,
+    pairwise_distance_matrix,
     rank_nearest_neighbors,
     select_block,
 )
@@ -121,7 +121,7 @@ def analyze_embedding_smoothness(
 
     scaled_features = StandardScaler().fit_transform(features.values)
     # Compute the cosine dissimilarity
-    cross_dist = cross_dissimilarity(scaled_features, metric="cosine")
+    cross_dist = pairwise_distance_matrix(scaled_features, metric="cosine")
     rank_fractions = rank_nearest_neighbors(cross_dist, normalize=True)
 
     # Compute piece-wise dissimilarity and rank difference


### PR DESCRIPTION
@Soorya19Pradeep could you review this and merge if it runs for you? I ran it myself without problems.
```
Adjacent Frame Dissimilarity Statistics:
Mean:           0.149
Std:            0.183
Median:         0.070
Peak:           0.035
P1:             0.054
P99:            0.425

Random Sampling Statistics:
Mean:           0.992
Std:            0.400
Median:         1.056
Peak:           1.385

Comparison Metrics:
Dynamic Range:  1.350

Distribution Sizes:
Adjacent Frame: 11,644 samples
Random:         11,644 samples
```
![image](https://github.com/user-attachments/assets/de23b5a8-5bc2-43dc-8fb0-89844917cc76)
