### PR TITLE
Script to use ConvNeXt v1 Tiny as a feature extractor

### DIFF
--- a/applications/contrastive_phenotyping/evaluation/imagenet_pretrained_features.py
+++ b/applications/contrastive_phenotyping/evaluation/imagenet_pretrained_features.py
@@ -8,6 +8,7 @@ import torch
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
+from pathlib import Path
 
 from viscy.data.triplet import TripletDataModule
 from viscy.transforms import ScaleIntensityRangePercentilesd
@@ -17,8 +18,8 @@ model = timm.create_model("convnext_tiny", pretrained=True).eval().to("cuda")
 
 # %%
 dm = TripletDataModule(
-    data_path="/hpc/reference/imaging/ALFI_dataset/Analysis/float_phase_ome_zarr_output_test.zarr",
-    tracks_path="/hpc/reference/imaging/ALFI_dataset/Analysis/track_phase_ome_zarr_output_test.zarr",
+    data_path="/hpc/projects/organelle_phenotyping/ALFI_models_data/datasets/zarr_datasets/float_phase_ome_zarr_output_test.zarr",
+    tracks_path="/hpc/projects/organelle_phenotyping/ALFI_models_data/datasets/zarr_datasets/track_phase_ome_zarr_output_test.zarr",
     source_channel=["DIC"],
     z_range=(0, 1),
     batch_size=128,
@@ -54,11 +55,35 @@ scaled_features = StandardScaler().fit_transform(pooled)
 pca = PCA(n_components=2)
 pca_features = pca.fit_transform(scaled_features)
 
+# %% add pooled to dataframe naming each column with feature_i
+for i, feature in enumerate(pooled.T):
+    tracks[f"feature_{i}"] = feature
+# add pca features to dataframe naming each column with pca_i
+for i, feature in enumerate(pca_features.T):
+    tracks[f"pca_{i}"] = feature
+
+# # save the dataframe as csv
+# tracks.to_csv("/hpc/projects/comp.micro/infected_cell_imaging/Single_cell_phenotyping/ContrastiveLearning/code/ALFI/imagenet_pretrained_features.csv", index=False)
+
+# %% load the dataframe
+# tracks = pd.read_csv("/hpc/projects/comp.micro/infected_cell_imaging/Single_cell_phenotyping/ContrastiveLearning/code/ALFI/imagenet_pretrained_features.csv")
+
+# %% load annotations
+
+ann_root = Path(
+    "/hpc/projects/organelle_phenotyping/ALFI_models_data/datasets/zarr_datasets"
+)
+ann_path = ann_root / "test_annotations.csv"
+annotation = pd.read_csv(ann_path)
+
+# add division column from annotation to tracks
+tracks["division"] = annotation["division"]
+
 # %%
-ax = sns.kdeplot(
-    x=pca_features[:, 0],
-    y=pca_features[:, 1],
-    hue=tracks["fov_name"].rename("FOV name"),
+ax = sns.scatterplot(
+    x=tracks["pca_0"],
+    y=tracks["pca_1"],
+    hue=tracks["division"],
     legend="full",
 )
 ax.set_xlabel("PCA1")

--- a/applications/contrastive_phenotyping/evaluation/imagenet_pretrained_features.py
+++ b/applications/contrastive_phenotyping/evaluation/imagenet_pretrained_features.py
@@ -1,0 +1,67 @@
+"""Use pre-trained ImageNet models to extract features from images."""
+
+# %%
+import pandas as pd
+import seaborn as sns
+import timm
+import torch
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+
+from viscy.data.triplet import TripletDataModule
+from viscy.transforms import ScaleIntensityRangePercentilesd
+
+# %%
+model = timm.create_model("convnext_tiny", pretrained=True).eval().to("cuda")
+
+# %%
+dm = TripletDataModule(
+    data_path="/hpc/reference/imaging/ALFI_dataset/Analysis/float_phase_ome_zarr_output_test.zarr",
+    tracks_path="/hpc/reference/imaging/ALFI_dataset/Analysis/track_phase_ome_zarr_output_test.zarr",
+    source_channel=["DIC"],
+    z_range=(0, 1),
+    batch_size=128,
+    num_workers=8,
+    initial_yx_patch_size=(128, 128),
+    final_yx_patch_size=(128, 128),
+    normalizations=[
+        ScaleIntensityRangePercentilesd(
+            keys=["DIC"], lower=50, upper=99, b_min=0.0, b_max=1.0
+        )
+    ],
+)
+dm.prepare_data()
+dm.setup("predict")
+
+# %%
+features = []
+indices = []
+
+with torch.inference_mode():
+    for batch in tqdm(dm.predict_dataloader()):
+        image = batch["anchor"][:, :, 0]
+        rgb_image = image.repeat(1, 3, 1, 1).to("cuda")
+        features.append(model.forward_features(rgb_image))
+        indices.append(batch["index"])
+
+# %%
+pooled = torch.cat(features).mean(dim=(2, 3)).cpu().numpy()
+tracks = pd.concat([pd.DataFrame(idx) for idx in indices])
+
+# %%
+scaled_features = StandardScaler().fit_transform(pooled)
+pca = PCA(n_components=2)
+pca_features = pca.fit_transform(scaled_features)
+
+# %%
+ax = sns.kdeplot(
+    x=pca_features[:, 0],
+    y=pca_features[:, 1],
+    hue=tracks["fov_name"].rename("FOV name"),
+    legend="full",
+)
+ax.set_xlabel("PCA1")
+ax.set_ylabel("PCA2")
+
+# %%

--- a/viscy/representation/evaluation/__init__.py
+++ b/viscy/representation/evaluation/__init__.py
@@ -1,7 +1,7 @@
 """
-This module enables evaluation of learned representations using annotations, such as 
-* cell division labels, 
-* infection state labels, 
+This module enables evaluation of learned representations using annotations, such as
+* cell division labels,
+* infection state labels,
 * labels predicted using supervised classifiers,
 * computed image features.
 
@@ -11,7 +11,7 @@ Following evaluation methods are implemented:
 * Correlation between embeddings and computed features using rank correlation.
 
 TODO: consider time- and condition-dependent clustering and UMAP visualization of patches developed earlier:
-https://github.com/mehta-lab/dynacontrast/blob/master/analysis/gmm.py 
+https://github.com/mehta-lab/dynacontrast/blob/master/analysis/gmm.py
 """
 
 import pandas as pd


### PR DESCRIPTION
Use ImageNet-pretrained encoder from timm as feature extractor.

For example, the PCA of the features (ALFI test split) shows separation between FOVs:

![image](https://github.com/user-attachments/assets/90f8096c-9678-47e9-b2ef-e0b34416757b)
