### PR TITLE
Catch hyperparameter incompatibility in checkpoints

### DIFF
--- a/viscy/cli.py
+++ b/viscy/cli.py
@@ -36,6 +36,13 @@ class VisCyCLI(LightningCLI):
             }
         )
 
+    def _parse_ckpt_path(self) -> None:
+        try:
+            return super()._parse_ckpt_path()
+        except SystemExit:
+            # FIXME: https://github.com/Lightning-AI/pytorch-lightning/issues/21255
+            return None
+
 
 def _setup_environment() -> None:
     """Set log level and TF32 precision."""


### PR DESCRIPTION
A stop gap for #291 as suggested in https://github.com/Lightning-AI/pytorch-lightning/issues/21255#issuecomment-3350031132 (option 1).