### PR TITLE
Add precommit to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 optional-dependencies.dev = [
   "hypothesis",
   "onnxruntime",
+  "pre-commit",
   "pytest",
   "pytest-cov",
   "ruff",


### PR DESCRIPTION
Currently `pre-commit` is not included in the development dependencies group, so the workflow described in [CONTRIBUTING.md](https://github.com/mehta-lab/VisCy/blob/main/CONTRIBUTING.md) does not work