### PR TITLE
perf(viscy-utils): bf16-precision SSIM helper for Hopper FCMAE training

### DIFF
--- a/applications/dynacell/configs/examples/fcmae_hopper_slowdown.md
+++ b/applications/dynacell/configs/examples/fcmae_hopper_slowdown.md
@@ -1,0 +1,336 @@
+# FCMAE VSCyto3D training on Hopper — ~10× slowdown vs pre-Hopper GPUs
+
+## Summary
+
+Pretrained FCMAE VSCyto3D finetunes for iPSC SEC61B (job 31297032) and TOMM20
+(job 31375338) train at roughly ~75 s/step on H200, vs ~5 s/step on L40S under
+the same config + pretrained checkpoint. The slowdown is consistent across
+Hopper GPUs (H100 and H200) and is **not** fixed by switching precision
+(fp16-mixed → bf16-mixed).
+
+## Verdict (2026-04-25) — MS-DSSIM is the dominant slow term
+
+Direct per-step measurements from a Lightning-config probe that drops
+the MS-DSSIM term from the loss (T2: `MixedLoss(l1_alpha=1.0,
+ms_dssim_alpha=0.0)`), 4 GPUs on H100 (gpu-f-6), `SEC61B_test48.zarr`,
+otherwise identical to the prod config:
+
+| Step | data_wait_ms | compute_ms |
+| ---: | ---:         | ---:       |
+| 0    | 8198         | 16397 *(init / cuDNN autotune)* |
+| 1    | 583.7        | 929.3      |
+| 2    | 594.7        | 903.7      |
+| 3    | 700.0        | 891.2      |
+| 4    | 609.2        | 2958.2     |
+| 5    | 583.3        | 1416.1     |
+| 6    | 560.0        | 935.7      |
+| 7    | 555.2        | 1257.7     |
+| 8    | 555.8        | 1241.8     |
+| 9    | 548.1        | 1870.6     |
+
+Steady-state floor on rank 0 is ~0.9 s/step compute. The same prod config
+**with** MS-DSSIM measured **45.5 s/step compute** on identical N=4 H100
+hardware (Probe C job 31451180 and T5 job 31451960, 8 and 4 consecutive
+steady-state STEP_TIMER lines respectively) — a **~50× delta** attributable
+to the MS-DSSIM term.
+
+A symmetric MS-DSSIM-only probe (T4) was queued but cancelled when its
+StartTime slipped 8 hours; the deduction is closed by subtraction:
+L1-only is fast, L1+MS-DSSIM is slow, therefore MS-DSSIM is the slow
+term.
+
+### Fix landed (2026-04-25) — bf16 SSIM helper, 11× speedup confirmed
+
+The fix replaces monai's `compute_ssim_and_cs` with a precision-aware
+helper `_compute_ssim_and_cs_bf16` (commit `e42c49a`) and drops the
+now-redundant `@torch.amp.custom_fwd(cast_inputs=fp32)` decorator from
+`MixedLoss` and `SpotlightLoss` (commit `3a7fa05`). The helper runs the
+5 Gaussian-mean convolutions in bf16 (with squared products computed in
+fp32 before casting, to preserve squaring precision) and promotes only
+the variance subtractions and C₁/C₂-guarded divisions to fp32.
+
+T6 sanity probe (job 31453564, gpu-f-2 H100, N=4, MS-DSSIM enabled,
+`SEC61B_test48.zarr`, otherwise identical to T5/Probe C):
+
+| Step | data_wait_ms | compute_ms |
+| ---: | ---:         | ---:       |
+| 0    | 11894.6      | 15674.9 *(init / cuDNN autotune)* |
+| 1    | 542.1        | 4139.3     |
+| 2    | 535.8        | 4140.2     |
+| 3    | 538.7        | 4143.2     |
+| 4    | 548.5        | 4155.6     |
+| 5    | 542.4        | 4164.7     |
+| 6    | 541.1        | 4166.4     |
+
+Steady-state mean compute_ms: **4151 ms** over 6 consecutive lines
+(std ~10 ms). Versus the **45.5 s/step** baseline on identical N=4 H100
+hardware with fp32 MS-DSSIM (Probe C `31451180`, T5 `31451960`):
+**~10.97× speedup**.
+
+The remaining ~4 s/step is the actual MS-DSSIM compute cost on Hopper
+in the bf16 regime — an order of magnitude faster than fp32, but still
+meaningfully more than the 0.9 s/step L1-only floor (T2). Further
+mitigation (reducing pyramid depth, MS-DSSIM frequency) would attack
+that residual; not pursued here since 4 s/step is workable for FCMAE
+finetune training.
+
+Validated by tests in `packages/viscy-utils/tests/test_metrics.py`,
+`test_mixed_loss.py`, and the extended `test_spotlight_loss.py`. The
+contract holds at: per-pixel rtol=5e-2/atol=1e-1 (random), aggregate
+rtol=1e-2/atol=1e-2 (random), aggregate rtol=2e-3/atol=5e-3
+(correlated-pair), gradient cosine similarity ≥0.99, sign-flip
+fraction <1% on `|grad_ref|>1e-3` voxels.
+
+The earlier "Hopper kernel / DDP bucket-view stride mismatch" hypothesis
+(see [Earlier diagnosis](#earlier-diagnosis-superseded) below) is wrong as
+a cause — the stride warnings are real but not load-bearing for the
+slowdown. A plain Lightning + synthetic-data + DDP probe on N=4 H100
+(no MS-DSSIM, no real data pipeline) ran at 185.6 ms/step steady-state,
+ruling out Lightning, DDP, cuDNN, and the data pipeline as the
+bottleneck.
+
+### Why MS-DSSIM is slow on Hopper
+
+The MS-DSSIM 5-level pyramid runs in fp32 — at every level,
+`compute_ssim_and_cs` (monai) executes 5 large-kernel convolutions
+(μₓ, μᵧ, μₓₓ, μᵧᵧ, μₓᵧ) with a `(D=15, 11, 11)` kernel; the multiscale
+wrapper then `avg_pool3d`-downsamples and repeats 5 times. The
+conv-heavy core therefore runs in fp32 regardless of any outer
+mixed-precision context.
+
+What the **measurement** establishes: with that path skipped (T2),
+compute drops from 45.5 s/step → ~0.9 s/step on identical N=4 H100
+hardware. So fp32 MS-DSSIM is dominating on Hopper.
+
+What is **inferred but not directly measured**: that the gap is
+specifically explained by Hopper's bf16/fp16-vs-fp32 tensor-core
+advantage being larger than Ampere's / Ada's. Plausible from
+published kernel ratios, but we have not benchmarked the same monai
+SSIM kernels across architectures. The cross-architecture explanation
+should be treated as the leading theory, not an established fact.
+
+### Where the fp32 cast comes from (two stacked sources)
+
+1. **monai's `compute_ssim_and_cs`** (`monai/metrics/regression.py:402-403`)
+   force-casts both inputs to fp32 unconditionally:
+
+   ```python
+   y_pred = convert_data_type(y_pred, output_type=torch.Tensor, dtype=torch.float)[0]
+   y     = convert_data_type(y,      output_type=torch.Tensor, dtype=torch.float)[0]
+   ```
+
+   This is what makes MS-DSSIM slow on Hopper. The 25 conv ops (5 stats ×
+   5 pyramid levels) all run with fp32 weights and fp32 inputs.
+
+2. **viscy's `MixedLoss.forward`** (`packages/viscy-utils/.../mixed_loss.py:43`)
+   adds an outer `@torch.amp.custom_fwd(cast_inputs=torch.float32)`.
+   Introduced in commit `b4ec13c` (PR
+   [#37](https://github.com/mehta-lab/VisCy/pull/37), 2023-08-30), which
+   focused on the pixelshuffle decoder — the cast came in alongside
+   without a justifying note in the PR review. The mechanic of
+   `custom_fwd(cast_inputs=...)` is "cast the inputs and run the
+   forward with autocast disabled," so the decorator really does
+   create an fp32 island when active. The pattern is the well-known
+   "force MS-SSIM to fp32 to avoid NaN under autocast" workaround
+   (cf. torchmetrics issue
+   [#2281](https://github.com/Lightning-AI/torchmetrics/issues/2281):
+   `σ² = E[X²] − μ²` subtraction produces tiny negative values from
+   float deviations, the C₁/C₂ stability constants don't cover them,
+   resulting in NaN; later fixed upstream). This is corroborated by
+   the `clamp=True` flag in our `ms_ssim_25d`, documented as "for
+   training stability when used in loss" — author was already fighting
+   numerical instability.
+
+   Today this outer cast is **largely redundant**: the conv-heavy core
+   inside monai is already pinned to fp32, so removing the `@custom_fwd`
+   decorator only affects `F.l1_loss`, `F.mse_loss`, and the outer
+   `F.avg_pool3d` downsamplings — none of which are the slow path.
+   Removing it alone does **not** unblock Hopper.
+
+### Mitigation options (revised)
+
+The bottleneck is monai's internal fp32 cast on the SSIM convs, not
+viscy's outer decorator. Practical fallback order:
+
+1. **Local-patch monai's `compute_ssim_and_cs` with a mixed-precision
+   variant** — keep variance-sensitive math in fp32, run convs/pooling
+   in bf16:
+   - convs (μₓ, μᵧ, μₓₓ, μᵧᵧ, μₓᵧ) and `avg_pool3d` between levels:
+     **bf16** (kernels and inputs both)
+   - `mu_xx − mu_x*mu_x`, `mu_yy − mu_y*mu_y`, `mu_xy − mu_x*mu_y`:
+     **fp32**
+   - C₁/C₂-guarded divisions for `contrast_sensitivity` and `ssim`:
+     **fp32**
+
+   bf16 keeps fp32's 8-bit exponent (vs fp16's 5-bit), so it is the
+   right candidate for SSIM's near-equal subtraction; fp16 should be
+   avoided. Validate numerical equivalence against the current fp32
+   path on a representative batch before training.
+
+2. **Reduce MS-DSSIM frequency** — e.g. apply the MS-DSSIM term every
+   N steps and L1-only on the others. No precision changes; degrades
+   loss signal but doesn't risk numerical regression.
+
+3. **Drop MS-DSSIM entirely** on Hopper finetune runs. Largest
+   behavior change; should be backed by parity training runs against
+   the L1+MS-DSSIM baseline.
+
+### Fastest confirmation experiment
+
+Patch `compute_ssim_and_cs` so that:
+
+- it does **not** immediately cast `y_pred` and `y` to fp32,
+- the convs run under autocast (bf16 on Hopper),
+- only the variance subtraction and C₁/C₂-guarded divisions are
+  explicitly promoted to fp32.
+
+Re-run the T2-style sanity probe with MS-DSSIM **enabled** and this
+patched path. If step time collapses from ~45 s toward the L1-only
+~0.9 s regime, that load-bearing identification is confirmed.
+
+> **Note:** dropping only the `@torch.amp.custom_fwd` decorator from
+> `MixedLoss.forward` (without touching monai's internal cast) will
+> **not** restore Hopper throughput — the 25 fp32 convs in the pyramid
+> remain. This was an earlier mitigation suggestion that I retracted
+> after reading monai's source.
+
+## Throughput measurements
+
+All rows below use the same `fcmae.ckpt`-warm-started FCMAE VSCyto3D model,
+`ddp_find_unused_parameters_true`, 4 GPUs, `z=15, yx=256`, `num_samples=4`,
+`mmap_preload=true`, `scratch_dir=/dev/shm`.
+
+### Pretrained finetune sanity probes across architectures
+
+All probes use `SEC61B_test48.zarr` (48 FOVs), pretrained FCMAE VSCyto3D
+warm-start, 4 GPUs, fp16-mixed unless noted, 3 epochs.
+
+| GPU      | Arch         | Compute cap | Precision  | Node     | RAM    | /dev/shm | s/step | Source |
+| ---      | ---          | ---         | ---        | ---      | ---:   | ---:     | ---:   | --- |
+| A40      | Ampere       | sm_86       | fp16-mixed | gpu-c-1  | 2.0 TB | 1002 GB  | **2.80** | sanity 31406782 (86 steps / 241 s) |
+| A6000    | Ampere       | sm_86       | fp16-mixed | gpu-b-3  | 0.5 TB | 252 GB   | **3.56** | sanity 31406785 (86 steps / 307 s) |
+| L40S     | Ada Lovelace | sm_89       | fp16-mixed | gpu-g-2  | 1.16 TB| —        | **5.1**  | earlier sanity (80 steps / 355 s) |
+| A100-40  | Ampere       | sm_80       | fp16-mixed | gpu-a-3  | 2.04 TB| —        | —      | sanity 31406783 NCCL BROADCAST timeout in DDP setup |
+| A100-80  | Ampere       | sm_80       | fp16-mixed | gpu-d-2  | 2.0 TB | —        | —      | sanity 31406784 NCCL BROADCAST timeout in DDP setup |
+| H100     | Hopper       | sm_90       | fp16-mixed | gpu-f-3  | 2.0 TB | —        | **47.6** | sanity 31400433 (20 steps / 951 s) |
+| H200     | Hopper       | sm_90       | bf16-mixed | gpu-h-3  | 2.06 TB| —        | **65.8** | sanity 31400431 (10 steps / 658 s) |
+| H200     | Hopper       | sm_90       | fp16-mixed | gpu-h-5  | 2.06 TB| —        | **~75**  | prod 31297032 (SEC61B, OOM after 60 h) |
+
+**The architecture split is sharp:** every pre-Hopper GPU runs at 2.8–5.1
+s/step. Every Hopper run we have measured (H100 fp16, H200 fp16, H200 bf16,
+scratch H100 fp16, scratch H100 bf16) lands in 46–75 s/step — a **13–27×
+slowdown** across the Hopper boundary regardless of precision, warm-start,
+or which Hopper SKU.
+
+The two A100 attempts both NCCL-timed out during a 32 M-element BROADCAST
+in DDP setup before any training step. That number matches the FCMAE
+encoder param count (32.1 M), so the symptom is consistent with rank 0
+being slow to load `fcmae.ckpt` (or otherwise blocked on rank-0-only I/O)
+while ranks 1–3 sat at the collective and the 30-min watchdog fired. This
+is an I/O coordination problem on those A100 nodes' shared-storage path,
+not a hardware fault — and not informative for the Hopper-vs-Ampere
+question. (Separate follow-up: rerun A100 sanity with rank 0 staging
+`fcmae.ckpt` before the DDP barrier, or measure raw read bandwidth from
+gpu-a-3 / gpu-d-2 to `/hpc/projects/virtual_staining`.)
+
+### Scratch-vs-pretrained × fp16-vs-bf16 controlled matrix (H100)
+
+To rule out the warm-start `ckpt_path` + `encoder_only: true` path and
+precision as the cause, we ran the same sanity harness with random init
+(no `ckpt_path`, no `encoder_only`) across both precisions on identical
+H100 hardware.
+
+| Init       | Precision   | GPU  | s/step | Source |
+| ---        | ---         | ---  | ---:   | --- |
+| Scratch    | fp16-mixed  | H100 | 46.57  | sanity job 31402627 (step 9→19 / 466 s) |
+| Scratch    | bf16-mixed  | H100 | 46.33  | sanity job 31402692 (step 9→19 / 463 s) |
+| Pretrained | fp16-mixed  | H100 | 47.60  | sanity job 31400433 (step 9→29 / 951 s) |
+| Pretrained | bf16-mixed  | H200 | 65.80  | sanity job 31400431 (step 9→19 / 658 s) |
+
+All four Hopper runs cluster in 46–66 s/step vs L40S 5.1 s/step. The
+slowdown is invariant to:
+
+1. Precision (fp16 ↔ bf16: 46.57 vs 46.33 on scratch — no difference).
+2. Warm-start (scratch ↔ pretrained on fp16: 46.57 vs 47.60 — no
+   difference).
+3. Hopper generation (H100 vs H200: both in the same band).
+
+**No config knob fixes this.** The slowdown is intrinsic to the FCMAE
+ConvNeXt graph hitting a slow Hopper kernel path.
+
+### Scratch FCMAE (prod runs, same architecture)
+
+| Dataset | GPU | Arch | Node | s/step | Notes |
+| --- | --- | --- | --- | ---: | --- |
+| SEC61B  | A40  | Ampere       | gpu-c-1 | 2.99 | 30 089 steps / 89 965 s (run 20260421-112347) |
+| TOMM20  | L40S | Ada Lovelace | gpu-g-2 | 4.91 | 15 599 steps / 76 641 s (run 20260422-060655) |
+| TOMM20  | H200 | Hopper       | gpu-h-2 | —    | failed after 4 s (missing ckpt path) |
+| SEC61B  | H200 | Hopper       | gpu-h-1 | —    | failed after 112 s (find_unused_parameters) |
+| SEC61B  | H200 | Hopper       | gpu-h-2 | —    | failed after ~46 min (missing resume ckpt) |
+
+**No FCMAE run (scratch or pretrained) has successfully reached steady-state
+training throughput on Hopper.** The "scratch ran fine" runs were all on
+pre-Hopper hardware (A40, L40S, A100 attempts).
+
+<a id="earlier-diagnosis-superseded"></a>
+## Earlier diagnosis (superseded by 2026-04-25 verdict above)
+
+The notes below were the working hypothesis before the L1-only probe
+showed compute time collapses 50× when MS-DSSIM is removed. They are
+left for the record — the cuDNN/DDP-stride warnings are real, but they
+are not the cause of the slowdown.
+
+- `py-spy dump` on live H200 rank 0 (prod SEC61B, job 31297032) pinned the
+  MainThread inside `_engine_run_backward` (`torch/autograd/graph.py:865`)
+  across 3 consecutive snapshots. DataLoader workers (`pt_data_worker`),
+  pin-memory loop, and wandb threads were all idle. → **bottleneck is
+  GPU-side backward(), not data loading.** (Consistent with verdict —
+  MS-DSSIM has a heavy backward.)
+- Hopper stderr consistently emits DDP warnings that don't appear on L40S:
+  - `AccumulateGrad node's stream does not match the stream of the node that
+    produced the incoming gradient` (pointing at DDP + stream ordering).
+  - `Grad strides do not match bucket view strides ... grad.sizes() = [240, 960, 1, 1],
+    strides() = [960, 1, 960, 960] vs bucket_view ... [960, 1, 1, 1]`
+    (pointing at a specific layer whose weight grad memory format breaks DDP's
+    bucket view contract on Hopper).
+- Switching `precision: bf16-mixed` on H200 changed throughput from ~75 → 65.8
+  s/step — basically the same order of magnitude. **Precision is not the
+  cause.**
+
+Earlier working hypothesis (now wrong): a specific kernel/layer (likely a
+pointwise 1×1 conv in the FCMAE ConvNeXt encoder given the `[240, 960, 1, 1]`
+weight shape) hits a slow Hopper path, and DDP can't fuse its grads cleanly
+due to the stride mismatch. **The L1-only probe falsified this** — with
+MS-DSSIM removed, that same encoder graph runs at ~0.9 s/step on H100,
+so the encoder is not the slow path.
+
+## OOM after ~20 h (separate, unresolved issue)
+
+These same 4-GPU jobs have also hit host-RAM OOM after **~20 hours of
+successful training**, even on datasets with ample nominal headroom (ER
+SEC61B is 80 GB compressed / 199 GB uncompressed on a 512 GB allocation).
+Because the kill happens deep into training and not at peak, this is a **slow
+host-RAM leak**, not a peak-sizing problem. Bumping `--mem=640G` just buys
+runway — it does not address the leak.
+
+Likely suspects (not yet instrumented):
+- Persistent DataLoader workers drifting via torch multiprocessing ref-count
+  leaks on forked COW pages.
+- `mmap_preload` + `/dev/shm` state not reclaimed across epochs.
+- A zarr chunk / pin-memory cache growing unbounded.
+
+Open TODO: log per-rank RSS at each epoch boundary in a production run and
+correlate with memory pressure signals to pin the actual source.
+
+## Recommendation
+
+1. **Done (commits `e42c49a` + `3a7fa05`):** local bf16 SSIM helper +
+   redundant decorator removal landed. Hopper FCMAE compute is now
+   ~4.15 s/step (T6 measurement) vs ~45.5 s/step before — within an
+   order of magnitude of L40S throughput.
+2. Future training runs (fresh starts, intentional checkpoint
+   migrations) can now target Hopper directly. Active prod runs on
+   A40/L40S (jobs 31415937, 31446584) should not be precision-flipped
+   mid-resume.
+3. Separately, add RSS instrumentation and investigate the 20 h host-RAM
+   leak; do not treat the `--mem=640G` bump as a fix.

--- a/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
@@ -1,12 +1,12 @@
 """Metrics for model evaluation"""
 
+from math import prod
 from typing import Sequence, Union
 from warnings import warn
 
 import numpy as np
 import torch
 import torch.nn.functional as F
-from monai.metrics.regression import compute_ssim_and_cs
 from scipy.optimize import linear_sum_assignment
 from skimage.measure import label, regionprops
 from torchmetrics.detection.mean_ap import MeanAveragePrecision
@@ -42,10 +42,7 @@ def VOI_metric(target, prediction):
     im_intersection = np.logical_and(im_pred_mask, im_targ_mask)
     im_inters_informed = im_intersection * im_targ_mask * im_pred_mask
 
-    marg_intr = (
-        np.histogramdd(np.ravel(im_inters_informed), bins=256)[0]
-        / im_inters_informed.size
-    )
+    marg_intr = np.histogramdd(np.ravel(im_inters_informed), bins=256)[0] / im_inters_informed.size
     marg_intr = list(filter(lambda p: p > 0, np.ravel(marg_intr)))
     entropy_intr = -np.sum(np.multiply(marg_intr, np.log2(marg_intr)))
 
@@ -128,9 +125,7 @@ def labels_to_masks(labels: torch.ShortTensor) -> torch.BoolTensor:
         raise ValueError(f"Labels must be 2D, got shape {labels.shape}.")
     segments = torch.unique(labels)
     n_instances = segments.numel() - 1
-    masks = torch.zeros(
-        (n_instances, *labels.shape), dtype=torch.bool, device=labels.device
-    )
+    masks = torch.zeros((n_instances, *labels.shape), dtype=torch.bool, device=labels.device)
     # TODO: optimize this?
     for s, segment in enumerate(segments):
         # start from label value 1, i.e. skip background label
@@ -150,13 +145,9 @@ def labels_to_detection(labels: torch.ShortTensor) -> dict[str, torch.Tensor]:
     return {
         "boxes": boxes,
         # dummy confidence scores
-        "scores": torch.ones(
-            (boxes.shape[0],), dtype=torch.float32, device=boxes.device
-        ),
+        "scores": torch.ones((boxes.shape[0],), dtype=torch.float32, device=boxes.device),
         # dummy class labels
-        "labels": torch.zeros(
-            (boxes.shape[0],), dtype=torch.uint8, device=boxes.device
-        ),
+        "labels": torch.zeros((boxes.shape[0],), dtype=torch.uint8, device=boxes.device),
         "masks": masks,
     }
 
@@ -172,16 +163,109 @@ def mean_average_precision(
         :py:class:`torchmetrics.detection.MeanAveragePrecision`
     :return dict[str, torch.Tensor]: COCO-style metrics
     """
-    defaults = dict(
-        iou_type="segm", box_format="xyxy", max_detection_thresholds=[1, 100, 10000]
-    )
+    defaults = dict(iou_type="segm", box_format="xyxy", max_detection_thresholds=[1, 100, 10000])
     if not kwargs:
         kwargs = {}
     map_metric = MeanAveragePrecision(**(defaults | kwargs))
-    map_metric.update(
-        [labels_to_detection(pred_labels)], [labels_to_detection(target_labels)]
-    )
+    map_metric.update([labels_to_detection(pred_labels)], [labels_to_detection(target_labels)])
     return map_metric.compute()
+
+
+def _compute_ssim_and_cs_bf16(
+    y_pred: torch.Tensor,
+    y: torch.Tensor,
+    spatial_dims: int,
+    kernel_size: Sequence[int],
+    data_range: Union[float, torch.Tensor] = 1.0,
+    k1: float = 0.01,
+    k2: float = 0.03,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute SSIM and contrast-sensitivity with bf16 convolutions.
+
+    Replaces monai's ``compute_ssim_and_cs`` (which unconditionally casts both
+    inputs to fp32 internally) with a precision-aware variant that runs the
+    five Gaussian-mean convolutions in bf16 and promotes only the variance
+    subtractions and C1/C2-guarded divisions to fp32. Squared products
+    (``y * y``, ``y_pred * y_pred``, ``y_pred * y``) are computed in fp32
+    before casting to bf16 for the conv input, which preserves precision on
+    the precision-sensitive squaring step at the cost of one extra cast per
+    squared term.
+
+    The conv accumulator is fp32 on CUDA tensor cores (sm >= 80) and on CPU,
+    so only the conv outputs (returned in bf16) lose precision relative to
+    monai's all-fp32 path.
+
+    Uniform kernel only — matches the single call site in :func:`ssim_25d`;
+    Gaussian-kernel and ``kernel_sigma`` parameters from monai's signature
+    are intentionally dropped.
+
+    Parameters
+    ----------
+    y_pred : torch.Tensor
+        Predicted batch with shape ``(B, C, *spatial)``.
+    y : torch.Tensor
+        Target batch with the same shape as ``y_pred``.
+    spatial_dims : int
+        Number of spatial dimensions (2 or 3); selects ``F.conv2d`` /
+        ``F.conv3d``.
+    kernel_size : Sequence[int]
+        Uniform window size, length equal to ``spatial_dims``.
+    data_range : float or torch.Tensor, optional
+        Data range of the inputs; used to compute the C1, C2 stability
+        constants. Defaults to ``1.0``.
+    k1 : float, optional
+        Luminance stability constant. Defaults to ``0.01``.
+    k2 : float, optional
+        Contrast stability constant. Defaults to ``0.03``.
+
+    Returns
+    -------
+    ssim : torch.Tensor
+        Per-pixel SSIM map in fp32, shape ``(B, C, *reduced_spatial)``.
+    cs : torch.Tensor
+        Per-pixel contrast-sensitivity map in fp32, same shape as ``ssim``.
+    """
+    if y.shape != y_pred.shape:
+        raise ValueError(f"y_pred and y must have same shape, got {y_pred.shape} and {y.shape}.")
+
+    num_channels = y_pred.size(1)
+
+    # Build uniform kernel in fp32 then cast to bf16 once.
+    kernel_fp32 = torch.ones((num_channels, 1, *kernel_size), device=y_pred.device, dtype=torch.float32) / float(
+        prod(kernel_size)
+    )
+    kernel_bf = kernel_fp32.to(torch.bfloat16)
+
+    # Compute squared products in fp32 to preserve squaring precision,
+    # then cast to bf16 for the conv input.
+    y_pred_fp32 = y_pred.float()
+    y_fp32 = y.float()
+    y_pred_bf = y_pred_fp32.to(torch.bfloat16)
+    y_bf = y_fp32.to(torch.bfloat16)
+    y_pred_sq_bf = (y_pred_fp32 * y_pred_fp32).to(torch.bfloat16)
+    y_sq_bf = (y_fp32 * y_fp32).to(torch.bfloat16)
+    y_pred_y_bf = (y_pred_fp32 * y_fp32).to(torch.bfloat16)
+
+    conv_fn = getattr(F, f"conv{spatial_dims}d")
+    mu_x = conv_fn(y_pred_bf, kernel_bf, groups=num_channels).float()
+    mu_y = conv_fn(y_bf, kernel_bf, groups=num_channels).float()
+    mu_xx = conv_fn(y_pred_sq_bf, kernel_bf, groups=num_channels).float()
+    mu_yy = conv_fn(y_sq_bf, kernel_bf, groups=num_channels).float()
+    mu_xy = conv_fn(y_pred_y_bf, kernel_bf, groups=num_channels).float()
+
+    # Stability constants in fp32 (data_range may be a 0-dim tensor; the
+    # multiplication promotes to fp32 since k1/k2 are Python floats).
+    c1 = (k1 * data_range) ** 2
+    c2 = (k2 * data_range) ** 2
+
+    sigma_x = mu_xx - mu_x * mu_x
+    sigma_y = mu_yy - mu_y * mu_y
+    sigma_xy = mu_xy - mu_x * mu_y
+
+    contrast_sensitivity = (2 * sigma_xy + c2) / (sigma_x + sigma_y + c2)
+    ssim_full = ((2 * mu_x * mu_y + c1) / (mu_x * mu_x + mu_y * mu_y + c1)) * contrast_sensitivity
+
+    return ssim_full, contrast_sensitivity
 
 
 def ssim_25d(
@@ -202,20 +286,16 @@ def ssim_25d(
     :return Optional[torch.Tensor]: contrast sensitivity
     """
     if preds.ndim != 5:
-        raise ValueError(
-            f"Input shape must be (B, C, D, W, H), got input shape {preds.shape}"
-        )
+        raise ValueError(f"Input shape must be (B, C, D, W, H), got input shape {preds.shape}")
     depth = preds.shape[2]
     if depth > 15:
         warn(f"Input depth {depth} is potentially too large for 2.5D SSIM.")
-    ssim_img, cs_img = compute_ssim_and_cs(
+    ssim_img, cs_img = _compute_ssim_and_cs_bf16(
         preds,
         target,
-        3,
-        kernel_sigma=None,
+        spatial_dims=3,
         kernel_size=(depth, *in_plane_window_size),
         data_range=target.max(),
-        kernel_type="uniform",
     )
     # aggregate to one scalar per batch
     ssim = ssim_img.view(ssim_img.shape[0], -1).mean(1)
@@ -253,9 +333,7 @@ def ms_ssim_25d(
     base_min = 1e-4
     mcs_list = []
     for _ in range(len(betas)):
-        ssim, contrast_sensitivity = ssim_25d(
-            preds, target, in_plane_window_size, return_contrast_sensitivity=True
-        )
+        ssim, contrast_sensitivity = ssim_25d(preds, target, in_plane_window_size, return_contrast_sensitivity=True)
         if clamp:
             contrast_sensitivity = contrast_sensitivity.clamp(min=base_min)
         mcs_list.append(contrast_sensitivity)

--- a/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
@@ -174,7 +174,6 @@ def mean_average_precision(
 def _compute_ssim_and_cs_bf16(
     y_pred: torch.Tensor,
     y: torch.Tensor,
-    spatial_dims: int,
     kernel_size: Sequence[int],
     data_range: Union[float, torch.Tensor] = 1.0,
     k1: float = 0.01,
@@ -195,21 +194,18 @@ def _compute_ssim_and_cs_bf16(
     so only the conv outputs (returned in bf16) lose precision relative to
     monai's all-fp32 path.
 
-    Uniform kernel only — matches the single call site in :func:`ssim_25d`;
-    Gaussian-kernel and ``kernel_sigma`` parameters from monai's signature
-    are intentionally dropped.
+    Specialized to 3D uniform kernels — matches the single call site in
+    :func:`ssim_25d`. Gaussian-kernel, ``kernel_sigma``, and ``spatial_dims``
+    parameters from monai's signature are intentionally dropped.
 
     Parameters
     ----------
     y_pred : torch.Tensor
-        Predicted batch with shape ``(B, C, *spatial)``.
+        Predicted batch with shape ``(B, C, D, H, W)``.
     y : torch.Tensor
         Target batch with the same shape as ``y_pred``.
-    spatial_dims : int
-        Number of spatial dimensions (2 or 3); selects ``F.conv2d`` /
-        ``F.conv3d``.
     kernel_size : Sequence[int]
-        Uniform window size, length equal to ``spatial_dims``.
+        Uniform 3D window size ``(D, H, W)``.
     data_range : float or torch.Tensor, optional
         Data range of the inputs; used to compute the C1, C2 stability
         constants. Defaults to ``1.0``.
@@ -236,22 +232,20 @@ def _compute_ssim_and_cs_bf16(
     )
     kernel_bf = kernel_fp32.to(torch.bfloat16)
 
-    # Compute squared products in fp32 to preserve squaring precision,
-    # then cast to bf16 for the conv input.
+    # Squared products in fp32 to preserve squaring precision; cast to bf16
+    # for the conv input. The simple (non-squared) inputs are cast inline at
+    # the conv site to avoid holding redundant bf16 copies of y / y_pred.
     y_pred_fp32 = y_pred.float()
     y_fp32 = y.float()
-    y_pred_bf = y_pred_fp32.to(torch.bfloat16)
-    y_bf = y_fp32.to(torch.bfloat16)
     y_pred_sq_bf = (y_pred_fp32 * y_pred_fp32).to(torch.bfloat16)
     y_sq_bf = (y_fp32 * y_fp32).to(torch.bfloat16)
     y_pred_y_bf = (y_pred_fp32 * y_fp32).to(torch.bfloat16)
 
-    conv_fn = getattr(F, f"conv{spatial_dims}d")
-    mu_x = conv_fn(y_pred_bf, kernel_bf, groups=num_channels).float()
-    mu_y = conv_fn(y_bf, kernel_bf, groups=num_channels).float()
-    mu_xx = conv_fn(y_pred_sq_bf, kernel_bf, groups=num_channels).float()
-    mu_yy = conv_fn(y_sq_bf, kernel_bf, groups=num_channels).float()
-    mu_xy = conv_fn(y_pred_y_bf, kernel_bf, groups=num_channels).float()
+    mu_x = F.conv3d(y_pred_fp32.to(torch.bfloat16), kernel_bf, groups=num_channels).float()
+    mu_y = F.conv3d(y_fp32.to(torch.bfloat16), kernel_bf, groups=num_channels).float()
+    mu_xx = F.conv3d(y_pred_sq_bf, kernel_bf, groups=num_channels).float()
+    mu_yy = F.conv3d(y_sq_bf, kernel_bf, groups=num_channels).float()
+    mu_xy = F.conv3d(y_pred_y_bf, kernel_bf, groups=num_channels).float()
 
     # Stability constants in fp32 (data_range may be a 0-dim tensor; the
     # multiplication promotes to fp32 since k1/k2 are Python floats).
@@ -293,7 +287,6 @@ def ssim_25d(
     ssim_img, cs_img = _compute_ssim_and_cs_bf16(
         preds,
         target,
-        spatial_dims=3,
         kernel_size=(depth, *in_plane_window_size),
         data_range=target.max(),
     )

--- a/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
@@ -183,12 +183,12 @@ def _compute_ssim_and_cs_bf16(
 
     Replaces monai's ``compute_ssim_and_cs`` (which unconditionally casts both
     inputs to fp32 internally) with a precision-aware variant that runs the
-    five Gaussian-mean convolutions in bf16 and promotes only the variance
-    subtractions and C1/C2-guarded divisions to fp32. Squared products
-    (``y * y``, ``y_pred * y_pred``, ``y_pred * y``) are computed in fp32
-    before casting to bf16 for the conv input, which preserves precision on
-    the precision-sensitive squaring step at the cost of one extra cast per
-    squared term.
+    five uniform-window mean convolutions in bf16 and promotes only the
+    variance subtractions and C1/C2-guarded divisions to fp32. Squared
+    products (``y * y``, ``y_pred * y_pred``, ``y_pred * y``) are computed in
+    fp32 before casting to bf16 for the conv input, which preserves precision
+    on the precision-sensitive squaring step at the cost of one extra cast
+    per squared term.
 
     The conv accumulator is fp32 on CUDA tensor cores (sm >= 80) and on CPU,
     so only the conv outputs (returned in bf16) lose precision relative to
@@ -236,17 +236,20 @@ def _compute_ssim_and_cs_bf16(
     )
     kernel_bf = kernel_fp32.to(torch.bfloat16)
 
-    # Squared products in fp32 to preserve squaring precision; cast to bf16
-    # for the conv input. The simple (non-squared) inputs are cast inline at
-    # the conv site to avoid holding redundant bf16 copies of y / y_pred.
+    # bf16 views of the simple (non-squared) inputs go straight from the
+    # caller's dtype — skips a round-trip via fp32 when the caller is
+    # already in bf16 (autocast). Squared products are computed in fp32
+    # first to preserve squaring precision, then cast to bf16 for the conv.
+    y_pred_bf = y_pred.to(torch.bfloat16)
+    y_bf = y.to(torch.bfloat16)
     y_pred_fp32 = y_pred.float()
     y_fp32 = y.float()
     y_pred_sq_bf = (y_pred_fp32 * y_pred_fp32).to(torch.bfloat16)
     y_sq_bf = (y_fp32 * y_fp32).to(torch.bfloat16)
     y_pred_y_bf = (y_pred_fp32 * y_fp32).to(torch.bfloat16)
 
-    mu_x = F.conv3d(y_pred_fp32.to(torch.bfloat16), kernel_bf, groups=num_channels).float()
-    mu_y = F.conv3d(y_fp32.to(torch.bfloat16), kernel_bf, groups=num_channels).float()
+    mu_x = F.conv3d(y_pred_bf, kernel_bf, groups=num_channels).float()
+    mu_y = F.conv3d(y_bf, kernel_bf, groups=num_channels).float()
     mu_xx = F.conv3d(y_pred_sq_bf, kernel_bf, groups=num_channels).float()
     mu_yy = F.conv3d(y_sq_bf, kernel_bf, groups=num_channels).float()
     mu_xy = F.conv3d(y_pred_y_bf, kernel_bf, groups=num_channels).float()

--- a/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
@@ -175,7 +175,7 @@ def _compute_ssim_and_cs_bf16(
     y_pred: torch.Tensor,
     y: torch.Tensor,
     kernel_size: Sequence[int],
-    data_range: Union[float, torch.Tensor] = 1.0,
+    data_range: float | torch.Tensor = 1.0,
     k1: float = 0.01,
     k2: float = 0.03,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -227,6 +227,10 @@ def _compute_ssim_and_cs_bf16(
     num_channels = y_pred.size(1)
 
     # Build uniform kernel in fp32 then cast to bf16 once.
+    # The kernel is rebuilt per call (5x per ms_ssim_25d invocation). The
+    # tensor is small (~1.8k elements at default 15x11x11) so the per-step
+    # overhead is negligible relative to the conv cost. If profiling ever
+    # shows otherwise, cache by (num_channels, kernel_size, device, dtype).
     kernel_fp32 = torch.ones((num_channels, 1, *kernel_size), device=y_pred.device, dtype=torch.float32) / float(
         prod(kernel_size)
     )

--- a/packages/viscy-utils/src/viscy_utils/losses/mixed_loss.py
+++ b/packages/viscy-utils/src/viscy_utils/losses/mixed_loss.py
@@ -4,7 +4,6 @@ Provides a configurable combination of L1, L2, and MS-DSSIM losses
 for image reconstruction tasks, adapted from Zhao et al.
 """
 
-import torch
 import torch.nn.functional as F
 from torch import nn
 
@@ -40,7 +39,6 @@ class MixedLoss(nn.Module):
         self.l2_alpha = l2_alpha
         self.ms_dssim_alpha = ms_dssim_alpha
 
-    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float32)
     def forward(self, preds, target):
         """Compute the mixed reconstruction loss.
 

--- a/packages/viscy-utils/src/viscy_utils/losses/spotlight.py
+++ b/packages/viscy-utils/src/viscy_utils/losses/spotlight.py
@@ -158,7 +158,6 @@ class SpotlightLoss(nn.Module):
         self.fg_threshold = fg_threshold
         self._warned_no_real_mask = False
 
-    @torch.amp.custom_fwd(device_type="cuda", cast_inputs=torch.float32)
     def forward(self, pred: Tensor, target: Tensor, fg_mask: Tensor | None = None) -> Tensor:
         """Compute the Spotlight loss.
 

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -105,7 +105,8 @@ def test_ssim_helper_gradient_flow():
 
     Per-voxel sign equality is too brittle (~0.25% benign flips on
     non-tiny gradients). Use cosine similarity + sign-flip fraction over
-    voxels with ``|grad_ref| > 1e-3``.
+    voxels above 10% of the reference grad max — relative threshold so
+    the assertion is scale-invariant regardless of loss magnitude.
     """
     torch.manual_seed(3)
     y = torch.rand(*_BATCH, device="cuda")

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -1,6 +1,6 @@
 """Tests for the bf16-precision SSIM helper in viscy_utils.evaluation.metrics.
 
-Covers the multi-tier numerical contract from the plan:
+Covers the multi-tier numerical contract:
 
 - per-pixel SSIM equivalence on random inputs (worst-case bf16 drift)
 - aggregate SSIM equivalence on random inputs (per-pixel noise averages out)
@@ -19,14 +19,13 @@ from viscy_utils.evaluation.metrics import _compute_ssim_and_cs_bf16
 # Representative iPSC SEC61B FCMAE batch shape.
 _BATCH = (2, 1, 15, 256, 256)
 _KERNEL = (15, 11, 11)
-_SPATIAL_DIMS = 3
 
 
 def _ref(y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return _monai_reference(
         y_pred,
         y,
-        spatial_dims=_SPATIAL_DIMS,
+        spatial_dims=3,
         kernel_size=_KERNEL,
         kernel_sigma=None,
         kernel_type="uniform",
@@ -38,7 +37,6 @@ def _bf16(y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Te
     return _compute_ssim_and_cs_bf16(
         y_pred,
         y,
-        spatial_dims=_SPATIAL_DIMS,
         kernel_size=_KERNEL,
         data_range=y.max(),
     )

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -133,10 +133,13 @@ def test_ssim_helper_gradient_flow():
     ).item()
     assert cos_sim >= 0.99, f"cosine similarity {cos_sim:.4f} below 0.99"
 
-    nontiny = grad_ref.abs() > 1e-3
-    if nontiny.any():
-        flip_fraction = ((grad_helper.sign() != grad_ref.sign()) & nontiny).float().sum() / nontiny.float().sum()
-        assert flip_fraction.item() < 0.01, f"sign-flip fraction {flip_fraction.item():.4f} above 1%"
+    # Relative threshold — observed |grad_ref| max is ~1.7e-6, so the
+    # earlier absolute 1e-3 threshold was vacuous. Anchor to 10% of the
+    # reference max so the assertion is scale-invariant and meaningful.
+    nontiny = grad_ref.abs() > 0.1 * grad_ref.abs().max()
+    assert nontiny.any(), "no non-tiny reference gradients to compare signs against"
+    flip_fraction = ((grad_helper.sign() != grad_ref.sign()) & nontiny).float().sum() / nontiny.float().sum()
+    assert flip_fraction.item() < 0.01, f"sign-flip fraction {flip_fraction.item():.4f} above 1%"
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -12,9 +12,23 @@ Covers the multi-tier numerical contract:
 import pytest
 import torch
 import torch.nn.functional as F
-from monai.metrics.regression import compute_ssim_and_cs as _monai_reference
 
 from viscy_utils.evaluation.metrics import _compute_ssim_and_cs_bf16
+
+# monai is not a hard dep of viscy-utils — skip the suite if absent rather
+# than failing at import time.
+_monai_regression = pytest.importorskip("monai.metrics.regression")
+_monai_reference = _monai_regression.compute_ssim_and_cs
+
+# The helper unconditionally uses bf16 convs. CUDA bf16 conv works on
+# sm_80+ in tensor cores and falls back to software emulation on older
+# devices, but the equivalence-vs-monai-fp32 tolerances were measured on
+# Hopper — skip on hardware where bf16 emulation could push drift past
+# the configured rtol/atol.
+_skip_no_bf16 = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.is_bf16_supported()),
+    reason="CUDA + bf16 tensor-core support required",
+)
 
 # Representative iPSC SEC61B FCMAE batch shape.
 _BATCH = (2, 1, 15, 256, 256)
@@ -42,7 +56,7 @@ def _bf16(y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Te
     )
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_ssim_helper_random_per_pixel_equivalence():
     """Per-pixel SSIM on random inputs, worst-case bf16 drift tier.
 
@@ -59,7 +73,7 @@ def test_ssim_helper_random_per_pixel_equivalence():
     torch.testing.assert_close(cs_helper, cs_ref, rtol=5e-2, atol=1e-1)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_ssim_helper_random_aggregate_equivalence():
     """Aggregate SSIM (mean over pixels) on random inputs.
 
@@ -79,7 +93,7 @@ def test_ssim_helper_random_aggregate_equivalence():
     torch.testing.assert_close(agg_helper, agg_ref, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_ssim_helper_correlated_pair_equivalence():
     """Aggregate SSIM on a correlated pair (pred = target + small noise).
 
@@ -99,7 +113,7 @@ def test_ssim_helper_correlated_pair_equivalence():
     torch.testing.assert_close(agg_helper, agg_ref, rtol=2e-3, atol=5e-3)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_ssim_helper_gradient_flow():
     """Gradient flow contract: finite, cosine-similar, low sign-flip rate.
 
@@ -141,7 +155,7 @@ def test_ssim_helper_gradient_flow():
     assert flip_fraction.item() < 0.01, f"sign-flip fraction {flip_fraction.item():.4f} above 1%"
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 @pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16, torch.float16])
 def test_ssim_helper_dtypes(input_dtype):
     """Helper returns fp32 regardless of input dtype."""

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -1,0 +1,153 @@
+"""Tests for the bf16-precision SSIM helper in viscy_utils.evaluation.metrics.
+
+Covers the multi-tier numerical contract from the plan:
+
+- per-pixel SSIM equivalence on random inputs (worst-case bf16 drift)
+- aggregate SSIM equivalence on random inputs (per-pixel noise averages out)
+- aggregate SSIM equivalence on correlated-pair inputs (closer to training)
+- gradient-flow correctness via cosine similarity and sign-flip fraction
+- output dtype invariance to input dtype
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from monai.metrics.regression import compute_ssim_and_cs as _monai_reference
+
+from viscy_utils.evaluation.metrics import _compute_ssim_and_cs_bf16
+
+# Representative iPSC SEC61B FCMAE batch shape.
+_BATCH = (2, 1, 15, 256, 256)
+_KERNEL = (15, 11, 11)
+_SPATIAL_DIMS = 3
+
+
+def _ref(y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return _monai_reference(
+        y_pred,
+        y,
+        spatial_dims=_SPATIAL_DIMS,
+        kernel_size=_KERNEL,
+        kernel_sigma=None,
+        kernel_type="uniform",
+        data_range=y.max(),
+    )
+
+
+def _bf16(y_pred: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return _compute_ssim_and_cs_bf16(
+        y_pred,
+        y,
+        spatial_dims=_SPATIAL_DIMS,
+        kernel_size=_KERNEL,
+        data_range=y.max(),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_ssim_helper_random_per_pixel_equivalence():
+    """Per-pixel SSIM on random inputs, worst-case bf16 drift tier.
+
+    Tolerance ≥2× margin over measured 0.0418 absolute drift.
+    """
+    torch.manual_seed(0)
+    y_pred = torch.rand(*_BATCH, device="cuda")
+    y = torch.rand(*_BATCH, device="cuda")
+
+    ssim_ref, cs_ref = _ref(y_pred, y)
+    ssim_helper, cs_helper = _bf16(y_pred, y)
+
+    torch.testing.assert_close(ssim_helper, ssim_ref, rtol=5e-2, atol=1e-1)
+    torch.testing.assert_close(cs_helper, cs_ref, rtol=5e-2, atol=1e-1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_ssim_helper_random_aggregate_equivalence():
+    """Aggregate SSIM (mean over pixels) on random inputs.
+
+    Per-pixel noise averages out across H×W ≈ 65k pixels.
+    Tolerance ≥25% margin over measured 0.00776 absolute drift.
+    """
+    torch.manual_seed(1)
+    y_pred = torch.rand(*_BATCH, device="cuda")
+    y = torch.rand(*_BATCH, device="cuda")
+
+    ssim_ref, _ = _ref(y_pred, y)
+    ssim_helper, _ = _bf16(y_pred, y)
+
+    agg_ref = ssim_ref.view(ssim_ref.shape[0], -1).mean(1)
+    agg_helper = ssim_helper.view(ssim_helper.shape[0], -1).mean(1)
+
+    torch.testing.assert_close(agg_helper, agg_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_ssim_helper_correlated_pair_equivalence():
+    """Aggregate SSIM on a correlated pair (pred = target + small noise).
+
+    Closer to training-time inputs; SSIM lives near 1.0 so relative drift
+    is much smaller than on uncorrelated random data.
+    """
+    torch.manual_seed(2)
+    y = torch.rand(*_BATCH, device="cuda")
+    y_pred = y + 0.05 * torch.randn_like(y)
+
+    ssim_ref, _ = _ref(y_pred, y)
+    ssim_helper, _ = _bf16(y_pred, y)
+
+    agg_ref = ssim_ref.view(ssim_ref.shape[0], -1).mean(1)
+    agg_helper = ssim_helper.view(ssim_helper.shape[0], -1).mean(1)
+
+    torch.testing.assert_close(agg_helper, agg_ref, rtol=2e-3, atol=5e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_ssim_helper_gradient_flow():
+    """Gradient flow contract: finite, cosine-similar, low sign-flip rate.
+
+    Per-voxel sign equality is too brittle (~0.25% benign flips on
+    non-tiny gradients). Use cosine similarity + sign-flip fraction over
+    voxels with ``|grad_ref| > 1e-3``.
+    """
+    torch.manual_seed(3)
+    y = torch.rand(*_BATCH, device="cuda")
+
+    y_pred_ref = (y + 0.05 * torch.randn_like(y)).detach().requires_grad_(True)
+    ssim_ref, _ = _ref(y_pred_ref, y)
+    (1 - ssim_ref).mean().backward()
+    grad_ref = y_pred_ref.grad
+
+    y_pred_helper = y_pred_ref.detach().clone().requires_grad_(True)
+    ssim_helper, _ = _bf16(y_pred_helper, y)
+    (1 - ssim_helper).mean().backward()
+    grad_helper = y_pred_helper.grad
+
+    assert grad_helper is not None
+    assert grad_helper.shape == grad_ref.shape
+    assert torch.isfinite(grad_helper).all()
+
+    cos_sim = F.cosine_similarity(
+        grad_helper.flatten().unsqueeze(0),
+        grad_ref.flatten().unsqueeze(0),
+        dim=1,
+    ).item()
+    assert cos_sim >= 0.99, f"cosine similarity {cos_sim:.4f} below 0.99"
+
+    nontiny = grad_ref.abs() > 1e-3
+    if nontiny.any():
+        flip_fraction = ((grad_helper.sign() != grad_ref.sign()) & nontiny).float().sum() / nontiny.float().sum()
+        assert flip_fraction.item() < 0.01, f"sign-flip fraction {flip_fraction.item():.4f} above 1%"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_ssim_helper_dtypes(input_dtype):
+    """Helper returns fp32 regardless of input dtype."""
+    torch.manual_seed(4)
+    y_pred = torch.rand(*_BATCH, device="cuda", dtype=input_dtype)
+    y = torch.rand(*_BATCH, device="cuda", dtype=input_dtype)
+
+    ssim_helper, cs_helper = _bf16(y_pred, y)
+
+    assert ssim_helper.dtype == torch.float32
+    assert cs_helper.dtype == torch.float32

--- a/packages/viscy-utils/tests/test_mixed_loss.py
+++ b/packages/viscy-utils/tests/test_mixed_loss.py
@@ -16,6 +16,11 @@ from viscy_utils.losses import MixedLoss
 # test convention.
 _BATCH = (2, 1, 15, 192, 192)
 
+_skip_no_bf16 = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.is_bf16_supported()),
+    reason="CUDA + bf16 tensor-core support required",
+)
+
 
 def _seeded_inputs(device: str = "cuda", seed: int = 0):
     torch.manual_seed(seed)
@@ -24,7 +29,7 @@ def _seeded_inputs(device: str = "cuda", seed: int = 0):
     return pred, target
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_mixed_loss_forward_finite_outside_autocast():
     """Forward returns a finite fp32 scalar outside any autocast context."""
     loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.5)
@@ -37,7 +42,7 @@ def test_mixed_loss_forward_finite_outside_autocast():
     assert torch.isfinite(loss).item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_mixed_loss_forward_under_bf16_autocast():
     """Forward under bf16 autocast returns a finite fp32 scalar.
 
@@ -61,7 +66,7 @@ def test_mixed_loss_forward_under_bf16_autocast():
     torch.testing.assert_close(loss_autocast, loss_fp32, rtol=1e-2, atol=1e-2)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_mixed_loss_gradient_flow_under_autocast():
     """Backward through MixedLoss under autocast bf16 produces finite grads."""
     loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.5)

--- a/packages/viscy-utils/tests/test_mixed_loss.py
+++ b/packages/viscy-utils/tests/test_mixed_loss.py
@@ -1,0 +1,94 @@
+"""Tests for MixedLoss after the @torch.amp.custom_fwd(cast_inputs=fp32) removal.
+
+Verifies the entry-point behaviour didn't change in any user-visible way:
+forward returns finite scalars in fp32 inside and outside autocast, gradients
+flow under autocast bf16, and the L1-only branch is bit-exact F.l1_loss.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from viscy_utils.losses import MixedLoss
+
+# Spatial size needs to be at least 2^4 * 11 = 176 for the 5-level MS-DSSIM
+# pyramid with 11x11 kernels — use 192 to match the cytoland CPU integration
+# test convention.
+_BATCH = (2, 1, 15, 192, 192)
+
+
+def _seeded_inputs(device: str = "cuda", seed: int = 0):
+    torch.manual_seed(seed)
+    pred = torch.rand(*_BATCH, device=device)
+    target = torch.rand(*_BATCH, device=device)
+    return pred, target
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_mixed_loss_forward_finite_outside_autocast():
+    """Forward returns a finite fp32 scalar outside any autocast context."""
+    loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.5)
+    pred, target = _seeded_inputs()
+
+    loss = loss_fn(pred, target)
+
+    assert loss.dtype == torch.float32
+    assert loss.ndim == 0
+    assert torch.isfinite(loss).item()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_mixed_loss_forward_under_bf16_autocast():
+    """Forward under bf16 autocast returns a finite fp32 scalar.
+
+    Drift between the no-decorator path (in autocast) and a manually
+    fp32-cast path is bounded by rtol=1e-2, atol=1e-2 — within the SSIM
+    helper's per-aggregate contract.
+    """
+    loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.5)
+    pred, target = _seeded_inputs(seed=1)
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        loss_autocast = loss_fn(pred, target)
+
+    # Manual fp32 baseline — what the @custom_fwd(cast_inputs=fp32) decorator
+    # produced. We don't actually wrap; we just call outside autocast on the
+    # same fp32 inputs.
+    loss_fp32 = loss_fn(pred.float(), target.float())
+
+    assert loss_autocast.dtype == torch.float32
+    assert torch.isfinite(loss_autocast).item()
+    torch.testing.assert_close(loss_autocast, loss_fp32, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_mixed_loss_gradient_flow_under_autocast():
+    """Backward through MixedLoss under autocast bf16 produces finite grads."""
+    loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.5)
+    pred, target = _seeded_inputs(seed=2)
+    pred = pred.detach().requires_grad_(True)
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        loss = loss_fn(pred, target)
+    loss.backward()
+
+    assert pred.grad is not None
+    assert pred.grad.shape == pred.shape
+    assert torch.isfinite(pred.grad).all().item()
+
+
+def test_mixed_loss_l1_only_matches_torch_l1():
+    """ms_dssim_alpha=0 collapses MixedLoss to alpha * F.l1_loss bit-exact.
+
+    Runs on CPU (no autocast, no SSIM). Confirms L1 branch behaviour is
+    identical to torch.nn.functional.l1_loss after decorator removal.
+    """
+    loss_fn = MixedLoss(l1_alpha=0.5, l2_alpha=0.0, ms_dssim_alpha=0.0)
+    torch.manual_seed(3)
+    pred = torch.rand(2, 1, 8, 64, 64)
+    target = torch.rand(2, 1, 8, 64, 64)
+
+    loss = loss_fn(pred, target)
+    expected = F.l1_loss(pred, target) * 0.5
+
+    torch.testing.assert_close(loss, expected, rtol=0, atol=0)

--- a/packages/viscy-utils/tests/test_spotlight_loss.py
+++ b/packages/viscy-utils/tests/test_spotlight_loss.py
@@ -269,3 +269,47 @@ def test_spotlight_loss_invalid_params():
         SpotlightLoss(lambda_mse=1.0)
     with pytest.raises(ValueError, match="eps"):
         SpotlightLoss(eps=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_spotlight_loss_forward_under_bf16_autocast():
+    """Forward+backward under bf16 autocast produces finite scalar + grads.
+
+    Verifies the @torch.amp.custom_fwd(cast_inputs=fp32) decorator removal
+    didn't break the autocast path. SpotlightLoss has no conv-heavy ops;
+    autocast policy already promotes the squared error / reductions /
+    divisions to fp32, so the decorator was redundant.
+    """
+    loss_fn = SpotlightLoss().cuda()
+    torch.manual_seed(0)
+    pred = torch.rand(2, 1, 4, 32, 32, device="cuda", requires_grad=True)
+    target = torch.rand(2, 1, 4, 32, 32, device="cuda")
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        loss = loss_fn(pred, target)
+    loss.backward()
+
+    assert torch.isfinite(loss).item()
+    assert pred.grad is not None
+    assert torch.isfinite(pred.grad).all().item()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+def test_spotlight_loss_autocast_matches_fp32_baseline():
+    """No-decorator autocast result tracks the explicit-fp32 baseline.
+
+    Drift is bounded by rtol=1e-2, atol=1e-2 — generous since SpotlightLoss
+    has no convs (sigmoid is the only autocast-affected op) and the
+    autocast policy promotes the precision-sensitive parts to fp32.
+    """
+    loss_fn = SpotlightLoss().cuda()
+    torch.manual_seed(1)
+    pred = torch.rand(2, 1, 4, 32, 32, device="cuda")
+    target = torch.rand(2, 1, 4, 32, 32, device="cuda")
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        loss_autocast = loss_fn(pred, target)
+
+    loss_fp32 = loss_fn(pred.float(), target.float())
+
+    torch.testing.assert_close(loss_autocast.float(), loss_fp32, rtol=1e-2, atol=1e-2)

--- a/packages/viscy-utils/tests/test_spotlight_loss.py
+++ b/packages/viscy-utils/tests/test_spotlight_loss.py
@@ -5,6 +5,11 @@ import torch
 
 from viscy_utils.losses.spotlight import SpotlightLoss, _otsu_threshold, _tunable_sigmoid
 
+_skip_no_bf16 = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.is_bf16_supported()),
+    reason="CUDA + bf16 tensor-core support required",
+)
+
 
 def test_tunable_sigmoid_range():
     """Output is clamped to [0, 1]."""
@@ -271,7 +276,7 @@ def test_spotlight_loss_invalid_params():
         SpotlightLoss(eps=0)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_spotlight_loss_forward_under_bf16_autocast():
     """Forward+backward under bf16 autocast produces finite scalar + grads.
 
@@ -294,7 +299,7 @@ def test_spotlight_loss_forward_under_bf16_autocast():
     assert torch.isfinite(pred.grad).all().item()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for bf16")
+@_skip_no_bf16
 def test_spotlight_loss_autocast_matches_fp32_baseline():
     """No-decorator autocast result tracks the explicit-fp32 baseline.
 

--- a/packages/viscy-utils/tests/test_spotlight_loss.py
+++ b/packages/viscy-utils/tests/test_spotlight_loss.py
@@ -298,9 +298,10 @@ def test_spotlight_loss_forward_under_bf16_autocast():
 def test_spotlight_loss_autocast_matches_fp32_baseline():
     """No-decorator autocast result tracks the explicit-fp32 baseline.
 
-    Drift is bounded by rtol=1e-2, atol=1e-2 — generous since SpotlightLoss
-    has no convs (sigmoid is the only autocast-affected op) and the
-    autocast policy promotes the precision-sensitive parts to fp32.
+    Drift is bounded by rtol=1e-3, atol=1e-3 — SpotlightLoss has no convs
+    (sigmoid is the only autocast-affected op) and the autocast policy
+    promotes the precision-sensitive parts to fp32; in practice the
+    measured drift is 0.0.
     """
     loss_fn = SpotlightLoss().cuda()
     torch.manual_seed(1)
@@ -312,4 +313,4 @@ def test_spotlight_loss_autocast_matches_fp32_baseline():
 
     loss_fp32 = loss_fn(pred.float(), target.float())
 
-    torch.testing.assert_close(loss_autocast.float(), loss_fp32, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(loss_autocast.float(), loss_fp32, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Summary

Replaces monai's fp32-pinned `compute_ssim_and_cs` with a precision-aware variant `_compute_ssim_and_cs_bf16` in viscy-utils. Drops the now-redundant `@torch.amp.custom_fwd(cast_inputs=fp32)` decorators on `MixedLoss.forward` and `SpotlightLoss.forward`. Restores Hopper (H100/H200) tensor-core throughput on FCMAE VSCyto3D training: **~45.5 s/step → ~4.15 s/step** on N=4 H100 (10.97× speedup).

## Why

FCMAE training on Hopper was ~10–15× slower than on Ampere/Ada. Direct measurement (T2 probe, job 31452082) showed compute time collapses to ~0.9 s/step when MS-DSSIM is removed from the loss, conclusively pinning fp32 MS-DSSIM as the dominant slow term. The fp32 cast lives at `monai/metrics/regression.py:402-403` (unconditional `convert_data_type(..., dtype=torch.float)` on both inputs); the 25 fp32 conv ops per loss invocation can't use Hopper's bf16 tensor cores.

The new helper runs the 5 Gaussian-mean convolutions in bf16 with squared products computed in fp32 *before* casting to bf16 (preserves squaring precision), and promotes only the variance subtractions and C₁/C₂-guarded divisions to fp32. The viscy `@custom_fwd` decorators were always redundant: `MixedLoss` was layered on top of monai's already-pinned fp32 path; `SpotlightLoss` has no conv-heavy ops and autocast policy already promotes its precision-sensitive reductions to fp32.

## Numerical contract (measured, with margin)

Empirical drift on `(2, 1, 15, 256, 256)` CUDA inputs vs monai fp32 reference:

| Tier | Measured drift | Test tolerance | Margin |
| --- | ---: | ---: | ---: |
| Per-pixel random | 0.0418 max abs | rtol=5e-2, atol=1e-1 | ≥2× |
| Aggregate random (mean over pixels) | 0.00776 max abs | rtol=1e-2, atol=1e-2 | ≥25% |
| Aggregate correlated-pair (`pred=target+0.05*randn`) | not measured | rtol=2e-3, atol=5e-3 | conservative |
| Gradient | 0.99977 cosine sim | cosine ≥ 0.99 + sign-flip < 1% on `\|grad_ref\|>10% of max` | — |

## Verification

- 7 SSIM contract tests in `packages/viscy-utils/tests/test_metrics.py`
- 4 MixedLoss entry-point tests in `packages/viscy-utils/tests/test_mixed_loss.py`
- 2 new SpotlightLoss autocast tests in `packages/viscy-utils/tests/test_spotlight_loss.py`
- Full `uv run pytest packages/viscy-utils/`: 141/141 pass
- CPU integration: `uv run pytest applications/cytoland/tests/test_training_integration.py::test_vsunet_mixed_loss_fast_dev_run` passes
- `uvx prek run --files ...` clean on all touched files

## T6 Hopper sanity probe (job 31453564, gpu-f-2 H100, N=4, MS-DSSIM enabled)

| Step | data_wait_ms | compute_ms |
| ---: | ---: | ---: |
| 0 | 11894.6 | 15674.9 *(init / cuDNN autotune)* |
| 1 | 542.1 | 4139.3 |
| 2 | 535.8 | 4140.2 |
| 3 | 538.7 | 4143.2 |
| 4 | 548.5 | 4155.6 |
| 5 | 542.4 | 4164.7 |
| 6 | 541.1 | 4166.4 |

Steady-state mean compute_ms: **4151 ms** ± 11 ms (6 consecutive STEP_TIMER lines). Versus T5/Probe C baseline of 45.5 s/step on identical hardware with fp32 MS-DSSIM: **10.97× speedup**.

## Test plan
- [x] `uv run pytest packages/viscy-utils/tests/test_metrics.py` (7 tests)
- [x] `uv run pytest packages/viscy-utils/tests/test_mixed_loss.py` (4 tests)
- [x] `uv run pytest packages/viscy-utils/tests/test_spotlight_loss.py` (24 tests, 2 new)
- [x] `uv run pytest packages/viscy-utils/` — full package suite (141 pass)
- [x] `uv run pytest applications/cytoland/tests/test_training_integration.py::test_vsunet_mixed_loss_fast_dev_run` — CPU bf16 path
- [x] `uvx prek run --files ...` clean on all touched files
- [x] Hopper sanity probe T6 — measured 4.15 s/step (10.97× speedup)
- [ ] Long-run loss-curve parity check on a real FCMAE finetune (post-merge)

## Operational note

Active prod runs on A40/L40S (jobs 31415937, 31446584) are intentionally not migrated mid-resume. Apply on next fresh training run or intentional checkpoint migration.

## Follow-ups (separate scope)

- Optional: hoist `_seeded_inputs` / `_BATCH` test fixtures to `conftest.py` if more SSIM/loss tests land
- Optional: extract the uniform-kernel builder to a shared util (also duplicated in `viscy_transforms/_elastic.py`)
- Unrelated, still open: 20-hour host-RAM leak in long FCMAE runs (see `applications/dynacell/configs/examples/fcmae_hopper_slowdown.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)