### PR TITLE
feat(dynacell): migrate eval metrics to torch-fidelity, add probes

### DIFF
--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -52,8 +52,13 @@ optional-dependencies.eval = [
   "microssim @ git+https://github.com/juglab/microssim.git@8bccb17d",
   "pandas",
   "scikit-image",
+  "scikit-learn>=1.4",
   "scipy",
   "segmenter-model-zoo",
+  # Pinned to a commit on toshas/torch-fidelity master that includes MIND
+  # (commit a51aa64 "add Monge Inception Distance") on top of v0.4.0.
+  # MIND is not in any tagged release yet.
+  "torch-fidelity @ git+https://github.com/toshas/torch-fidelity.git@5e211a9",
   "tqdm",
   "transformers",
 ]

--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -57,7 +57,8 @@ optional-dependencies.eval = [
   "segmenter-model-zoo",
   # Pinned to a commit on toshas/torch-fidelity master that includes MIND
   # (commit a51aa64 "add Monge Inception Distance") on top of v0.4.0.
-  # MIND is not in any tagged release yet.
+  # Upgrade path: drop the `@5e211a9` suffix and pin a tagged release once
+  # upstream cuts one that includes MIND (target: `torch-fidelity>=0.5.0`).
   "torch-fidelity @ git+https://github.com/toshas/torch-fidelity.git@5e211a9",
   "tqdm",
   "transformers",

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -63,9 +63,7 @@ feature_extractor:
       embedding_dim: 768
       projection_dim: 32
       drop_path_rate: 0.0
-  # Optional CELL-DINO foundation backbone (DINOv2 ViT-L/16 pretrained on
-  # the Human Protein Atlas). Leave `weights_path` null to skip the
-  # backbone entirely; set to a local `.pth` state_dict to enable.
+  # CELL-DINO (DINOv2 ViT-L/16 pretrained on HPA). `weights_path: null` disables.
   celldino:
     weights_path: null
     img_size: 224

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -63,6 +63,13 @@ feature_extractor:
       embedding_dim: 768
       projection_dim: 32
       drop_path_rate: 0.0
+  # Optional CELL-DINO foundation backbone (DINOv2 ViT-L/16 pretrained on
+  # the Human Protein Atlas). Leave `weights_path` null to skip the
+  # backbone entirely; set to a local `.pth` state_dict to enable.
+  celldino:
+    weights_path: null
+    img_size: 224
+    patch_size: 16
 
 use_gpu: true
 compute_microssim: true
@@ -75,6 +82,7 @@ force_recompute:
   gt_cp: false
   gt_dinov3: false
   gt_dynaclr: false
+  gt_celldino: false
   final_metrics: false
 
 save:

--- a/applications/dynacell/src/dynacell/evaluation/cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/cache.py
@@ -25,7 +25,7 @@ import zarr
 from iohub.ngff import open_ome_zarr
 from omegaconf import OmegaConf
 
-FeatureKind = Literal["cp", "dinov3", "dynaclr"]
+FeatureKind = Literal["cp", "dinov3", "dynaclr", "celldino"]
 
 CACHE_SCHEMA_VERSION = 1
 
@@ -60,6 +60,10 @@ class CachePaths:
     def dynaclr_features(self, ckpt_sha12: str) -> Path:
         """Return the zarr group path for DynaCLR features keyed by *ckpt_sha12*."""
         return self.features_dir / "dynaclr" / f"{ckpt_sha12}.zarr"
+
+    def celldino_features(self, weights_sha12: str) -> Path:
+        """Return the zarr group path for CELL-DINO features keyed by *weights_sha12*."""
+        return self.features_dir / "celldino" / f"{weights_sha12}.zarr"
 
 
 def cache_paths(gt_cache_dir: Path | str) -> CachePaths:
@@ -275,6 +279,7 @@ def _features_group_path(
     *,
     model_name: str | None = None,
     ckpt_sha12: str | None = None,
+    weights_sha12: str | None = None,
 ) -> Path:
     """Resolve the zarr group path for a feature cache entry."""
     if kind == "cp":
@@ -287,6 +292,10 @@ def _features_group_path(
         if ckpt_sha12 is None:
             raise ValueError("ckpt_sha12 is required for kind='dynaclr'")
         return paths.dynaclr_features(ckpt_sha12)
+    if kind == "celldino":
+        if weights_sha12 is None:
+            raise ValueError("weights_sha12 is required for kind='celldino'")
+        return paths.celldino_features(weights_sha12)
     raise ValueError(f"Unknown feature kind: {kind!r}")
 
 
@@ -316,13 +325,16 @@ def open_features_group(
     mode: Literal["r", "a"] = "a",
     model_name: str | None = None,
     ckpt_sha12: str | None = None,
+    weights_sha12: str | None = None,
 ):
     """Yield an open zarr group for one feature-cache artifact.
 
     Use this for per-FOV batch reads/writes so the underlying store is opened
     once per FOV instead of once per timepoint.
     """
-    group_path = _features_group_path(paths, kind, model_name=model_name, ckpt_sha12=ckpt_sha12)
+    group_path = _features_group_path(
+        paths, kind, model_name=model_name, ckpt_sha12=ckpt_sha12, weights_sha12=weights_sha12
+    )
     if mode == "r" and not group_path.exists():
         yield None
         return
@@ -338,6 +350,7 @@ def read_features(
     *,
     model_name: str | None = None,
     ckpt_sha12: str | None = None,
+    weights_sha12: str | None = None,
 ) -> np.ndarray | None:
     """Read cached target-side features for one (position, timepoint).
 
@@ -345,7 +358,9 @@ def read_features(
     :func:`open_features_group` + :func:`read_features_from_group` for
     per-FOV batch reads.
     """
-    with open_features_group(paths, kind, mode="r", model_name=model_name, ckpt_sha12=ckpt_sha12) as group:
+    with open_features_group(
+        paths, kind, mode="r", model_name=model_name, ckpt_sha12=ckpt_sha12, weights_sha12=weights_sha12
+    ) as group:
         if group is None:
             return None
         return read_features_from_group(group, pos_name, t)
@@ -360,6 +375,7 @@ def write_features(
     *,
     model_name: str | None = None,
     ckpt_sha12: str | None = None,
+    weights_sha12: str | None = None,
 ) -> None:
     """Write target-side features for one (position, timepoint).
 
@@ -367,7 +383,9 @@ def write_features(
     :func:`open_features_group` + :func:`write_features_to_group` for
     per-FOV batch writes.
     """
-    with open_features_group(paths, kind, mode="a", model_name=model_name, ckpt_sha12=ckpt_sha12) as group:
+    with open_features_group(
+        paths, kind, mode="a", model_name=model_name, ckpt_sha12=ckpt_sha12, weights_sha12=weights_sha12
+    ) as group:
         write_features_to_group(group, pos_name, t, features)
 
 

--- a/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
+++ b/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
@@ -34,7 +34,7 @@ import numpy as np
 from dynacell.evaluation.feature_select import select_features
 from dynacell.evaluation.linear_probe import MADScaler, paired_auroc
 
-_FEATURE_TYPES = ("cp", "dinov3", "dynaclr")
+_FEATURE_TYPES = ("cp", "dinov3", "dynaclr", "celldino")
 _SOURCES = ("pred", "gt")
 _CONDITION_TOKENS = ("mock", "denv", "zikv")
 _DEFAULT_PAIRS = (("mock", "denv"), ("mock", "zikv"))

--- a/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
+++ b/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
@@ -28,13 +28,15 @@ import argparse
 import csv
 import sys
 from pathlib import Path
+from typing import get_args
 
 import numpy as np
 
+from dynacell.evaluation.cache import FeatureKind
 from dynacell.evaluation.feature_select import select_features
 from dynacell.evaluation.linear_probe import MADScaler, paired_auroc
 
-_FEATURE_TYPES = ("cp", "dinov3", "dynaclr", "celldino")
+_FEATURE_TYPES: tuple[str, ...] = get_args(FeatureKind)
 _SOURCES = ("pred", "gt")
 _CONDITION_TOKENS = ("mock", "denv", "zikv")
 _DEFAULT_PAIRS = (("mock", "denv"), ("mock", "zikv"))

--- a/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
+++ b/applications/dynacell/src/dynacell/evaluation/cross_condition_probe.py
@@ -1,0 +1,233 @@
+"""Cross-condition linear-probe CLI.
+
+Post-hoc diagnostic that runs FOV-stratified logistic-regression probes
+between two infection conditions for each of the three feature spaces
+(CP regionprops, DINOv3, DynaCLR), separately for GT and predicted
+embeddings, on the per-cell ``*_single_cell_embeddings.npz`` artifacts
+emitted by ``dynacell.evaluation.pipeline._save_embeddings``.
+
+Run from the repository root, after at least two per-plate evals have
+finished::
+
+    uv run python -m dynacell.evaluation.cross_condition_probe \\
+        --eval_dirs \\
+            /hpc/projects/.../eval_celldiff_iterative_membrane_mock \\
+            /hpc/projects/.../eval_celldiff_iterative_membrane_denv \\
+            /hpc/projects/.../eval_celldiff_iterative_membrane_zikv \\
+        --out /tmp/cross_condition_probe.csv
+
+The script auto-detects the conditions (mock/denv/zikv) from the eval
+dir's trailing path token. It always emits a CSV with rows for every
+(feature_type × pair × source) combination present in the inputs, and
+NaN AUROC for pairs that don't reach two unique condition labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from dynacell.evaluation.feature_select import select_features
+from dynacell.evaluation.linear_probe import MADScaler, paired_auroc
+
+_FEATURE_TYPES = ("cp", "dinov3", "dynaclr")
+_SOURCES = ("pred", "gt")
+_CONDITION_TOKENS = ("mock", "denv", "zikv")
+_DEFAULT_PAIRS = (("mock", "denv"), ("mock", "zikv"))
+
+
+def _detect_condition(eval_dir: Path) -> str:
+    """Extract ``mock``, ``denv``, or ``zikv`` from the dir name's trailing token."""
+    name = eval_dir.name
+    for token in _CONDITION_TOKENS:
+        if name.endswith(f"_{token}"):
+            return token
+    raise ValueError(f"cannot infer condition from eval_dir name {name!r}: expected trailing _{{mock,denv,zikv}}")
+
+
+def _load_embeddings(eval_dir: Path, source: str, feature: str) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(embeddings, fov_ids)`` from one ``*_single_cell_embeddings.npz``.
+
+    ``np.load`` raises ``FileNotFoundError`` when the NPZ is missing.
+    """
+    npz_path = eval_dir / "embeddings" / f"{source}_{feature}_single_cell_embeddings.npz"
+    with np.load(npz_path) as data:
+        return np.asarray(data["embeddings"]), np.asarray(data["fov"])
+
+
+def _probe_pair(
+    eval_dirs_by_condition: dict[str, Path],
+    pair: tuple[str, str],
+    feature: str,
+    source: str,
+    n_splits: int,
+    rng_seed: int,
+) -> dict:
+    """Run one ``fov_stratified_auroc`` call for the given (pair, feature, source).
+
+    Returns a row dict ready for the CSV writer. NaN row when either
+    side has no embeddings on disk; this is recorded explicitly so the
+    consumer can tell "skipped" from "ran and got noisy result".
+    """
+    c0, c1 = pair
+    row = {
+        "feature_type": feature,
+        "pair": f"{c0}_vs_{c1}",
+        "source": source,
+        "n_cells_c0": 0,
+        "n_cells_c1": 0,
+        "n_fovs": 0,
+        "n_folds": 0,
+        "auroc_mean": float("nan"),
+        "auroc_std": float("nan"),
+        "skipped_reason": "",
+    }
+    if c0 not in eval_dirs_by_condition or c1 not in eval_dirs_by_condition:
+        row["skipped_reason"] = "missing eval dir for one side of pair"
+        return row
+    try:
+        x0, fov0 = _load_embeddings(eval_dirs_by_condition[c0], source, feature)
+        x1, fov1 = _load_embeddings(eval_dirs_by_condition[c1], source, feature)
+    except FileNotFoundError as e:
+        row["skipped_reason"] = f"missing embeddings file: {e}"
+        return row
+    if x0.size == 0 or x1.size == 0:
+        row["skipped_reason"] = "empty embeddings on one side"
+        return row
+    if x0.shape[1] != x1.shape[1]:
+        raise ValueError(f"feature dim mismatch for {feature} {source}: {c0}={x0.shape[1]} vs {c1}={x1.shape[1]}")
+
+    # CP regionprops: variance + correlation prune on the pooled cohort
+    # to drop near-constant or redundant columns. Skipped for deep
+    # embeddings (DINOv3/DynaCLR), which are dense learned features.
+    if feature == "cp":
+        x0, x1, _ = select_features(x0, x1)
+        if x0.size == 0 or x1.size == 0:
+            row["skipped_reason"] = "all CP columns dropped by select_features"
+            return row
+
+    # Per-plate MAD normalization: cancels per-plate intensity offsets
+    # (illumination, exposure, gain) that would otherwise dominate the
+    # classifier — especially on CP regionprops, where raw intensity
+    # columns make different plates trivially separable (AUROC = 1.0).
+    x0_scaled = MADScaler().fit_transform(x0.astype(np.float64))
+    x1_scaled = MADScaler().fit_transform(x1.astype(np.float64))
+    # Tag FOV ids by condition so the two sides cannot collide.
+    fov0_tagged = np.asarray([f"{c0}::{f}" for f in fov0])
+    fov1_tagged = np.asarray([f"{c1}::{f}" for f in fov1])
+    result = paired_auroc(x0_scaled, x1_scaled, fov0_tagged, fov1_tagged, n_splits=n_splits, rng_seed=rng_seed)
+    row.update(
+        {
+            "n_cells_c0": int(len(x0)),
+            "n_cells_c1": int(len(x1)),
+            "n_fovs": int(len(np.unique(fov0_tagged)) + len(np.unique(fov1_tagged))),
+            "n_folds": int(result["n_folds"]),
+            "auroc_mean": float(result["auroc_mean"]),
+            "auroc_std": float(result["auroc_std"]),
+        }
+    )
+    return row
+
+
+def run(
+    eval_dirs: list[Path],
+    out_path: Path,
+    pairs: tuple[tuple[str, str], ...] = _DEFAULT_PAIRS,
+    n_splits: int = 5,
+    rng_seed: int = 2020,
+) -> Path:
+    """Probe each (pair, feature, source) and dump a long-form CSV.
+
+    Parameters
+    ----------
+    eval_dirs : list[Path]
+        Per-plate eval directories (one per condition). The condition
+        is inferred from the dir name's trailing ``_{mock,denv,zikv}``.
+    out_path : Path
+        Output CSV.
+    pairs : sequence[tuple[str, str]]
+        Condition pairs to probe. Defaults to ``(mock,denv)`` + ``(mock,zikv)``.
+    n_splits, rng_seed : int
+        Forwarded to ``fov_stratified_auroc``.
+    """
+    eval_dirs_by_condition: dict[str, Path] = {}
+    for d in eval_dirs:
+        cond = _detect_condition(d)
+        if cond in eval_dirs_by_condition:
+            raise ValueError(f"duplicate condition {cond!r}: {eval_dirs_by_condition[cond]} and {d}")
+        eval_dirs_by_condition[cond] = d
+
+    rows = []
+    for feature in _FEATURE_TYPES:
+        for pair in pairs:
+            for source in _SOURCES:
+                rows.append(_probe_pair(eval_dirs_by_condition, pair, feature, source, n_splits, rng_seed))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "feature_type",
+        "pair",
+        "source",
+        "n_cells_c0",
+        "n_cells_c1",
+        "n_fovs",
+        "n_folds",
+        "auroc_mean",
+        "auroc_std",
+        "skipped_reason",
+    ]
+    with out_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    return out_path
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--eval_dirs",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="per-plate eval directories (2 or 3 of mock/denv/zikv)",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="output CSV path",
+    )
+    ap.add_argument(
+        "--n-splits",
+        type=int,
+        default=5,
+        help="GroupKFold splits (default: 5)",
+    )
+    ap.add_argument(
+        "--rng-seed",
+        type=int,
+        default=2020,
+        help="seed for LogisticRegression tie-breaking (default: 2020)",
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    out = run(
+        args.eval_dirs,
+        args.out,
+        n_splits=args.n_splits,
+        rng_seed=args.rng_seed,
+    )
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
@@ -197,6 +197,17 @@ def compute_feature_similarity(
         Number of bootstrap resamples for Precision / Recall / F1.
     prc_bootstrap_size : int, optional
         Per-resample size; defaults to ``min(n_pred, n_target)``.
+
+    Notes
+    -----
+    Precision / Recall / F1 are bootstrap *means* over resamples drawn
+    with replacement at ``prc_bootstrap_size`` rows per side. At the
+    default ``prc_bootstrap_size == min(n_pred, n_target)``, each draw
+    omits ~37% of unique source rows, so the reported values are
+    systematically lower than the single-shot all-cells PRC computed by
+    the paper script. They are still directly comparable across models /
+    plates / conditions evaluated with the same bootstrap scheme — but
+    do not compare them to non-bootstrap PRC tables.
     mind_num_projections : int
         Number of random projections for MIND.
     rng_seed : int

--- a/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
@@ -1,0 +1,288 @@
+"""Feature-space similarity metrics backed by torch-fidelity.
+
+Replaces the prior in-tree implementations
+(:func:`dynacell.evaluation.utils._frechet_distance`,
+:func:`dynacell.evaluation.utils._polynomial_mmd`,
+:func:`dynacell.evaluation.utils._pairwise_feature_metrics`) with the
+``*_features_to_metric`` helpers from ``torch_fidelity``, plus a
+bootstrap loop around Kynkäänniemi precision / recall so the dataset
+metrics ship mean *and* std for every kernel-based or manifold-based
+quantity. Cosine similarity stays in-tree because torch-fidelity does
+not expose a helper for it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch_fidelity.metric_fid import fid_features_to_statistics, fid_statistics_to_metric
+from torch_fidelity.metric_kid import kid_features_to_metric
+from torch_fidelity.metric_mind import mind_features_to_metric
+from torch_fidelity.metric_prc import prc_features_to_metric
+
+_KID_MIN_SUBSET_SIZE = 16
+
+
+def _median_cosine_similarity(pred: np.ndarray, target: np.ndarray) -> float:
+    """Per-row median cosine similarity between aligned ``(pred, target)``.
+
+    Returns ``nan`` when no row pair has non-zero norms on both sides.
+    """
+    valid_rows = np.isfinite(pred).all(axis=1) & np.isfinite(target).all(axis=1)
+    if not np.any(valid_rows):
+        return float("nan")
+    pred = pred[valid_rows]
+    target = target[valid_rows]
+    numerator = np.einsum("ij,ij->i", pred, target)
+    denominator = np.linalg.norm(pred, axis=1) * np.linalg.norm(target, axis=1)
+    nonzero = denominator > 0
+    if not np.any(nonzero):
+        return float("nan")
+    cos = np.clip(numerator[nonzero] / denominator[nonzero], -1.0, 1.0)
+    return float(np.median(cos))
+
+
+def _to_tensor(x: np.ndarray) -> torch.Tensor:
+    """Wrap a ``(n, d)`` array as a CPU float32 ``torch.Tensor``."""
+    return torch.from_numpy(np.ascontiguousarray(x, dtype=np.float32))
+
+
+def _fid(pred: np.ndarray, target: np.ndarray) -> float:
+    """Frechet distance via torch-fidelity's eigvals-based composition.
+
+    Mirrors the math at ``torch_fidelity.metric_fid.fid_statistics_to_metric``:
+    for symmetric PSD ``Σ₁, Σ₂``, ``Σᵢ √λᵢ(Σ₁·Σ₂) == Tr(sqrt(Σ₁·Σ₂))``.
+    Faster than ``scipy.linalg.sqrtm`` and avoids its convergence warnings.
+    """
+    if pred.shape[0] == 0 or target.shape[0] == 0:
+        return float("nan")
+    stats_pred = fid_features_to_statistics(_to_tensor(pred))
+    stats_target = fid_features_to_statistics(_to_tensor(target))
+    out = fid_statistics_to_metric(stats_pred, stats_target, verbose=False)
+    return float(out["frechet_inception_distance"])
+
+
+def _kid(
+    pred: np.ndarray,
+    target: np.ndarray,
+    kid_subsets: int,
+    kid_subset_size: int,
+    rng_seed: int,
+) -> tuple[float, float]:
+    """KID mean and std with auto-shrunk subset size for small cohorts.
+
+    Returns ``(nan, nan)`` when the effective subset size drops below
+    :data:`_KID_MIN_SUBSET_SIZE` (KID std is uninformative when the
+    library would otherwise resample with replacement-like overlap).
+    """
+    n_pred = pred.shape[0]
+    n_target = target.shape[0]
+    if n_pred == 0 or n_target == 0:
+        return float("nan"), float("nan")
+    effective_size = min(kid_subset_size, n_pred, n_target)
+    if effective_size < _KID_MIN_SUBSET_SIZE:
+        return float("nan"), float("nan")
+    out = kid_features_to_metric(
+        _to_tensor(pred),
+        _to_tensor(target),
+        kid_subsets=kid_subsets,
+        kid_subset_size=effective_size,
+        kid_kernel="poly",
+        rng_seed=rng_seed,
+        verbose=False,
+    )
+    return (
+        float(out["kernel_inception_distance_mean"]),
+        float(out["kernel_inception_distance_std"]),
+    )
+
+
+def _bootstrap_prc(
+    pred: np.ndarray,
+    target: np.ndarray,
+    prc_neighborhood: int,
+    prc_bootstrap_subsets: int,
+    prc_bootstrap_size: int,
+    rng_seed: int,
+) -> tuple[float, float, float, float, float, float]:
+    """Bootstrap Kynkäänniemi precision / recall / F1 means and stds.
+
+    Each iteration draws ``prc_bootstrap_size`` rows with replacement
+    from both ``pred`` and ``target``, rebuilds the k-NN manifolds on
+    those resamples, and calls ``prc_features_to_metric`` (PRC
+    convention: ``features_1=generated, features_2=real``).
+    """
+    rng = np.random.default_rng(rng_seed)
+    precisions = np.empty(prc_bootstrap_subsets, dtype=np.float64)
+    recalls = np.empty(prc_bootstrap_subsets, dtype=np.float64)
+    f_scores = np.empty(prc_bootstrap_subsets, dtype=np.float64)
+    n_pred = pred.shape[0]
+    n_target = target.shape[0]
+    pred_t = _to_tensor(pred)
+    target_t = _to_tensor(target)
+    for b in range(prc_bootstrap_subsets):
+        idx_pred = torch.from_numpy(rng.integers(0, n_pred, size=prc_bootstrap_size))
+        idx_target = torch.from_numpy(rng.integers(0, n_target, size=prc_bootstrap_size))
+        out = prc_features_to_metric(
+            pred_t[idx_pred],
+            target_t[idx_target],
+            prc_neighborhood=prc_neighborhood,
+            verbose=False,
+        )
+        precisions[b] = out["precision"]
+        recalls[b] = out["recall"]
+        f_scores[b] = out["f_score"]
+    return (
+        float(precisions.mean()),
+        float(precisions.std()),
+        float(recalls.mean()),
+        float(recalls.std()),
+        float(f_scores.mean()),
+        float(f_scores.std()),
+    )
+
+
+def _mind(pred: np.ndarray, target: np.ndarray, num_projections: int, rng_seed: int) -> float:
+    """Sliced 2-Wasserstein based MIND from torch-fidelity."""
+    if pred.shape[0] == 0 or target.shape[0] == 0:
+        return float("nan")
+    out = mind_features_to_metric(
+        _to_tensor(pred),
+        _to_tensor(target),
+        mind_num_projections=num_projections,
+        rng_seed=rng_seed,
+        cuda=False,
+        verbose=False,
+    )
+    return float(out["monge_inception_distance"])
+
+
+def compute_feature_similarity(
+    pred: np.ndarray,
+    target: np.ndarray,
+    prefix: str,
+    kid_subsets: int = 100,
+    kid_subset_size: int = 1000,
+    prc_neighborhood: int = 5,
+    prc_bootstrap_subsets: int = 100,
+    prc_bootstrap_size: int | None = None,
+    mind_num_projections: int = 1000,
+    rng_seed: int = 2020,
+) -> dict[str, float]:
+    """Compute dataset-level feature-similarity metrics for one prefix.
+
+    Returns the FID / KID (mean + std) / Precision / Recall / F1 (each
+    mean + bootstrap std) / MIND / median cosine similarity dict keyed
+    by ``f"{prefix}_<METRIC>"``. Empty / single-row inputs return all-NaN.
+
+    Parameters
+    ----------
+    pred : np.ndarray
+        Predicted per-cell features, shape ``(n_pred, d)``. Treated as
+        the "generated" side (``features_1`` in torch-fidelity's PRC
+        convention).
+    target : np.ndarray
+        Ground-truth per-cell features, shape ``(n_target, d)``. Treated
+        as the "real" side (``features_2``).
+    prefix : str
+        Column prefix, e.g. ``"CP"``, ``"DINOv3"``, ``"DynaCLR"``.
+    kid_subsets, kid_subset_size : int
+        Forwarded to ``kid_features_to_metric``; the subset size is
+        auto-shrunk to ``min(kid_subset_size, n_pred, n_target)`` and
+        the metric is NaN'd when the result is below 16.
+    prc_neighborhood : int
+        ``k`` for Kynkäänniemi manifold radii. ``5`` matches the
+        in-repo paper script.
+    prc_bootstrap_subsets : int
+        Number of bootstrap resamples for Precision / Recall / F1.
+    prc_bootstrap_size : int, optional
+        Per-resample size; defaults to ``min(n_pred, n_target)``.
+    mind_num_projections : int
+        Number of random projections for MIND.
+    rng_seed : int
+        Seed shared across KID, PRC bootstrap, and MIND.
+    """
+    keys = (
+        f"{prefix}_FID",
+        f"{prefix}_KID",
+        f"{prefix}_KID_std",
+        f"{prefix}_Precision",
+        f"{prefix}_Precision_std",
+        f"{prefix}_Recall",
+        f"{prefix}_Recall_std",
+        f"{prefix}_F1",
+        f"{prefix}_F1_std",
+        f"{prefix}_MIND",
+        f"{prefix}_Median_Cosine_Similarity",
+    )
+    if pred.size == 0 or target.size == 0:
+        return dict.fromkeys(keys, float("nan"))
+    if pred.shape[1] != target.shape[1]:
+        raise ValueError(f"Feature dim mismatch: pred {pred.shape[1]} vs target {target.shape[1]}")
+
+    pred = np.asarray(pred, dtype=np.float32)
+    target = np.asarray(target, dtype=np.float32)
+
+    fid = _fid(pred, target)
+    kid_mean, kid_std = _kid(pred, target, kid_subsets, kid_subset_size, rng_seed)
+    bootstrap_size = prc_bootstrap_size or min(pred.shape[0], target.shape[0])
+    p_mean, p_std, r_mean, r_std, f_mean, f_std = _bootstrap_prc(
+        pred, target, prc_neighborhood, prc_bootstrap_subsets, bootstrap_size, rng_seed
+    )
+    mind = _mind(pred, target, mind_num_projections, rng_seed)
+    cos = _median_cosine_similarity(pred, target)
+
+    return {
+        f"{prefix}_FID": fid,
+        f"{prefix}_KID": kid_mean,
+        f"{prefix}_KID_std": kid_std,
+        f"{prefix}_Precision": p_mean,
+        f"{prefix}_Precision_std": p_std,
+        f"{prefix}_Recall": r_mean,
+        f"{prefix}_Recall_std": r_std,
+        f"{prefix}_F1": f_mean,
+        f"{prefix}_F1_std": f_std,
+        f"{prefix}_MIND": mind,
+        f"{prefix}_Median_Cosine_Similarity": cos,
+    }
+
+
+def compute_feature_similarity_pairwise(
+    pred: np.ndarray,
+    target: np.ndarray,
+    prefix: str,
+    kid_subsets: int = 100,
+    kid_subset_size: int = 1000,
+    rng_seed: int = 2020,
+) -> dict[str, float]:
+    """Per-(FOV, timepoint) variant: FID, KID mean + std, cosine only.
+
+    PRC and MIND are dataset-level metrics; running them per-timepoint
+    on ~50-cell cohorts is uninformative (the manifold is too sparse
+    and the bootstrap variance dominates). Returns the four-column dict
+    keyed by ``f"{prefix}_<METRIC>"``.
+    """
+    keys = (
+        f"{prefix}_FID",
+        f"{prefix}_KID",
+        f"{prefix}_KID_std",
+        f"{prefix}_Median_Cosine_Similarity",
+    )
+    if pred.size == 0 or target.size == 0:
+        return dict.fromkeys(keys, float("nan"))
+    if pred.shape[1] != target.shape[1]:
+        raise ValueError(f"Feature dim mismatch: pred {pred.shape[1]} vs target {target.shape[1]}")
+
+    pred = np.asarray(pred, dtype=np.float32)
+    target = np.asarray(target, dtype=np.float32)
+
+    fid = _fid(pred, target)
+    kid_mean, kid_std = _kid(pred, target, kid_subsets, kid_subset_size, rng_seed)
+    cos = _median_cosine_similarity(pred, target)
+
+    return {
+        f"{prefix}_FID": fid,
+        f"{prefix}_KID": kid_mean,
+        f"{prefix}_KID_std": kid_std,
+        f"{prefix}_Median_Cosine_Similarity": cos,
+    }

--- a/applications/dynacell/src/dynacell/evaluation/feature_metrics_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_metrics_test.py
@@ -1,0 +1,244 @@
+"""Tests for :mod:`dynacell.evaluation.feature_metrics`.
+
+Runs the real :func:`compute_feature_similarity` / :func:`compute_feature_similarity_pairwise`
+end-to-end with tiny inputs to keep the suite fast.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dynacell.evaluation.feature_metrics import (
+    compute_feature_similarity,
+    compute_feature_similarity_pairwise,
+)
+
+
+def test_identical_inputs_give_zero_distances() -> None:
+    """Same array on both sides -> all distance metrics collapse to ~0, similarities to ~1."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((200, 32)).astype(np.float32)
+
+    result = compute_feature_similarity(
+        x,
+        x,
+        "CP",
+        kid_subsets=20,
+        kid_subset_size=50,
+        prc_bootstrap_subsets=20,
+        mind_num_projections=200,
+    )
+
+    assert result["CP_FID"] == pytest.approx(0.0, abs=1e-4)
+    # KID on identical pools is still nonzero from the bootstrap subset sampling and the
+    # poly-kernel bias term; tolerate up to 0.1 in absolute value (shifted case >> 1).
+    assert abs(result["CP_KID"]) < 0.1
+    assert np.isfinite(result["CP_KID_std"])
+    # PRC with bootstrap resampling-with-replacement on identical pools still drops
+    # ~5-15% of unique rows per draw, so per-bootstrap precision/recall < 1.0; the
+    # bootstrap mean over 20 draws lands around 0.9.
+    assert result["CP_Precision"] > 0.85
+    assert result["CP_Recall"] > 0.85
+    assert result["CP_F1"] > 0.85
+    assert result["CP_MIND"] < 1e-3
+    assert result["CP_Median_Cosine_Similarity"] == pytest.approx(1.0)
+
+
+def test_shifted_distributions_give_nonzero_metrics() -> None:
+    """Mean-shift between pred and target -> nonzero FID/KID/MIND."""
+    rng = np.random.default_rng(0)
+    n, d = 200, 32
+    target = rng.standard_normal((n, d)).astype(np.float32)
+    pred = target + 1.0
+
+    result = compute_feature_similarity(
+        pred,
+        target,
+        "CP",
+        kid_subsets=20,
+        kid_subset_size=50,
+        prc_bootstrap_subsets=20,
+        mind_num_projections=200,
+    )
+
+    assert result["CP_FID"] > 1.0
+    assert result["CP_KID"] > 0.0
+    assert result["CP_KID_std"] > 0.0
+    assert result["CP_MIND"] > 0.0
+
+
+def test_prc_bootstrap_std_is_nonzero() -> None:
+    """Bootstrap actually resamples -> Precision/Recall/F1 std > 0 on non-trivial inputs."""
+    rng = np.random.default_rng(1)
+    n, d = 200, 32
+    target = rng.standard_normal((n, d)).astype(np.float32)
+    pred = target + 0.5 * rng.standard_normal((n, d)).astype(np.float32)
+
+    result = compute_feature_similarity(
+        pred,
+        target,
+        "CP",
+        kid_subsets=20,
+        kid_subset_size=50,
+        prc_bootstrap_subsets=20,
+        mind_num_projections=200,
+    )
+
+    assert result["CP_Precision_std"] > 0.0
+    assert result["CP_Recall_std"] > 0.0
+    assert result["CP_F1_std"] > 0.0
+
+
+def test_prc_asymmetric_high_precision_low_recall() -> None:
+    """Pred covers only one of target's two clusters -> high precision, lower recall.
+
+    Target has two well-separated Gaussian clusters; pred samples only the first.
+    Generated samples land inside the real manifold (high precision) but the second
+    real cluster has no nearby generated points (low recall). Guards against an
+    accidental ``features_1``/``features_2`` swap in the wrapper, which would
+    invert the gap. Row counts are matched so the in-tree median cosine helper
+    (which requires aligned rows) does not crash.
+    """
+    rng = np.random.default_rng(0)
+    cluster_a = rng.standard_normal((100, 8)).astype(np.float32)
+    cluster_b = rng.standard_normal((100, 8)).astype(np.float32) + 5.0
+    target = np.vstack([cluster_a, cluster_b])
+    pred = rng.standard_normal((200, 8)).astype(np.float32)
+
+    result = compute_feature_similarity(
+        pred,
+        target,
+        "CP",
+        prc_bootstrap_subsets=20,
+        kid_subsets=20,
+        kid_subset_size=50,
+        mind_num_projections=100,
+    )
+
+    assert result["CP_Precision"] - result["CP_Recall"] > 0.05
+
+
+def test_kid_small_cohort_returns_nan() -> None:
+    """Effective KID subset < 16 -> KID mean/std NaN, other metrics remain finite."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((10, 8)).astype(np.float32)
+
+    result = compute_feature_similarity(
+        x,
+        x,
+        "CP",
+        kid_subsets=5,
+        kid_subset_size=1000,
+        prc_bootstrap_subsets=5,
+        mind_num_projections=50,
+    )
+
+    assert np.isnan(result["CP_KID"])
+    assert np.isnan(result["CP_KID_std"])
+    assert np.isfinite(result["CP_FID"])
+    assert np.isfinite(result["CP_MIND"])
+    assert np.isfinite(result["CP_Precision"])
+    assert np.isfinite(result["CP_Recall"])
+    assert np.isfinite(result["CP_F1"])
+    assert np.isfinite(result["CP_Median_Cosine_Similarity"])
+
+
+def test_empty_arrays_return_all_nan() -> None:
+    """Empty inputs -> all 11 metric keys present, all NaN."""
+    empty = np.empty((0, 0), dtype=np.float32)
+    result = compute_feature_similarity(empty, empty, "CP")
+
+    expected_keys = {
+        "CP_FID",
+        "CP_KID",
+        "CP_KID_std",
+        "CP_Precision",
+        "CP_Precision_std",
+        "CP_Recall",
+        "CP_Recall_std",
+        "CP_F1",
+        "CP_F1_std",
+        "CP_MIND",
+        "CP_Median_Cosine_Similarity",
+    }
+    assert set(result.keys()) == expected_keys
+    assert np.isnan(np.array(list(result.values()))).all()
+
+
+def test_feature_dim_mismatch_raises() -> None:
+    """Mismatched feature dims -> ValueError."""
+    pred = np.zeros((10, 8), dtype=np.float32)
+    target = np.zeros((10, 4), dtype=np.float32)
+    with pytest.raises(ValueError, match="dim mismatch|Feature dim"):
+        compute_feature_similarity(pred, target, "CP")
+
+
+def test_pairwise_variant_returns_four_metrics() -> None:
+    """Pairwise variant exposes only FID, KID (mean+std), and cosine."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((50, 16)).astype(np.float32)
+
+    result = compute_feature_similarity_pairwise(
+        x,
+        x,
+        "CP",
+        kid_subsets=20,
+        kid_subset_size=20,
+    )
+
+    assert set(result.keys()) == {
+        "CP_FID",
+        "CP_KID",
+        "CP_KID_std",
+        "CP_Median_Cosine_Similarity",
+    }
+    assert result["CP_FID"] == pytest.approx(0.0, abs=1e-4)
+    # KID on identical pools is still nonzero from the bootstrap subset sampling and the
+    # poly-kernel bias term; tolerate the small-subset magnitude.
+    assert abs(result["CP_KID"]) < 0.5
+    assert result["CP_Median_Cosine_Similarity"] == pytest.approx(1.0)
+
+
+def test_pairwise_empty_returns_all_nan() -> None:
+    """Pairwise variant on empty inputs -> 4 NaN keys with the requested prefix."""
+    empty = np.empty((0, 0), dtype=np.float32)
+    result = compute_feature_similarity_pairwise(empty, empty, "DINOv3")
+
+    assert set(result.keys()) == {
+        "DINOv3_FID",
+        "DINOv3_KID",
+        "DINOv3_KID_std",
+        "DINOv3_Median_Cosine_Similarity",
+    }
+    assert np.isnan(np.array(list(result.values()))).all()
+
+
+def test_seed_reproducibility() -> None:
+    """Same seed -> identical PRC means; different seed -> at least one PRC mean differs."""
+    rng = np.random.default_rng(2)
+    n, d = 200, 16
+    target = rng.standard_normal((n, d)).astype(np.float32)
+    pred = target + 0.5 * rng.standard_normal((n, d)).astype(np.float32)
+
+    kwargs = dict(
+        prefix="CP",
+        kid_subsets=20,
+        kid_subset_size=50,
+        prc_bootstrap_subsets=20,
+        mind_num_projections=200,
+    )
+
+    result_a = compute_feature_similarity(pred, target, rng_seed=2020, **kwargs)
+    result_b = compute_feature_similarity(pred, target, rng_seed=2020, **kwargs)
+    result_c = compute_feature_similarity(pred, target, rng_seed=4040, **kwargs)
+
+    assert result_a["CP_Precision"] == result_b["CP_Precision"]
+    assert result_a["CP_Recall"] == result_b["CP_Recall"]
+    assert result_a["CP_F1"] == result_b["CP_F1"]
+
+    assert (
+        result_a["CP_Precision"] != result_c["CP_Precision"]
+        or result_a["CP_Recall"] != result_c["CP_Recall"]
+        or result_a["CP_F1"] != result_c["CP_F1"]
+    )

--- a/applications/dynacell/src/dynacell/evaluation/feature_select.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_select.py
@@ -15,11 +15,19 @@ from __future__ import annotations
 
 import numpy as np
 
+# Defaults shared with downstream consumers (e.g. the cp_selected_feature_mask
+# JSON sidecar emitted by the evaluation pipeline). Keep `select_features`,
+# `variance_threshold`, and `correlation_threshold` keyword defaults aligned
+# with these constants so the sidecar cannot drift from the actual call.
+DEFAULT_FREQ_CUT = 0.05
+DEFAULT_UNIQUE_CUT = 0.01
+DEFAULT_CORR_THRESHOLD = 0.9
+
 
 def variance_threshold(
     X_pooled: np.ndarray,
-    freq_cut: float = 0.05,
-    unique_cut: float = 0.01,
+    freq_cut: float = DEFAULT_FREQ_CUT,
+    unique_cut: float = DEFAULT_UNIQUE_CUT,
 ) -> np.ndarray:
     """Drop near-constant columns.
 
@@ -46,6 +54,13 @@ def variance_threshold(
     np.ndarray
         Boolean keep-mask of shape ``(n_features,)``. ``True`` entries are
         kept.
+
+    Notes
+    -----
+    Iterates columns and calls :func:`numpy.unique` per column —
+    ``O(n_features * n_samples log n_samples)``. Designed for the
+    ~30-column CP regionprops matrix; do not feed deep-feature matrices
+    (1024+ columns) through this without vectorizing first.
     """
     n_samples, n_features = X_pooled.shape
     keep = np.ones(n_features, dtype=bool)
@@ -65,7 +80,7 @@ def variance_threshold(
 
 def correlation_threshold(
     X_pooled: np.ndarray,
-    threshold: float = 0.9,
+    threshold: float = DEFAULT_CORR_THRESHOLD,
     method: str = "pearson",
 ) -> np.ndarray:
     """Greedy iterative drop of correlated columns.
@@ -148,9 +163,9 @@ def correlation_threshold(
 def select_features(
     gt: np.ndarray,
     pred: np.ndarray,
-    freq_cut: float = 0.05,
-    unique_cut: float = 0.01,
-    corr_threshold: float = 0.9,
+    freq_cut: float = DEFAULT_FREQ_CUT,
+    unique_cut: float = DEFAULT_UNIQUE_CUT,
+    corr_threshold: float = DEFAULT_CORR_THRESHOLD,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Pool ``(gt, pred)``, apply both filters in sequence, return filtered pair + mask.
 

--- a/applications/dynacell/src/dynacell/evaluation/feature_select.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_select.py
@@ -1,0 +1,203 @@
+"""Variance + correlation feature pruning for the CP regionprops track.
+
+Vendored from pycytominer (BSD-3); no runtime dep.
+
+The math implemented here is adapted from pycytominer
+(https://github.com/cytomining/pycytominer, BSD-3-Clause).
+
+Notes
+-----
+All functions operate on float64 numpy arrays directly — never DataFrames —
+so they can be used inside tight evaluation loops without pandas overhead.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def variance_threshold(
+    X_pooled: np.ndarray,
+    freq_cut: float = 0.05,
+    unique_cut: float = 0.01,
+) -> np.ndarray:
+    """Drop near-constant columns.
+
+    A column is dropped iff EITHER condition is True:
+
+    - frequency-ratio test: ``count_of_2nd_most_common / count_of_most_common
+      < freq_cut`` (a column whose values cluster on one dominant level is
+      dropped). When the column has only one unique value, ``freq_ratio`` is
+      defined as ``0.0`` and the column is dropped.
+    - uniqueness test: ``n_unique_values / n_samples < unique_cut`` (a column
+      with very few distinct values relative to row count is dropped).
+
+    Parameters
+    ----------
+    X_pooled : np.ndarray
+        Shape ``(n_samples, n_features)``, float64.
+    freq_cut : float, optional
+        Threshold for the frequency-ratio test. Defaults to ``0.05``.
+    unique_cut : float, optional
+        Threshold for the uniqueness test. Defaults to ``0.01``.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean keep-mask of shape ``(n_features,)``. ``True`` entries are
+        kept.
+    """
+    n_samples, n_features = X_pooled.shape
+    keep = np.ones(n_features, dtype=bool)
+    for j in range(n_features):
+        col = X_pooled[:, j]
+        _, counts = np.unique(col, return_counts=True)
+        counts_sorted = np.sort(counts)[::-1]
+        if counts_sorted.size == 1:
+            freq_ratio = 0.0
+        else:
+            freq_ratio = counts_sorted[1] / counts_sorted[0]
+        uniqueness = counts_sorted.size / n_samples
+        if freq_ratio < freq_cut or uniqueness < unique_cut:
+            keep[j] = False
+    return keep
+
+
+def correlation_threshold(
+    X_pooled: np.ndarray,
+    threshold: float = 0.9,
+    method: str = "pearson",
+) -> np.ndarray:
+    """Greedy iterative drop of correlated columns.
+
+    Builds the absolute-Pearson-correlation matrix, walks every pair with
+    ``|corr| > threshold`` in descending ``|corr|`` order, and for each
+    surviving pair drops the column whose total sum of ``|corr|`` with the
+    remaining columns is larger (ties broken by higher column index).
+    NaN correlations (from zero-variance columns) are treated as ``0``.
+
+    Parameters
+    ----------
+    X_pooled : np.ndarray
+        Shape ``(n_samples, n_features)``, float64.
+    threshold : float, optional
+        Absolute-correlation threshold above which a pair is considered
+        redundant. Defaults to ``0.9``.
+    method : str, optional
+        Only ``"pearson"`` is supported. Any other value raises
+        ``ValueError``.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean keep-mask of shape ``(n_features,)``.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is anything other than ``"pearson"``.
+    """
+    if method != "pearson":
+        raise ValueError(f"Only method='pearson' is supported, got method={method!r}.")
+
+    n_features = X_pooled.shape[1]
+    if n_features == 0:
+        return np.ones(0, dtype=bool)
+
+    corr = np.corrcoef(X_pooled, rowvar=False)
+    corr = np.abs(np.nan_to_num(corr, nan=0.0))
+    # corrcoef on a single column returns a 0-d array; promote to 2-d.
+    corr = np.atleast_2d(corr)
+    np.fill_diagonal(corr, 0.0)
+
+    # Collect all (i, j) with i<j and corr[i,j] > threshold, descending by corr.
+    iu, ju = np.triu_indices(n_features, k=1)
+    mask = corr[iu, ju] > threshold
+    pair_i = iu[mask]
+    pair_j = ju[mask]
+    pair_c = corr[pair_i, pair_j]
+    order = np.argsort(-pair_c, kind="stable")
+    pair_i = pair_i[order]
+    pair_j = pair_j[order]
+
+    keep = np.ones(n_features, dtype=bool)
+    for i, j in zip(pair_i, pair_j, strict=False):
+        if not keep[i] or not keep[j]:
+            continue
+        surviving = keep.copy()
+        # Exclude self when summing each candidate's connectivity to survivors.
+        surviving_i = surviving.copy()
+        surviving_i[i] = False
+        surviving_j = surviving.copy()
+        surviving_j[j] = False
+        sum_i = corr[i, surviving_i].sum()
+        sum_j = corr[j, surviving_j].sum()
+        # Use a tolerance: when the two sums are effectively equal (e.g. a lone
+        # correlated pair with no other strong neighbors), fall through to the
+        # higher-index tie-break.
+        if np.isclose(sum_i, sum_j, rtol=1e-5, atol=1e-8):
+            drop = max(i, j)
+        elif sum_i > sum_j:
+            drop = i
+        else:
+            drop = j
+        keep[drop] = False
+    return keep
+
+
+def select_features(
+    gt: np.ndarray,
+    pred: np.ndarray,
+    freq_cut: float = 0.05,
+    unique_cut: float = 0.01,
+    corr_threshold: float = 0.9,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Pool ``(gt, pred)``, apply both filters in sequence, return filtered pair + mask.
+
+    Variance pruning happens first (cheap), correlation pruning second on the
+    survivors.
+
+    Parameters
+    ----------
+    gt : np.ndarray
+        Shape ``(n_gt, n_features)``, float64.
+    pred : np.ndarray
+        Shape ``(n_pred, n_features)``, float64.
+    freq_cut : float, optional
+        Forwarded to :func:`variance_threshold`. Defaults to ``0.05``.
+    unique_cut : float, optional
+        Forwarded to :func:`variance_threshold`. Defaults to ``0.01``.
+    corr_threshold : float, optional
+        Forwarded to :func:`correlation_threshold`. Defaults to ``0.9``.
+
+    Returns
+    -------
+    gt_filtered : np.ndarray
+        Shape ``(n_gt, n_kept)``.
+    pred_filtered : np.ndarray
+        Shape ``(n_pred, n_kept)``.
+    keep_mask : np.ndarray
+        Boolean mask of shape ``(n_features,)``. Composition of variance +
+        correlation pruning.
+
+    Raises
+    ------
+    ValueError
+        If ``gt`` and ``pred`` disagree on the feature dimension.
+    """
+    if gt.shape[1] != pred.shape[1]:
+        raise ValueError(f"feature dim mismatch: gt.shape[1]={gt.shape[1]} vs pred.shape[1]={pred.shape[1]}.")
+
+    n_features = gt.shape[1]
+    pooled = np.vstack([gt, pred])
+
+    mask_var = variance_threshold(pooled, freq_cut=freq_cut, unique_cut=unique_cut)
+    pooled2 = pooled[:, mask_var]
+
+    mask_corr_local = correlation_threshold(pooled2, threshold=corr_threshold, method="pearson")
+
+    keep_mask = np.zeros(n_features, dtype=bool)
+    var_indices = np.flatnonzero(mask_var)
+    keep_mask[var_indices[mask_corr_local]] = True
+
+    return gt[:, keep_mask], pred[:, keep_mask], keep_mask

--- a/applications/dynacell/src/dynacell/evaluation/feature_select_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_select_test.py
@@ -1,0 +1,160 @@
+"""Tests for :mod:`dynacell.evaluation.feature_select`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dynacell.evaluation.feature_select import (
+    correlation_threshold,
+    select_features,
+    variance_threshold,
+)
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """Seeded numpy generator for reproducible tests."""
+    return np.random.default_rng(42)
+
+
+def test_variance_threshold_drops_constant_and_near_constant(
+    rng: np.random.Generator,
+) -> None:
+    n_samples = 100
+    n_features = 12
+    X = rng.standard_normal((n_samples, n_features)).astype(np.float64)
+    # Column 0: constant.
+    X[:, 0] = 0.0
+    # Column 1: 99% zeros + 1% unique-noise → uniqueness ~ 2/100 = 0.02
+    # but freq_ratio = 1/99 < 0.05, so dropped.
+    X[:, 1] = 0.0
+    X[0, 1] = 1.23
+
+    keep = variance_threshold(X, freq_cut=0.05, unique_cut=0.01)
+
+    assert keep.dtype == bool
+    assert keep.shape == (n_features,)
+    assert not keep[0]
+    assert not keep[1]
+    assert keep[2:].all()
+
+
+def test_variance_threshold_freq_ratio() -> None:
+    # Case A: drop. counts = [95, 4, 1] → freq_ratio = 4/95 < 0.05.
+    col_a = np.array([0.0] * 95 + [1.0] * 4 + [2.0] * 1)
+    X_a = col_a.reshape(-1, 1)
+    keep_a = variance_threshold(X_a, freq_cut=0.05, unique_cut=0.01)
+    assert not keep_a[0]
+
+    # Case B: keep. counts = [80, 15, 5] → freq_ratio = 15/80 = 0.1875 > 0.05,
+    # uniqueness = 3/100 = 0.03 > 0.01.
+    col_b = np.array([0.0] * 80 + [1.0] * 15 + [2.0] * 5)
+    X_b = col_b.reshape(-1, 1)
+    keep_b = variance_threshold(X_b, freq_cut=0.05, unique_cut=0.01)
+    assert keep_b[0]
+
+
+def test_correlation_threshold_drops_redundant(
+    rng: np.random.Generator,
+) -> None:
+    n_samples = 200
+    X = rng.standard_normal((n_samples, 5)).astype(np.float64)
+    # Make col 3 a near-clone of col 1.
+    X[:, 3] = X[:, 1] + 1e-4 * rng.standard_normal(n_samples)
+
+    keep = correlation_threshold(X, threshold=0.9, method="pearson")
+
+    assert keep.dtype == bool
+    assert keep.shape == (5,)
+    # The redundant pair is {1, 3}; with the tie-break rule the higher index
+    # drops.
+    assert not keep[3]
+    assert keep[0]
+    assert keep[1]
+    assert keep[2]
+    assert keep[4]
+
+
+def test_correlation_threshold_threshold_respected(
+    rng: np.random.Generator,
+) -> None:
+    n_samples = 200
+    X = rng.standard_normal((n_samples, 5)).astype(np.float64)
+    X[:, 3] = X[:, 1] + 1e-4 * rng.standard_normal(n_samples)
+
+    keep = correlation_threshold(X, threshold=0.999999, method="pearson")
+
+    # corr(col1, col3) ≈ 0.9999..., below the threshold of 0.999999 in expectation;
+    # but to be robust, we check that at most one column is dropped.
+    # The intent of the test is "raise threshold → nothing drops"; this is a
+    # softer assertion that tolerates floating-point noise.
+    assert keep.sum() >= 4
+
+
+def test_correlation_threshold_rejects_unsupported_method(
+    rng: np.random.Generator,
+) -> None:
+    X = rng.standard_normal((20, 3)).astype(np.float64)
+    with pytest.raises(ValueError):
+        correlation_threshold(X, threshold=0.9, method="spearman")
+
+
+def test_select_features_applies_both_filters(
+    rng: np.random.Generator,
+) -> None:
+    # features: [constant, A, A+ε, B]
+    n_gt = 60
+    n_pred = 60
+    n_total = n_gt + n_pred
+
+    a = rng.standard_normal(n_total).astype(np.float64)
+    b = rng.standard_normal(n_total).astype(np.float64)
+    eps = 1e-4 * rng.standard_normal(n_total).astype(np.float64)
+
+    pooled = np.column_stack(
+        [
+            np.zeros(n_total),  # feature 0: constant
+            a,  # feature 1: A
+            a + eps,  # feature 2: A + ε
+            b,  # feature 3: independent
+        ]
+    )
+
+    gt = pooled[:n_gt]
+    pred = pooled[n_gt:]
+
+    gt_f, pred_f, keep_mask = select_features(gt, pred, freq_cut=0.05, unique_cut=0.01, corr_threshold=0.9)
+
+    assert keep_mask.dtype == bool
+    assert keep_mask.shape == (4,)
+    # Feature 0 dropped by variance pruning.
+    assert not keep_mask[0]
+    # Feature 3 always kept (independent).
+    assert keep_mask[3]
+    # Exactly one of {1, 2} survives the correlation pruning.
+    assert keep_mask[1] ^ keep_mask[2]
+    assert keep_mask.sum() == 2
+    assert gt_f.shape == (n_gt, 2)
+    assert pred_f.shape == (n_pred, 2)
+
+
+def test_select_features_shape_mismatch_raises(
+    rng: np.random.Generator,
+) -> None:
+    gt = rng.standard_normal((10, 5)).astype(np.float64)
+    pred = rng.standard_normal((10, 6)).astype(np.float64)
+    with pytest.raises(ValueError, match="dim mismatch|shape"):
+        select_features(gt, pred)
+
+
+def test_select_features_returns_aligned_filtered_arrays(
+    rng: np.random.Generator,
+) -> None:
+    gt = rng.standard_normal((30, 8)).astype(np.float64)
+    pred = rng.standard_normal((25, 8)).astype(np.float64)
+    gt_f, pred_f, keep_mask = select_features(gt, pred)
+
+    assert gt_f.shape[0] == 30
+    assert pred_f.shape[0] == 25
+    assert gt_f.shape[1] == pred_f.shape[1] == int(keep_mask.sum())

--- a/applications/dynacell/src/dynacell/evaluation/linear_probe.py
+++ b/applications/dynacell/src/dynacell/evaluation/linear_probe.py
@@ -1,0 +1,201 @@
+"""FOV-stratified linear-probe diagnostics for per-cell embeddings."""
+
+import warnings
+
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import GroupKFold
+from sklearn.pipeline import Pipeline
+
+
+class MADScaler(BaseEstimator, TransformerMixin):
+    """Median-absolute-deviation scaler.
+
+    For each column j: x_scaled = (x - median_j) / (mad_j + eps), with
+    mad_j = median(|x_j - median_j|). This is the user's specified
+    "robustMAD" normalization — NOT sklearn's RobustScaler (which uses
+    IQR = Q3 - Q1).
+    """
+
+    def fit(self, X, y=None):
+        """Compute per-column median and MAD.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Feature matrix of shape (n_samples, n_features).
+        y : None
+            Ignored. Present for sklearn compatibility.
+
+        Returns
+        -------
+        self : MADScaler
+            Fitted scaler.
+        """
+        self.median_ = np.median(X, axis=0)
+        self.mad_ = np.median(np.abs(X - self.median_), axis=0)
+        return self
+
+    def transform(self, X):
+        """Apply MAD normalization using fitted statistics.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Feature matrix of shape (n_samples, n_features).
+
+        Returns
+        -------
+        np.ndarray
+            Scaled feature matrix with the same shape as ``X``.
+        """
+        return (X - self.median_) / (self.mad_ + 1e-12)
+
+
+def indistinguishability(auroc: float) -> float:
+    """Map an AUROC to an indistinguishability score in [0, 1].
+
+    The score is ``1 - 2 * |AUROC - 0.5|``. Higher values indicate that
+    the two classes are less distinguishable. AUROC of 0.5 (chance)
+    maps to 1.0; AUROC of 0.0 or 1.0 (perfectly separable) maps to 0.0.
+
+    Parameters
+    ----------
+    auroc : float
+        Area under the ROC curve.
+
+    Returns
+    -------
+    float
+        Indistinguishability score in [0, 1].
+    """
+    return 1.0 - 2.0 * abs(auroc - 0.5)
+
+
+def fov_stratified_auroc(
+    X: np.ndarray,
+    y: np.ndarray,
+    fov_id: np.ndarray,
+    n_splits: int = 5,
+    rng_seed: int = 2020,
+) -> dict:
+    """FOV-stratified linear-probe AUROC.
+
+    Pipeline = ``MADScaler() + LogisticRegression(max_iter=2000,
+    class_weight='balanced', random_state=rng_seed)``. Fits inside CV
+    so the scaler is trained only on the fold's training cells —
+    no leakage from val FOV statistics into normalization.
+
+    Splitting uses :class:`sklearn.model_selection.GroupKFold` with
+    ``groups=fov_id``. Each fold's val set contains entire FOVs absent
+    from train. When ``n_unique_fovs < n_splits``, falls back to
+    ``GroupKFold(n_unique_fovs)``; when the result is fewer than 2
+    folds, returns ``auroc_std=NaN``.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Feature matrix of shape (n_cells, n_features).
+    y : np.ndarray
+        Binary labels of shape (n_cells,) with values in {0, 1}.
+    fov_id : np.ndarray
+        FOV identifier of shape (n_cells,); any hashable dtype.
+    n_splits : int, optional
+        Requested number of CV folds, by default 5.
+    rng_seed : int, optional
+        Random state for the logistic regression, by default 2020.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``auroc_mean``, ``auroc_std``, and
+        ``n_folds``.
+    """
+    n_unique = len(np.unique(fov_id))
+    effective_splits = min(n_splits, n_unique)
+
+    if effective_splits < 2:
+        warnings.warn(
+            f"Only {n_unique} unique FOV(s); need >=2 to run GroupKFold. Returning NaN.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return {
+            "auroc_mean": float("nan"),
+            "auroc_std": float("nan"),
+            "n_folds": effective_splits,
+        }
+
+    pipeline = Pipeline(
+        [
+            ("scaler", MADScaler()),
+            (
+                "clf",
+                LogisticRegression(
+                    max_iter=2000,
+                    class_weight="balanced",
+                    random_state=rng_seed,
+                ),
+            ),
+        ]
+    )
+
+    splitter = GroupKFold(n_splits=effective_splits)
+    aurocs: list[float] = []
+
+    for train_idx, val_idx in splitter.split(X, y, groups=fov_id):
+        y_val = y[val_idx]
+        if len(np.unique(y_val)) < 2:
+            warnings.warn(
+                "Skipping fold with only one class in validation set.",
+                UserWarning,
+                stacklevel=2,
+            )
+            continue
+        pipeline.fit(X[train_idx], y[train_idx])
+        proba = pipeline.predict_proba(X[val_idx])[:, 1]
+        aurocs.append(roc_auc_score(y_val, proba))
+
+    if len(aurocs) == 0:
+        return {
+            "auroc_mean": float("nan"),
+            "auroc_std": float("nan"),
+            "n_folds": effective_splits,
+        }
+
+    auroc_mean = float(np.mean(aurocs))
+    auroc_std = float(np.std(aurocs)) if len(aurocs) >= 2 else float("nan")
+
+    return {
+        "auroc_mean": auroc_mean,
+        "auroc_std": auroc_std,
+        "n_folds": effective_splits,
+    }
+
+
+def paired_auroc(
+    x_a: np.ndarray,
+    x_b: np.ndarray,
+    fov_a: np.ndarray,
+    fov_b: np.ndarray,
+    n_splits: int = 5,
+    rng_seed: int = 2020,
+) -> dict:
+    """FOV-stratified binary probe on two stacked cohorts.
+
+    Builds ``X = vstack([x_a, x_b])``, ``y = [0…, 1…]``, and
+    ``fov_id = concat([fov_a, fov_b])``, then delegates to
+    :func:`fov_stratified_auroc`. Callers add their own column prefix
+    when mapping the result back into a metrics row.
+
+    Returns the same dict as :func:`fov_stratified_auroc`, or an
+    all-NaN result with ``n_folds=0`` when either side is empty.
+    """
+    if x_a.size == 0 or x_b.size == 0:
+        return {"auroc_mean": float("nan"), "auroc_std": float("nan"), "n_folds": 0}
+    X = np.vstack([x_a, x_b])
+    y = np.concatenate([np.zeros(len(x_a), dtype=np.int8), np.ones(len(x_b), dtype=np.int8)])
+    fov_ids = np.concatenate([fov_a, fov_b])
+    return fov_stratified_auroc(X, y, fov_ids, n_splits=n_splits, rng_seed=rng_seed)

--- a/applications/dynacell/src/dynacell/evaluation/linear_probe_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/linear_probe_test.py
@@ -1,0 +1,130 @@
+"""Tests for FOV-stratified linear-probe diagnostics."""
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+
+from dynacell.evaluation.linear_probe import (
+    MADScaler,
+    fov_stratified_auroc,
+    indistinguishability,
+)
+
+
+def test_indistinguishability_corner_values():
+    assert indistinguishability(0.0) == pytest.approx(0.0)
+    assert indistinguishability(0.25) == pytest.approx(0.5)
+    assert indistinguishability(0.5) == pytest.approx(1.0)
+    assert indistinguishability(0.75) == pytest.approx(0.5)
+    assert indistinguishability(1.0) == pytest.approx(0.0)
+
+
+def test_madscaler_fit_transform_shape():
+    rng = np.random.default_rng(2020)
+    X = rng.normal(size=(50, 4))
+    scaler = MADScaler()
+    Xt = scaler.fit(X).transform(X)
+    assert Xt.shape == X.shape
+    # After transform with statistics fit on the same data, per-column
+    # median should be ~0.
+    np.testing.assert_allclose(np.median(Xt, axis=0), np.zeros(4), atol=1e-10)
+
+
+def test_madscaler_handles_zero_mad():
+    # Constant column has MAD=0; eps guard prevents division-by-zero.
+    X = np.column_stack([np.ones(20), np.arange(20).astype(float)])
+    scaler = MADScaler()
+    Xt = scaler.fit(X).transform(X)
+    assert np.all(np.isfinite(Xt))
+
+
+def test_madscaler_is_sklearn_compatible():
+    rng = np.random.default_rng(2020)
+    X = rng.normal(size=(60, 3))
+    y = (X[:, 0] > 0).astype(int)
+    pipeline = Pipeline(
+        [
+            ("scaler", MADScaler()),
+            ("clf", LogisticRegression(max_iter=500)),
+        ]
+    )
+    pipeline.fit(X, y)
+    preds = pipeline.predict(X)
+    assert preds.shape == y.shape
+    proba = pipeline.predict_proba(X)
+    assert proba.shape == (60, 2)
+
+
+def test_fov_stratified_auroc_no_leak():
+    rng = np.random.default_rng(2020)
+    n_cells = 200
+    n_fovs = 10
+    # Assign cells to FOVs evenly.
+    fov_id = np.repeat(np.arange(n_fovs), n_cells // n_fovs)
+    # Column 0: small global signal correlated with y.
+    col0 = rng.normal(size=n_cells)
+    y = (col0 > 0).astype(int)
+    # Add noise to col0 so the signal is weak but present.
+    col0_noisy = col0 + rng.normal(scale=1.5, size=n_cells)
+    # Column 1: per-FOV constant (different value per FOV); no signal across
+    # FOVs. A leaky pipeline would memorize FOV identity from col 1.
+    fov_constants = rng.normal(size=n_fovs) * 10.0
+    col1 = fov_constants[fov_id]
+    X = np.column_stack([col0_noisy, col1])
+
+    result = fov_stratified_auroc(X, y, fov_id, n_splits=5, rng_seed=2020)
+    assert result["n_folds"] == 5
+    assert 0.55 < result["auroc_mean"] < 0.90
+    assert result["auroc_std"] > 0
+
+
+def test_fov_stratified_auroc_small_fov_fallback():
+    rng = np.random.default_rng(2020)
+    n_cells = 60
+    # Only 3 unique FOV ids.
+    fov_id = np.repeat(np.arange(3), n_cells // 3)
+    X = rng.normal(size=(n_cells, 4))
+    # Make y depend on X so AUROC is finite.
+    y = (X[:, 0] > 0).astype(int)
+    result = fov_stratified_auroc(X, y, fov_id, n_splits=5, rng_seed=2020)
+    assert result["n_folds"] == 3
+    assert np.isfinite(result["auroc_mean"])
+
+
+def test_fov_stratified_auroc_single_fov_returns_nan():
+    rng = np.random.default_rng(2020)
+    n_cells = 40
+    fov_id = np.zeros(n_cells, dtype=int)
+    X = rng.normal(size=(n_cells, 3))
+    y = (X[:, 0] > 0).astype(int)
+    with pytest.warns(UserWarning):
+        result = fov_stratified_auroc(X, y, fov_id, n_splits=5, rng_seed=2020)
+    assert np.isnan(result["auroc_mean"])
+    assert np.isnan(result["auroc_std"])
+    assert result["n_folds"] == 1
+
+
+def test_fov_stratified_auroc_degenerate_fold_skipped():
+    rng = np.random.default_rng(2020)
+    n_cells = 40
+    # 2 unique FOVs; all cells in FOV 0 are class 0, all in FOV 1 are class 1.
+    fov_id = np.repeat(np.arange(2), n_cells // 2)
+    y = fov_id.copy()
+    X = rng.normal(size=(n_cells, 3))
+    with pytest.warns(UserWarning):
+        result = fov_stratified_auroc(X, y, fov_id, n_splits=2, rng_seed=2020)
+    assert np.isnan(result["auroc_mean"])
+
+
+def test_fov_stratified_auroc_end_to_end_signal_present():
+    rng = np.random.default_rng(2020)
+    n_cells = 400
+    n_fovs = 20
+    fov_id = rng.integers(0, n_fovs, size=n_cells)
+    # Strong feature-0 signal correlated with y.
+    col0 = rng.normal(size=n_cells)
+    y = (col0 > 0).astype(int)
+    X = np.column_stack([col0, rng.normal(size=(n_cells, 3))])
+    result = fov_stratified_auroc(X, y, fov_id, n_splits=5, rng_seed=2020)
+    assert result["auroc_mean"] > 0.75

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -367,6 +367,13 @@ def features_from_crops(crops, feature_extractor):
     batch path lets each extractor stack all cells of a (FOV, t) into a
     single forward, amortizing Python overhead and letting cuDNN pick
     wider kernels.
+
+    Extractor contract
+    ------------------
+    Both code paths require the extractor to return a ``torch.Tensor``
+    (``.detach().cpu()`` is called on the result). ``extract_features``
+    must return one tensor per crop; ``extract_features_batch`` must
+    return a stacked tensor whose leading dim equals ``len(crops)``.
     """
     if not crops:
         return np.empty((0, 0), dtype=np.float32)

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -21,7 +21,7 @@ except ImportError:
     spectral_pcc = None  # type: ignore[assignment]
 
 from dynacell.evaluation.torch_ssim import ssim as torch_ssim
-from dynacell.evaluation.utils import _frechet_distance, _minmax_norm, _pairwise_feature_metrics, _polynomial_mmd
+from dynacell.evaluation.utils import _minmax_norm
 
 
 def _require_microssim():
@@ -64,6 +64,7 @@ def _normalize_to_target_scale(
 
     return (y_true - target_min) / denom, (y_pred - target_min) / denom
 
+
 @torch.inference_mode()
 def _min_max_normalize(
     x: torch.Tensor,
@@ -75,6 +76,7 @@ def _min_max_normalize(
     x = (x - x.min()) / torch.clamp(x.max() - x.min(), min=eps)
 
     return x
+
 
 @torch.inference_mode()
 def corr_coef(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -324,27 +326,6 @@ def cp_pred_regionprops(prediction, cell_segmentation, spacing):
     return _cp_raw_regionprops(_minmax_norm(prediction), cell_segmentation, spacing)
 
 
-def cp_pairwise(pred_raw, target_raw):
-    """Pair raw CP regionprops into CP_FID / CP_KID / CP_Median_Cosine_Similarity.
-
-    Applies the target-side all-zero column drop and per-matrix z-score that
-    the original monolithic ``cp_feature_similarity`` applied, then delegates
-    to :func:`_pairwise_feature_metrics`. Returns NaN metrics for empty inputs.
-    """
-    if pred_raw.shape != target_raw.shape:
-        raise ValueError(f"Feature shape mismatch: pred {pred_raw.shape} vs target {target_raw.shape}")
-    if pred_raw.size == 0:
-        return _nan_pairwise("CP")
-    non_zero_cols = ~np.all(target_raw == 0, axis=0)
-    pred_mat = pred_raw[:, non_zero_cols]
-    target_mat = target_raw[:, non_zero_cols]
-    pred_mat = (pred_mat - pred_mat.mean(axis=0)) / (pred_mat.std(axis=0) + 1e-8)
-    target_mat = (target_mat - target_mat.mean(axis=0)) / (target_mat.std(axis=0) + 1e-8)
-    if pred_mat.size == 0:
-        return _nan_pairwise("CP")
-    return _pairwise_feature_metrics(pred_mat, target_mat, "CP")
-
-
 def _extract_per_cell_features(img_2d, cell_segmentation_3d, feature_extractor, patch_size):
     """Iterate cells in the shared 3-D segmentation and extract 2-D per-cell features.
 
@@ -400,61 +381,3 @@ def deep_pred_features(prediction, cell_segmentation, feature_extractor, patch_s
         )
     prediction_2d = _minmax_norm(np.max(prediction, axis=0))
     return _extract_per_cell_features(prediction_2d, cell_segmentation, feature_extractor, patch_size)
-
-
-def deep_pairwise(pred_feats, target_feats, name):
-    """Pair per-cell deep features into ``{name}_FID`` / ``_KID`` / ``_Median_Cosine_Similarity``.
-
-    Empty inputs (no cells) produce NaN metrics.
-    """
-    if name not in ("DINOv3", "DynaCLR"):
-        raise ValueError(f"Unsupported feature extractor: {name}")
-    if pred_feats.shape != target_feats.shape:
-        raise ValueError(f"Feature shape mismatch: pred {pred_feats.shape} vs target {target_feats.shape}")
-    if pred_feats.size == 0:
-        return _nan_pairwise(name)
-    return _pairwise_feature_metrics(pred_feats, target_feats, name)
-
-
-def _nan_pairwise(name):
-    """Return a dict of NaN placeholders matching the pairwise-metrics schema."""
-    return {
-        f"{name}_Median_Cosine_Similarity": float("nan"),
-        f"{name}_FID": float("nan"),
-        f"{name}_KID": float("nan"),
-    }
-
-
-def cp_dataset_fid_kid(pred_raw_all: list[np.ndarray], target_raw_all: list[np.ndarray]) -> dict[str, float]:
-    """FID and KID for CP features pooled across the full dataset."""
-    if not pred_raw_all:
-        return {"CP_FID": float("nan"), "CP_KID": float("nan")}
-    pred_raw = np.concatenate(pred_raw_all, axis=0)
-    target_raw = np.concatenate(target_raw_all, axis=0)
-    non_zero_cols = ~np.all(target_raw == 0, axis=0)
-    pred_mat = pred_raw[:, non_zero_cols]
-    target_mat = target_raw[:, non_zero_cols]
-    if pred_mat.size == 0:
-        return {"CP_FID": float("nan"), "CP_KID": float("nan")}
-    pred_mat = (pred_mat - pred_mat.mean(axis=0)) / (pred_mat.std(axis=0) + 1e-8)
-    target_mat = (target_mat - target_mat.mean(axis=0)) / (target_mat.std(axis=0) + 1e-8)
-    return {
-        "CP_FID": _frechet_distance(pred_mat, target_mat),
-        "CP_KID": _polynomial_mmd(pred_mat, target_mat),
-    }
-
-
-def deep_dataset_fid_kid(
-    pred_feats_all: list[np.ndarray], target_feats_all: list[np.ndarray], name: str
-) -> dict[str, float]:
-    """FID and KID for deep embeddings pooled across the full dataset."""
-    if name not in ("DINOv3", "DynaCLR"):
-        raise ValueError(f"Unsupported feature extractor: {name}")
-    if not pred_feats_all:
-        return {f"{name}_FID": float("nan"), f"{name}_KID": float("nan")}
-    pred_feats = np.concatenate(pred_feats_all, axis=0)
-    target_feats = np.concatenate(target_feats_all, axis=0)
-    return {
-        f"{name}_FID": _frechet_distance(pred_feats, target_feats),
-        f"{name}_KID": _polynomial_mmd(pred_feats, target_feats),
-    }

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -326,14 +326,14 @@ def cp_pred_regionprops(prediction, cell_segmentation, spacing):
     return _cp_raw_regionprops(_minmax_norm(prediction), cell_segmentation, spacing)
 
 
-def _extract_per_cell_features(img_2d, cell_segmentation_3d, feature_extractor, patch_size):
-    """Iterate cells in the shared 3-D segmentation and extract 2-D per-cell features.
+def _build_per_cell_crops_2d(img_2d, cell_segmentation_3d, patch_size):
+    """Build per-cell masked 2-D crops shared across deep-feature extractors.
 
     Iteration order is ``np.unique(cell_segmentation_3d)`` with the
-    background label ``0`` skipped. Both GT and prediction loops use the
-    same segmentation, so their returned arrays align row-by-row.
+    background label ``0`` skipped. The result is a list of
+    ``(patch_size, patch_size)`` arrays, one per non-background cell.
     """
-    feats = []
+    crops: list[np.ndarray] = []
     for idx in np.unique(cell_segmentation_3d):
         if idx == 0:
             continue
@@ -355,29 +355,68 @@ def _extract_per_cell_features(img_2d, cell_segmentation_3d, feature_extractor, 
         if pad_y_before or pad_y_after or pad_x_before or pad_x_after:
             pad = ((pad_y_before, pad_y_after), (pad_x_before, pad_x_after))
             cell_crop = np.pad(cell_crop, pad, mode="constant")
-        feat = feature_extractor.extract_features(cell_crop).detach().cpu().numpy().reshape(-1)
-        feats.append(feat)
-    if not feats:
+        crops.append(cell_crop)
+    return crops
+
+
+def features_from_crops(crops, feature_extractor):
+    """Run a deep-feature extractor over a list of masked 2-D crops.
+
+    Uses ``feature_extractor.extract_features_batch(crops)`` when the
+    extractor provides it; otherwise falls back to per-cell calls. The
+    batch path lets each extractor stack all cells of a (FOV, t) into a
+    single forward, amortizing Python overhead and letting cuDNN pick
+    wider kernels.
+    """
+    if not crops:
         return np.empty((0, 0), dtype=np.float32)
+    batch_fn = getattr(feature_extractor, "extract_features_batch", None)
+    if batch_fn is not None:
+        out = batch_fn(crops)
+        return np.asarray(out.detach().cpu()).reshape(len(crops), -1).astype(np.float32, copy=False)
+    feats = [feature_extractor.extract_features(c).detach().cpu().numpy().reshape(-1) for c in crops]
     return np.stack(feats, axis=0)
+
+
+def build_pred_crops(prediction, cell_segmentation, patch_size):
+    """Compute the 2-D max-z projection + per-cell crops on the prediction side.
+
+    Shared by every deep-feature extractor in the eval pipeline so the
+    max-projection, cell iteration, and crop construction run once per
+    (FOV, timepoint) instead of once per backbone.
+    """
+    if prediction.shape != cell_segmentation.shape:
+        raise ValueError(
+            f"Shape mismatch: prediction {prediction.shape} vs cell_segmentation {cell_segmentation.shape}"
+        )
+    prediction_2d = _minmax_norm(np.max(prediction, axis=0))
+    return _build_per_cell_crops_2d(prediction_2d, cell_segmentation, patch_size)
+
+
+def build_target_crops(target, cell_segmentation, patch_size):
+    """Compute the 2-D max-z projection + per-cell crops on the GT side."""
+    if target.shape != cell_segmentation.shape:
+        raise ValueError(f"Shape mismatch: target {target.shape} vs cell_segmentation {cell_segmentation.shape}")
+    target_2d = _minmax_norm(np.max(target, axis=0))
+    return _build_per_cell_crops_2d(target_2d, cell_segmentation, patch_size)
 
 
 def deep_target_features(target, cell_segmentation, feature_extractor, patch_size):
     """GT-side per-cell deep embeddings, shape ``(n_cells, feature_dim)``.
 
     Cacheable per ``(gt_path, cell_segmentation_path, patch_size, feature_extractor_identity)``.
+    Backward-compat wrapper: prefer :func:`build_target_crops` +
+    :func:`features_from_crops` when the same crops feed multiple extractors.
     """
-    if target.shape != cell_segmentation.shape:
-        raise ValueError(f"Shape mismatch: target {target.shape} vs cell_segmentation {cell_segmentation.shape}")
-    target_2d = _minmax_norm(np.max(target, axis=0))
-    return _extract_per_cell_features(target_2d, cell_segmentation, feature_extractor, patch_size)
+    crops = build_target_crops(target, cell_segmentation, patch_size)
+    return features_from_crops(crops, feature_extractor)
 
 
 def deep_pred_features(prediction, cell_segmentation, feature_extractor, patch_size):
-    """Prediction-side per-cell deep embeddings, shape ``(n_cells, feature_dim)``."""
-    if prediction.shape != cell_segmentation.shape:
-        raise ValueError(
-            f"Shape mismatch: prediction {prediction.shape} vs cell_segmentation {cell_segmentation.shape}"
-        )
-    prediction_2d = _minmax_norm(np.max(prediction, axis=0))
-    return _extract_per_cell_features(prediction_2d, cell_segmentation, feature_extractor, patch_size)
+    """Prediction-side per-cell deep embeddings, shape ``(n_cells, feature_dim)``.
+
+    Backward-compat wrapper: prefer :func:`build_pred_crops` +
+    :func:`features_from_crops` when the same crops feed multiple extractors.
+    """
+    crops = build_pred_crops(prediction, cell_segmentation, patch_size)
+    return features_from_crops(crops, feature_extractor)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1,5 +1,7 @@
 """Batch orchestration: load, segment, evaluate, save."""
 
+import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import hydra
@@ -10,14 +12,16 @@ from omegaconf import DictConfig
 from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
+from dynacell.evaluation.feature_metrics import (
+    compute_feature_similarity,
+    compute_feature_similarity_pairwise,
+)
+from dynacell.evaluation.feature_select import select_features
+from dynacell.evaluation.linear_probe import indistinguishability, paired_auroc
 from dynacell.evaluation.metrics import (
     calculate_microssim,
     compute_pixel_metrics,
-    cp_dataset_fid_kid,
-    cp_pairwise,
     cp_pred_regionprops,
-    deep_dataset_fid_kid,
-    deep_pairwise,
     deep_pred_features,
     evaluate_segmentations,
 )
@@ -30,6 +34,45 @@ from dynacell.evaluation.pipeline_cache import (
     resolve_dynaclr_encoder_cfg,
 )
 from dynacell.evaluation.utils import plot_metrics
+
+
+def _zscore_per_side(pred: np.ndarray, target: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Per-side z-score: separate (mean, std) computed for each matrix."""
+    pred_z = (pred - pred.mean(axis=0)) / (pred.std(axis=0) + 1e-8)
+    target_z = (target - target.mean(axis=0)) / (target.std(axis=0) + 1e-8)
+    return pred_z, target_z
+
+
+def _cp_pairwise_preprocess(pred_raw: np.ndarray, target_raw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Per-(FOV, timepoint) CP cleanup: drop target-zero columns then z-score.
+
+    Returns ``(np.empty(...), np.empty(...))`` when all columns drop, so
+    the caller can short-circuit and emit a NaN row.
+    """
+    non_zero_cols = ~np.all(target_raw == 0, axis=0)
+    pred_mat = pred_raw[:, non_zero_cols]
+    target_mat = target_raw[:, non_zero_cols]
+    if pred_mat.size == 0:
+        return pred_mat, target_mat
+    return _zscore_per_side(pred_mat, target_mat)
+
+
+def _real_vs_pred_probe(
+    pred_arr: np.ndarray,
+    target_arr: np.ndarray,
+    pred_fovs: np.ndarray,
+    target_fovs: np.ndarray,
+    prefix: str,
+    rng_seed: int = 2020,
+) -> dict[str, float]:
+    """Probe A: linear classifier on ``[gt; pred]`` with FOV-stratified CV."""
+    result = paired_auroc(target_arr, pred_arr, target_fovs, pred_fovs, rng_seed=rng_seed)
+    auroc = float(result["auroc_mean"])
+    return {
+        f"{prefix}_RealVsPred_AUROC": auroc,
+        f"{prefix}_RealVsPred_AUROC_std": float(result["auroc_std"]),
+        f"{prefix}_Indistinguishability": indistinguishability(auroc),
+    }
 
 
 def _save_embeddings(save_dir: Path, groups: dict[str, tuple[list, list, list]]) -> None:
@@ -210,17 +253,29 @@ def evaluate_predictions(config: DictConfig):
                     if config.compute_feature_metrics:
                         pred_cp = cp_pred_regionprops(predict[t], cell_segmentation[t], config.pixel_metrics.spacing)
                         pred_dinov3 = deep_pred_features(
-                            predict[t], cell_segmentation[t], dinov3_feature_extractor, config.feature_metrics.patch_size
+                            predict[t],
+                            cell_segmentation[t],
+                            dinov3_feature_extractor,
+                            config.feature_metrics.patch_size,
                         )
                         pred_dynaclr = deep_pred_features(
-                            predict[t], cell_segmentation[t], dynaclr_feature_extractor, config.feature_metrics.patch_size
+                            predict[t],
+                            cell_segmentation[t],
+                            dynaclr_feature_extractor,
+                            config.feature_metrics.patch_size,
                         )
-                        cosine_metrics = {
-                            **cp_pairwise(pred_cp, gt_cp_per_t[t]),
-                            **deep_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
-                            **deep_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
+                        # Per-timepoint CP: drop target-zero columns + per-side z-score.
+                        # Deep features stay untouched.
+                        if pred_cp.size and gt_cp_per_t[t].size:
+                            pred_cp_z, gt_cp_z = _cp_pairwise_preprocess(pred_cp, gt_cp_per_t[t])
+                        else:
+                            pred_cp_z, gt_cp_z = pred_cp, gt_cp_per_t[t]
+                        pairwise_metrics = {
+                            **compute_feature_similarity_pairwise(pred_cp_z, gt_cp_z, "CP"),
+                            **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
+                            **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
                         }
-                        all_feature_metrics.append({**data_info, **cosine_metrics})
+                        all_feature_metrics.append({**data_info, **pairwise_metrics})
                         if pred_cp.size > 0:
                             pred_cp_feats.append(pred_cp)
                             gt_cp_feats.append(gt_cp_per_t[t])
@@ -265,13 +320,85 @@ def evaluate_predictions(config: DictConfig):
                 seg_plate.close()
 
     if config.compute_feature_metrics and all_feature_metrics:
-        dataset_fid_kid = {
-            **cp_dataset_fid_kid(pred_cp_feats, gt_cp_feats),
-            **deep_dataset_fid_kid(pred_dinov3_feats, gt_dinov3_feats, "DINOv3"),
-            **deep_dataset_fid_kid(pred_dynaclr_feats, gt_dynaclr_feats, "DynaCLR"),
-        }
+        dataset_row: dict[str, float] = {}
+
+        # Stage per-prefix inputs: (pred_for_metric, target_for_metric,
+        # pred_for_probe, target_for_probe, pred_fovs, target_fovs).
+        # CP gets pruning + z-score; the pre-prune CP arrays feed the
+        # linear probe so MADScaler can normalize per-fold.
+        prefix_inputs: list[tuple[str, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]] = []
+
+        if pred_cp_feats:
+            pred_cp_raw = np.concatenate(pred_cp_feats, axis=0)
+            target_cp_raw = np.concatenate(gt_cp_feats, axis=0)
+            target_cp_filtered, pred_cp_filtered, cp_keep_mask = select_features(target_cp_raw, pred_cp_raw)
+            mask_payload = {
+                "keep_mask": [bool(b) for b in cp_keep_mask],
+                "n_kept": int(cp_keep_mask.sum()),
+                "n_total": int(cp_keep_mask.size),
+                "criteria": {"freq_cut": 0.05, "unique_cut": 0.01, "corr_threshold": 0.9},
+            }
+            (save_dir / "cp_selected_feature_mask.json").write_text(json.dumps(mask_payload, indent=2))
+            if pred_cp_filtered.size and target_cp_filtered.size:
+                pred_cp_z, target_cp_z = _zscore_per_side(pred_cp_filtered, target_cp_filtered)
+            else:
+                pred_cp_z, target_cp_z = pred_cp_filtered, target_cp_filtered
+            prefix_inputs.append(
+                (
+                    "CP",
+                    pred_cp_z,
+                    target_cp_z,
+                    pred_cp_filtered,
+                    target_cp_filtered,
+                    np.concatenate(pred_cp_fovs, axis=0),
+                    np.concatenate(gt_cp_fovs, axis=0),
+                )
+            )
+
+        for name, pred_feats, gt_feats, pred_fovs, gt_fovs in (
+            ("DINOv3", pred_dinov3_feats, gt_dinov3_feats, pred_dinov3_fovs, gt_dinov3_fovs),
+            ("DynaCLR", pred_dynaclr_feats, gt_dynaclr_feats, pred_dynaclr_fovs, gt_dynaclr_fovs),
+        ):
+            if pred_feats:
+                pred_arr = np.concatenate(pred_feats, axis=0)
+                target_arr = np.concatenate(gt_feats, axis=0)
+                prefix_inputs.append(
+                    (
+                        name,
+                        pred_arr,
+                        target_arr,
+                        pred_arr,
+                        target_arr,
+                        np.concatenate(pred_fovs, axis=0),
+                        np.concatenate(gt_fovs, axis=0),
+                    )
+                )
+
+        def _compute_one(args):
+            name, p_metric, t_metric, p_probe, t_probe, fov_p, fov_t = args
+            return {
+                **compute_feature_similarity(p_metric, t_metric, name),
+                **_real_vs_pred_probe(p_probe, t_probe, fov_p, fov_t, name),
+            }
+
+        if prefix_inputs:
+            # Threads suffice: torch-fidelity, sklearn LBFGS, and numpy BLAS
+            # all release the GIL inside their hot loops.
+            with ThreadPoolExecutor(max_workers=min(3, len(prefix_inputs))) as pool:
+                for result in pool.map(_compute_one, prefix_inputs):
+                    dataset_row.update(result)
+
+        # NaN-fill any prefix that had no cells (parallel pool would
+        # otherwise skip it). Cheap; runs on empty arrays.
+        for name in ("CP", "DINOv3", "DynaCLR"):
+            if f"{name}_FID" not in dataset_row:
+                dataset_row.update(compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name))
+                dataset_row.update(
+                    _real_vs_pred_probe(np.empty((0, 0)), np.empty((0, 0)), np.empty(0), np.empty(0), name)
+                )
+
         for row in all_feature_metrics:
-            row.update(dataset_fid_kid)
+            row.update(dataset_row)
         _save_embeddings(
             save_dir,
             {

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -96,7 +96,7 @@ def _save_embeddings(save_dir: Path, groups: dict[str, tuple[list, list, list]])
 def evaluate_predictions(config: DictConfig):
     """Evaluate predictions on all test images."""
     from dynacell.evaluation.segmentation import prepare_segmentation_model, segment
-    from dynacell.evaluation.utils import DinoV3FeatureExtractor, DynaCLRFeatureExtractor
+    from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     all_pixel_metrics = []
     all_mask_metrics = []
@@ -113,8 +113,10 @@ def evaluate_predictions(config: DictConfig):
     dinov3_model_name = None
     dynaclr_ckpt_path = None
     dynaclr_encoder_cfg = None
+    celldino_weights_path = None
     dinov3_feature_extractor = None
     dynaclr_feature_extractor = None
+    celldino_feature_extractor = None
 
     if config.compute_feature_metrics:
         if io_config.cell_segmentation_path is None:
@@ -128,12 +130,23 @@ def evaluate_predictions(config: DictConfig):
             checkpoint=dynaclr_config.checkpoint,
             encoder_config=dynaclr_encoder_cfg,
         )
+        # CELL-DINO is opt-in: only instantiate when `weights_path` is set.
+        celldino_cfg = getattr(config.feature_extractor, "celldino", None)
+        weights_path = getattr(celldino_cfg, "weights_path", None) if celldino_cfg is not None else None
+        if weights_path is not None:
+            celldino_weights_path = str(weights_path)
+            celldino_feature_extractor = CellDinoFeatureExtractor(
+                weights_path=celldino_weights_path,
+                img_size=int(celldino_cfg.img_size),
+                patch_size=int(celldino_cfg.patch_size),
+            )
 
     cache_ctx = init_cache_context(
         config,
         dinov3_model_name=dinov3_model_name,
         dynaclr_ckpt_path=dynaclr_ckpt_path,
         dynaclr_encoder_cfg=dynaclr_encoder_cfg,
+        celldino_weights_path=celldino_weights_path,
     )
 
     seg_path = Path(io_config.cell_segmentation_path) if io_config.cell_segmentation_path is not None else None
@@ -156,6 +169,12 @@ def evaluate_predictions(config: DictConfig):
     gt_dynaclr_feats: list[np.ndarray] = []
     gt_dynaclr_fovs: list[np.ndarray] = []
     gt_dynaclr_ts: list[np.ndarray] = []
+    pred_celldino_feats: list[np.ndarray] = []
+    pred_celldino_fovs: list[np.ndarray] = []
+    pred_celldino_ts: list[np.ndarray] = []
+    gt_celldino_feats: list[np.ndarray] = []
+    gt_celldino_fovs: list[np.ndarray] = []
+    gt_celldino_ts: list[np.ndarray] = []
 
     channel_names = ["prediction_seg", "target_seg"]
     with (
@@ -221,6 +240,13 @@ def evaluate_predictions(config: DictConfig):
                     gt_dynaclr_per_t = fov_gt_deep_features(
                         cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
                     )
+                    gt_celldino_per_t = (
+                        fov_gt_deep_features(
+                            cache_ctx, pos_name_pred, target, cell_segmentation, celldino_feature_extractor, "celldino"
+                        )
+                        if celldino_feature_extractor is not None
+                        else None
+                    )
 
                 microssim_data = []
                 fov_pixel_metrics = []
@@ -265,6 +291,16 @@ def evaluate_predictions(config: DictConfig):
                             dynaclr_feature_extractor,
                             config.feature_metrics.patch_size,
                         )
+                        pred_celldino = (
+                            deep_pred_features(
+                                predict[t],
+                                cell_segmentation[t],
+                                celldino_feature_extractor,
+                                config.feature_metrics.patch_size,
+                            )
+                            if celldino_feature_extractor is not None
+                            else None
+                        )
                         # Per-timepoint CP: drop target-zero columns + per-side z-score.
                         # Deep features stay untouched.
                         if pred_cp.size and gt_cp_per_t[t].size:
@@ -276,6 +312,10 @@ def evaluate_predictions(config: DictConfig):
                             **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
                             **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
                         }
+                        if pred_celldino is not None:
+                            pairwise_metrics.update(
+                                compute_feature_similarity_pairwise(pred_celldino, gt_celldino_per_t[t], "CellDINO")
+                            )
                         all_feature_metrics.append({**data_info, **pairwise_metrics})
                         if pred_cp.size > 0:
                             pred_cp_feats.append(pred_cp)
@@ -301,6 +341,14 @@ def evaluate_predictions(config: DictConfig):
                             pred_dynaclr_ts.append(np.full(n, t, dtype=np.int32))
                             gt_dynaclr_fovs.append(np.full(n, pos_name_pred))
                             gt_dynaclr_ts.append(np.full(n, t, dtype=np.int32))
+                        if pred_celldino is not None and pred_celldino.size > 0:
+                            pred_celldino_feats.append(pred_celldino)
+                            gt_celldino_feats.append(gt_celldino_per_t[t])
+                            n = len(pred_celldino)
+                            pred_celldino_fovs.append(np.full(n, pos_name_pred))
+                            pred_celldino_ts.append(np.full(n, t, dtype=np.int32))
+                            gt_celldino_fovs.append(np.full(n, pos_name_pred))
+                            gt_celldino_ts.append(np.full(n, t, dtype=np.int32))
 
                 seg = np.stack(segmentations, axis=0)  # shape: (T, 2, D, H, W)
                 row, col, fov = pos_name_pred.split("/")
@@ -356,10 +404,15 @@ def evaluate_predictions(config: DictConfig):
                 )
             )
 
-        for name, pred_feats, gt_feats, pred_fovs, gt_fovs in (
+        deep_tracks = [
             ("DINOv3", pred_dinov3_feats, gt_dinov3_feats, pred_dinov3_fovs, gt_dinov3_fovs),
             ("DynaCLR", pred_dynaclr_feats, gt_dynaclr_feats, pred_dynaclr_fovs, gt_dynaclr_fovs),
-        ):
+        ]
+        if celldino_feature_extractor is not None:
+            deep_tracks.append(
+                ("CellDINO", pred_celldino_feats, gt_celldino_feats, pred_celldino_fovs, gt_celldino_fovs)
+            )
+        for name, pred_feats, gt_feats, pred_fovs, gt_fovs in deep_tracks:
             if pred_feats:
                 pred_arr = np.concatenate(pred_feats, axis=0)
                 target_arr = np.concatenate(gt_feats, axis=0)
@@ -385,17 +438,20 @@ def evaluate_predictions(config: DictConfig):
         if prefix_inputs:
             # Threads suffice: torch-fidelity, sklearn LBFGS, and numpy BLAS
             # all release the GIL inside their hot loops. Cap inner BLAS to
-            # 1 thread so the 3 outer threads don't oversubscribe cores.
+            # 1 thread so the outer threads don't oversubscribe cores.
             with (
                 threadpool_limits(limits=1),
-                ThreadPoolExecutor(max_workers=min(3, len(prefix_inputs))) as pool,
+                ThreadPoolExecutor(max_workers=min(4, len(prefix_inputs))) as pool,
             ):
                 for result in pool.map(_compute_one, prefix_inputs):
                     dataset_row.update(result)
 
         # NaN-fill any prefix that had no cells (parallel pool would
         # otherwise skip it). Cheap; runs on empty arrays.
-        for name in ("CP", "DINOv3", "DynaCLR"):
+        expected_prefixes = ["CP", "DINOv3", "DynaCLR"]
+        if celldino_feature_extractor is not None:
+            expected_prefixes.append("CellDINO")
+        for name in expected_prefixes:
             if f"{name}_FID" not in dataset_row:
                 dataset_row.update(compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name))
                 dataset_row.update(
@@ -404,17 +460,18 @@ def evaluate_predictions(config: DictConfig):
 
         for row in all_feature_metrics:
             row.update(dataset_row)
-        _save_embeddings(
-            save_dir,
-            {
-                "pred_cp": (pred_cp_feats, pred_cp_fovs, pred_cp_ts),
-                "gt_cp": (gt_cp_feats, gt_cp_fovs, gt_cp_ts),
-                "pred_dinov3": (pred_dinov3_feats, pred_dinov3_fovs, pred_dinov3_ts),
-                "gt_dinov3": (gt_dinov3_feats, gt_dinov3_fovs, gt_dinov3_ts),
-                "pred_dynaclr": (pred_dynaclr_feats, pred_dynaclr_fovs, pred_dynaclr_ts),
-                "gt_dynaclr": (gt_dynaclr_feats, gt_dynaclr_fovs, gt_dynaclr_ts),
-            },
-        )
+        embedding_groups = {
+            "pred_cp": (pred_cp_feats, pred_cp_fovs, pred_cp_ts),
+            "gt_cp": (gt_cp_feats, gt_cp_fovs, gt_cp_ts),
+            "pred_dinov3": (pred_dinov3_feats, pred_dinov3_fovs, pred_dinov3_ts),
+            "gt_dinov3": (gt_dinov3_feats, gt_dinov3_fovs, gt_dinov3_ts),
+            "pred_dynaclr": (pred_dynaclr_feats, pred_dynaclr_fovs, pred_dynaclr_ts),
+            "gt_dynaclr": (gt_dynaclr_feats, gt_dynaclr_fovs, gt_dynaclr_ts),
+        }
+        if celldino_feature_extractor is not None:
+            embedding_groups["pred_celldino"] = (pred_celldino_feats, pred_celldino_fovs, pred_celldino_ts)
+            embedding_groups["gt_celldino"] = (gt_celldino_feats, gt_celldino_fovs, gt_celldino_ts)
+        _save_embeddings(save_dir, embedding_groups)
 
     return all_pixel_metrics, all_mask_metrics, all_feature_metrics
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -20,11 +20,12 @@ from dynacell.evaluation.feature_metrics import (
 from dynacell.evaluation.feature_select import select_features
 from dynacell.evaluation.linear_probe import indistinguishability, paired_auroc
 from dynacell.evaluation.metrics import (
+    build_pred_crops,
     calculate_microssim,
     compute_pixel_metrics,
     cp_pred_regionprops,
-    deep_pred_features,
     evaluate_segmentations,
+    features_from_crops,
 )
 from dynacell.evaluation.pipeline_cache import (
     flush_manifest,
@@ -130,11 +131,9 @@ def evaluate_predictions(config: DictConfig):
             checkpoint=dynaclr_config.checkpoint,
             encoder_config=dynaclr_encoder_cfg,
         )
-        # CELL-DINO is opt-in: only instantiate when `weights_path` is set.
-        celldino_cfg = getattr(config.feature_extractor, "celldino", None)
-        weights_path = getattr(celldino_cfg, "weights_path", None) if celldino_cfg is not None else None
-        if weights_path is not None:
-            celldino_weights_path = str(weights_path)
+        celldino_cfg = config.feature_extractor.celldino
+        if celldino_cfg.weights_path is not None:
+            celldino_weights_path = str(celldino_cfg.weights_path)
             celldino_feature_extractor = CellDinoFeatureExtractor(
                 weights_path=celldino_weights_path,
                 img_size=int(celldino_cfg.img_size),
@@ -279,25 +278,17 @@ def evaluate_predictions(config: DictConfig):
 
                     if config.compute_feature_metrics:
                         pred_cp = cp_pred_regionprops(predict[t], cell_segmentation[t], config.pixel_metrics.spacing)
-                        pred_dinov3 = deep_pred_features(
-                            predict[t],
-                            cell_segmentation[t],
-                            dinov3_feature_extractor,
-                            config.feature_metrics.patch_size,
+                        # Build the per-cell 2-D crops once per timepoint and
+                        # reuse them across all 3-4 deep backbones (max-z
+                        # projection + cell-iteration + crop construction
+                        # are otherwise redundant per backbone).
+                        pred_crops_2d = build_pred_crops(
+                            predict[t], cell_segmentation[t], config.feature_metrics.patch_size
                         )
-                        pred_dynaclr = deep_pred_features(
-                            predict[t],
-                            cell_segmentation[t],
-                            dynaclr_feature_extractor,
-                            config.feature_metrics.patch_size,
-                        )
+                        pred_dinov3 = features_from_crops(pred_crops_2d, dinov3_feature_extractor)
+                        pred_dynaclr = features_from_crops(pred_crops_2d, dynaclr_feature_extractor)
                         pred_celldino = (
-                            deep_pred_features(
-                                predict[t],
-                                cell_segmentation[t],
-                                celldino_feature_extractor,
-                                config.feature_metrics.patch_size,
-                            )
+                            features_from_crops(pred_crops_2d, celldino_feature_extractor)
                             if celldino_feature_extractor is not None
                             else None
                         )

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from iohub.ngff import open_ome_zarr
 from omegaconf import DictConfig
+from threadpoolctl import threadpool_limits
 from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
@@ -43,7 +44,7 @@ def _zscore_per_side(pred: np.ndarray, target: np.ndarray) -> tuple[np.ndarray, 
     return pred_z, target_z
 
 
-def _cp_pairwise_preprocess(pred_raw: np.ndarray, target_raw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def _cp_dropzero_zscore(pred_raw: np.ndarray, target_raw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Per-(FOV, timepoint) CP cleanup: drop target-zero columns then z-score.
 
     Returns ``(np.empty(...), np.empty(...))`` when all columns drop, so
@@ -267,7 +268,7 @@ def evaluate_predictions(config: DictConfig):
                         # Per-timepoint CP: drop target-zero columns + per-side z-score.
                         # Deep features stay untouched.
                         if pred_cp.size and gt_cp_per_t[t].size:
-                            pred_cp_z, gt_cp_z = _cp_pairwise_preprocess(pred_cp, gt_cp_per_t[t])
+                            pred_cp_z, gt_cp_z = _cp_dropzero_zscore(pred_cp, gt_cp_per_t[t])
                         else:
                             pred_cp_z, gt_cp_z = pred_cp, gt_cp_per_t[t]
                         pairwise_metrics = {
@@ -383,8 +384,12 @@ def evaluate_predictions(config: DictConfig):
 
         if prefix_inputs:
             # Threads suffice: torch-fidelity, sklearn LBFGS, and numpy BLAS
-            # all release the GIL inside their hot loops.
-            with ThreadPoolExecutor(max_workers=min(3, len(prefix_inputs))) as pool:
+            # all release the GIL inside their hot loops. Cap inner BLAS to
+            # 1 thread so the 3 outer threads don't oversubscribe cores.
+            with (
+                threadpool_limits(limits=1),
+                ThreadPoolExecutor(max_workers=min(3, len(prefix_inputs))) as pool,
+            ):
                 for result in pool.map(_compute_one, prefix_inputs):
                     dataset_row.update(result)
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -17,7 +17,12 @@ from dynacell.evaluation.feature_metrics import (
     compute_feature_similarity,
     compute_feature_similarity_pairwise,
 )
-from dynacell.evaluation.feature_select import select_features
+from dynacell.evaluation.feature_select import (
+    DEFAULT_CORR_THRESHOLD,
+    DEFAULT_FREQ_CUT,
+    DEFAULT_UNIQUE_CUT,
+    select_features,
+)
 from dynacell.evaluation.linear_probe import indistinguishability, paired_auroc
 from dynacell.evaluation.metrics import (
     build_pred_crops,
@@ -376,7 +381,11 @@ def evaluate_predictions(config: DictConfig):
                 "keep_mask": [bool(b) for b in cp_keep_mask],
                 "n_kept": int(cp_keep_mask.sum()),
                 "n_total": int(cp_keep_mask.size),
-                "criteria": {"freq_cut": 0.05, "unique_cut": 0.01, "corr_threshold": 0.9},
+                "criteria": {
+                    "freq_cut": DEFAULT_FREQ_CUT,
+                    "unique_cut": DEFAULT_UNIQUE_CUT,
+                    "corr_threshold": DEFAULT_CORR_THRESHOLD,
+                },
             }
             (save_dir / "cp_selected_feature_mask.json").write_text(json.dumps(mask_payload, indent=2))
             if pred_cp_filtered.size and target_cp_filtered.size:

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -84,7 +84,7 @@ def _resolve_force(force: DictConfig) -> dict[str, bool]:
         "gt_cp": all_flag or bool(force.gt_cp),
         "gt_dinov3": all_flag or bool(force.gt_dinov3),
         "gt_dynaclr": all_flag or bool(force.gt_dynaclr),
-        "gt_celldino": all_flag or bool(getattr(force, "gt_celldino", False)),
+        "gt_celldino": all_flag or bool(force.gt_celldino),
         "final_metrics": all_flag or bool(force.final_metrics),
     }
 
@@ -379,8 +379,8 @@ def fov_gt_deep_features(
 ) -> list[np.ndarray]:
     """Return target-side deep embeddings per timepoint for one feature family.
 
-    ``kind`` is ``"dinov3"`` or ``"dynaclr"``. The cache key (model name or
-    checkpoint hash) is pulled from *ctx*.
+    ``kind`` is ``"dinov3"``, ``"dynaclr"``, or ``"celldino"``. The cache key
+    (model name or checkpoint/weights hash) is pulled from *ctx*.
     """
     if kind == "dinov3":
         force_key = "gt_dinov3"

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -56,6 +56,7 @@ class _CacheContext:
     dinov3_model_name: str | None = None
     dynaclr_ckpt_sha12: str | None = None
     dynaclr_encoder_sha12: str | None = None
+    celldino_weights_sha12: str | None = None
     _manifest_dirty: bool = field(default=False, init=False, repr=False)
 
     @property
@@ -83,6 +84,7 @@ def _resolve_force(force: DictConfig) -> dict[str, bool]:
         "gt_cp": all_flag or bool(force.gt_cp),
         "gt_dinov3": all_flag or bool(force.gt_dinov3),
         "gt_dynaclr": all_flag or bool(force.gt_dynaclr),
+        "gt_celldino": all_flag or bool(getattr(force, "gt_celldino", False)),
         "final_metrics": all_flag or bool(force.final_metrics),
     }
 
@@ -93,6 +95,7 @@ def init_cache_context(
     dinov3_model_name: str | None = None,
     dynaclr_ckpt_path: str | None = None,
     dynaclr_encoder_cfg: dict[str, Any] | None = None,
+    celldino_weights_path: str | None = None,
 ) -> _CacheContext:
     """Open and validate the GT cache for the current run.
 
@@ -106,6 +109,9 @@ def init_cache_context(
         DynaCLR checkpoint path; ``None`` when feature metrics are disabled.
     dynaclr_encoder_cfg
         DynaCLR encoder config (resolved dict); ``None`` when disabled.
+    celldino_weights_path
+        CELL-DINO ``.pth`` state_dict path; ``None`` when the CELL-DINO
+        backbone is not configured.
     """
     io = config.io
     force = _resolve_force(config.force_recompute)
@@ -114,13 +120,13 @@ def init_cache_context(
     spacing = list(config.pixel_metrics.spacing)
     patch_size = int(config.feature_metrics.patch_size)
 
+    dynaclr_ckpt_sha12 = ckpt_sha256_12(dynaclr_ckpt_path) if dynaclr_ckpt_path is not None else None
+    dynaclr_encoder_sha12 = encoder_config_sha256_12(dynaclr_encoder_cfg) if dynaclr_encoder_cfg is not None else None
+    celldino_weights_sha12 = ckpt_sha256_12(celldino_weights_path) if celldino_weights_path is not None else None
+
     if io.gt_cache_dir is None:
         if require_complete:
             raise ValueError("io.require_complete_cache=true requires io.gt_cache_dir to be set")
-        dynaclr_ckpt_sha12 = ckpt_sha256_12(dynaclr_ckpt_path) if dynaclr_ckpt_path is not None else None
-        dynaclr_encoder_sha12 = (
-            encoder_config_sha256_12(dynaclr_encoder_cfg) if dynaclr_encoder_cfg is not None else None
-        )
         return _CacheContext(
             paths=None,
             manifest={},
@@ -132,6 +138,7 @@ def init_cache_context(
             dinov3_model_name=dinov3_model_name,
             dynaclr_ckpt_sha12=dynaclr_ckpt_sha12,
             dynaclr_encoder_sha12=dynaclr_encoder_sha12,
+            celldino_weights_sha12=celldino_weights_sha12,
         )
 
     paths = cache_paths(Path(io.gt_cache_dir))
@@ -151,9 +158,6 @@ def init_cache_context(
         cell_segmentation_path=cell_seg_path,
     )
 
-    dynaclr_ckpt_sha12 = ckpt_sha256_12(dynaclr_ckpt_path) if dynaclr_ckpt_path is not None else None
-    dynaclr_encoder_sha12 = encoder_config_sha256_12(dynaclr_encoder_cfg) if dynaclr_encoder_cfg is not None else None
-
     ctx = _CacheContext(
         paths=paths,
         manifest=manifest,
@@ -165,6 +169,7 @@ def init_cache_context(
         dinov3_model_name=dinov3_model_name,
         dynaclr_ckpt_sha12=dynaclr_ckpt_sha12,
         dynaclr_encoder_sha12=dynaclr_encoder_sha12,
+        celldino_weights_sha12=celldino_weights_sha12,
     )
     _validate_artifact_params(ctx)
     return ctx
@@ -203,6 +208,16 @@ def _validate_artifact_params(ctx: _CacheContext) -> None:
                 "patch_size": ctx.patch_size,
             },
             artifact_label=f"dynaclr_features[{ctx.dynaclr_ckpt_sha12}]",
+        )
+    if ctx.celldino_weights_sha12 is not None:
+        celldino_section = artifacts.get("celldino_features", {})
+        check_artifact_params(
+            celldino_section.get(ctx.celldino_weights_sha12),
+            {
+                "weights_sha256_12": ctx.celldino_weights_sha12,
+                "patch_size": ctx.patch_size,
+            },
+            artifact_label=f"celldino_features[{ctx.celldino_weights_sha12}]",
         )
 
 
@@ -388,6 +403,17 @@ def fov_gt_deep_features(
             "path": f"features/dynaclr/{ctx.dynaclr_ckpt_sha12}.zarr",
             "checkpoint_sha256_12": ctx.dynaclr_ckpt_sha12,
             "encoder_config_sha256_12": ctx.dynaclr_encoder_sha12,
+            "patch_size": ctx.patch_size,
+            "built_at": built_at_now(),
+        }
+    elif kind == "celldino":
+        force_key = "gt_celldino"
+        artifact_label = f"celldino_features[{ctx.celldino_weights_sha12}]"
+        cache_kwargs = {"weights_sha12": ctx.celldino_weights_sha12}
+        manifest_keys = ["celldino_features", ctx.celldino_weights_sha12]
+        entry = {
+            "path": f"features/celldino/{ctx.celldino_weights_sha12}.zarr",
+            "weights_sha256_12": ctx.celldino_weights_sha12,
             "patch_size": ctx.patch_size,
             "built_at": built_at_now(),
         }

--- a/applications/dynacell/src/dynacell/evaluation/save_paths.py
+++ b/applications/dynacell/src/dynacell/evaluation/save_paths.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 # Mapping from code-side model key (config dir name) to paper key.
 # Source of truth: applications/dynacell/CLAUDE.md
-_PAPER_KEY: dict[str, str] = {
+PAPER_KEY: dict[str, str] = {
     "fcmae_vscyto3d_scratch": "unext2",
     "fcmae_vscyto3d_pretrained": "vscyto3d",
     "fnet3d_paper": "fnet3d",
@@ -32,7 +32,7 @@ _PAPER_KEY: dict[str, str] = {
 # Organelle-name translation: code config dir → paper-script organelle key.
 # Mito uses the long form `mitochondria` in paper outputs (paper script
 # lines 41-44).
-_ORGANELLE_PAPER: dict[str, str] = {
+ORGANELLE_PAPER: dict[str, str] = {
     "nucleus": "nucleus",
     "membrane": "membrane",
     "er": "er",
@@ -97,9 +97,9 @@ def extract_predict_output_store(composed: dict, leaf_path: Path) -> Path:
 
 def paper_key(code_model: str) -> str:
     """Translate the code-side model key (e.g. config dir name) to the paper key."""
-    if code_model not in _PAPER_KEY:
-        raise ValueError(f"unknown model key {code_model!r}; expected one of {sorted(_PAPER_KEY)}")
-    return _PAPER_KEY[code_model]
+    if code_model not in PAPER_KEY:
+        raise ValueError(f"unknown model key {code_model!r}; expected one of {sorted(PAPER_KEY)}")
+    return PAPER_KEY[code_model]
 
 
 def _a549trained_key(code_model: str) -> str:
@@ -156,8 +156,8 @@ def eval_save_dir(
         If any of ``organelle``, ``code_model``, ``train_set``, or ``test_plate``
         is not one of the supported values.
     """
-    if organelle not in _ORGANELLE_PAPER:
-        raise ValueError(f"unknown organelle {organelle!r}; expected one of {sorted(_ORGANELLE_PAPER)}")
+    if organelle not in ORGANELLE_PAPER:
+        raise ValueError(f"unknown organelle {organelle!r}; expected one of {sorted(ORGANELLE_PAPER)}")
     if test_plate not in {"ipsc", "mock", "denv", "zikv"}:
         raise ValueError(f"unknown test_plate {test_plate!r}; expected one of 'ipsc' | 'mock' | 'denv' | 'zikv'")
     if train_set not in {
@@ -169,7 +169,7 @@ def eval_save_dir(
             f"unknown train_set {train_set!r}; expected one of "
             f"'ipsc_confocal' | 'a549_mantis' | 'joint_ipsc_confocal_a549_mantis'"
         )
-    organelle_paper = _ORGANELLE_PAPER[organelle]
+    organelle_paper = ORGANELLE_PAPER[organelle]
     root = Path(data_root)
     if test_plate == "ipsc":
         if train_set == "ipsc_confocal":

--- a/applications/dynacell/src/dynacell/evaluation/save_paths.py
+++ b/applications/dynacell/src/dynacell/evaluation/save_paths.py
@@ -1,0 +1,202 @@
+"""Canonical eval-output directory naming for dynacell virtual-staining benchmarks.
+
+# IMPORTANT: This file is DELIBERATELY duplicated with
+#   /hpc/mydata/alex.kalinin/dynacell/paper/scripts/compute_all_organelle_precision_recall.py
+#     (the `eval_dir_for` function, lines 55-110)
+# Both must stay in sync — VisCy and the paper repo are independent git repos.
+
+Returns the same on-disk save_dir that downstream paper aggregation scripts
+expect. Used by ``applications/dynacell/tools/submit_evaluation_job.py`` to
+emit ``save.save_dir=<path>`` Hydra overrides.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Mapping from code-side model key (config dir name) to paper key.
+# Source of truth: applications/dynacell/CLAUDE.md
+_PAPER_KEY: dict[str, str] = {
+    "fcmae_vscyto3d_scratch": "unext2",
+    "fcmae_vscyto3d_pretrained": "vscyto3d",
+    "fnet3d_paper": "fnet3d",
+    "unetvit3d": "unetvit3d",
+    # CELL-Diff variants all collapse to a single iterative paper key for
+    # iPSC-trained evaluations (matches paper script line 51).
+    "celldiff": "celldiff_iterative",
+    "celldiff_iterative": "celldiff_iterative",
+    "celldiff_sliding_window": "celldiff_iterative",
+    "celldiff_denoise": "celldiff_iterative",
+}
+
+# Organelle-name translation: code config dir → paper-script organelle key.
+# Mito uses the long form `mitochondria` in paper outputs (paper script
+# lines 41-44).
+_ORGANELLE_PAPER: dict[str, str] = {
+    "nucleus": "nucleus",
+    "membrane": "membrane",
+    "er": "er",
+    "mito": "mitochondria",
+}
+
+# Organelle → eval-side Hydra `target` group name. Membrane and nucleus are
+# 1:1; ER and Mito disambiguate by gene to match the target YAMLs under
+# `configs/benchmarks/virtual_staining/_internal/shared/eval/target/`.
+ORGANELLE_EVAL_TARGET: dict[str, str] = {
+    "nucleus": "nucleus",
+    "membrane": "membrane",
+    "er": "er_sec61b",
+    "mito": "mito_tomm20",
+}
+
+# Organelle → A549 date-plate hosting that gene's antibody. Also mirrored in
+# `applications/dynacell/tests/test_evaluate_compose.py::_A549_PLATES`.
+ORGANELLE_A549_PLATE: dict[str, str] = {
+    "er": "2024_11_07",
+    "mito": "2024_11_21",
+    "nucleus": "2026_03_26",
+    "membrane": "2026_03_26",
+}
+
+_DEFAULT_DATA_ROOT = Path("/hpc/projects/virtual_staining/training/dynacell")
+DEFAULT_EVAL_RUN_ROOT = _DEFAULT_DATA_ROOT / "eval_runs"
+
+
+def eval_predict_set_group(organelle: str, dataset_name: str) -> str:
+    """Return the eval-side Hydra ``predict_set`` group name for one leaf.
+
+    iPSC composes back to itself; A549 plates are keyed by the date of the
+    physical plate that hosts the organelle's antibody (see
+    :data:`ORGANELLE_A549_PLATE`).
+    """
+    if dataset_name == "aics-hipsc":
+        return "ipsc_confocal"
+    if organelle not in ORGANELLE_A549_PLATE:
+        raise ValueError(
+            f"cannot map organelle {organelle!r} to an A549 plate; expected one of {sorted(ORGANELLE_A549_PLATE)}"
+        )
+    return f"a549_mantis_{ORGANELLE_A549_PLATE[organelle]}"
+
+
+def extract_predict_output_store(composed: dict, leaf_path: Path) -> Path:
+    """Pull ``HCSPredictionWriter.init_args.output_store`` from a composed predict config."""
+    callbacks = composed.get("trainer", {}).get("callbacks", [])
+    if not isinstance(callbacks, list):
+        raise ValueError(f"{leaf_path}: trainer.callbacks must be a list (got {type(callbacks).__name__})")
+    for cb in callbacks:
+        if not isinstance(cb, dict):
+            continue
+        if str(cb.get("class_path", "")).endswith("HCSPredictionWriter"):
+            init_args = cb.get("init_args", {}) or {}
+            store = init_args.get("output_store")
+            if not store:
+                raise ValueError(f"{leaf_path}: HCSPredictionWriter has no init_args.output_store")
+            return Path(store)
+    raise ValueError(f"{leaf_path}: no HCSPredictionWriter callback found under trainer.callbacks")
+
+
+def paper_key(code_model: str) -> str:
+    """Translate the code-side model key (e.g. config dir name) to the paper key."""
+    if code_model not in _PAPER_KEY:
+        raise ValueError(f"unknown model key {code_model!r}; expected one of {sorted(_PAPER_KEY)}")
+    return _PAPER_KEY[code_model]
+
+
+def _a549trained_key(code_model: str) -> str:
+    """A549-trained naming uses the bare paper key (no celldiff variant suffix)."""
+    if code_model.startswith("celldiff"):
+        return "celldiff"
+    return paper_key(code_model)
+
+
+def _joint_key(code_model: str) -> str:
+    """Joint-trained naming collapses celldiff variants and otherwise = paper key."""
+    if code_model.startswith("celldiff"):
+        return "celldiff"
+    return paper_key(code_model)
+
+
+def eval_save_dir(
+    organelle: str,
+    code_model: str,
+    train_set: str,
+    test_plate: str,
+    data_root: str | Path = _DEFAULT_DATA_ROOT,
+) -> Path:
+    """Return canonical eval save_dir following the paper-script convention.
+
+    Must produce identical paths to
+    paper/scripts/compute_all_organelle_precision_recall.py:eval_dir_for.
+
+    Parameters
+    ----------
+    organelle : str
+        Config-side organelle key: ``nucleus`` | ``membrane`` | ``er`` | ``mito``.
+    code_model : str
+        Config-side model key (e.g. ``fnet3d_paper``, ``fcmae_vscyto3d_pretrained``,
+        ``celldiff_iterative``).
+    train_set : str
+        Train-set group name: ``ipsc_confocal`` | ``a549_mantis`` |
+        ``joint_ipsc_confocal_a549_mantis``.
+    test_plate : str
+        Test plate identifier: ``ipsc`` for iPSC test; ``mock`` | ``denv`` | ``zikv``
+        for A549 plates.
+    data_root : str or Path, optional
+        Base directory under which the canonical layout is rooted. Defaults to
+        ``/hpc/projects/virtual_staining/training/dynacell``.
+
+    Returns
+    -------
+    Path
+        Absolute path to the eval save_dir. Does not create the directory.
+
+    Raises
+    ------
+    ValueError
+        If any of ``organelle``, ``code_model``, ``train_set``, or ``test_plate``
+        is not one of the supported values.
+    """
+    if organelle not in _ORGANELLE_PAPER:
+        raise ValueError(f"unknown organelle {organelle!r}; expected one of {sorted(_ORGANELLE_PAPER)}")
+    if test_plate not in {"ipsc", "mock", "denv", "zikv"}:
+        raise ValueError(f"unknown test_plate {test_plate!r}; expected one of 'ipsc' | 'mock' | 'denv' | 'zikv'")
+    if train_set not in {
+        "ipsc_confocal",
+        "a549_mantis",
+        "joint_ipsc_confocal_a549_mantis",
+    }:
+        raise ValueError(
+            f"unknown train_set {train_set!r}; expected one of "
+            f"'ipsc_confocal' | 'a549_mantis' | 'joint_ipsc_confocal_a549_mantis'"
+        )
+    organelle_paper = _ORGANELLE_PAPER[organelle]
+    root = Path(data_root)
+    if test_plate == "ipsc":
+        if train_set == "ipsc_confocal":
+            return root / "ipsc" / "evaluations" / f"eval_{paper_key(code_model)}_{organelle_paper}"
+        if train_set == "a549_mantis":
+            return (
+                root
+                / "ipsc"
+                / "evaluations_a549trained_with_embeddings"
+                / f"eval_{_a549trained_key(code_model)}_a549trained_{organelle_paper}"
+            )
+        # joint
+        return root / "ipsc" / "joint_evaluations" / f"eval_{_joint_key(code_model)}_joint_{organelle_paper}"
+    # A549 plate (mock | denv | zikv)
+    if train_set == "ipsc_confocal":
+        return (
+            root
+            / "a549"
+            / "evaluations_with_embeddings"
+            / f"eval_{paper_key(code_model)}_{organelle_paper}_{test_plate}"
+        )
+    if train_set == "a549_mantis":
+        return (
+            root
+            / "a549"
+            / "evaluations_a549trained_with_embeddings"
+            / f"eval_{_a549trained_key(code_model)}_a549trained_{organelle_paper}_{test_plate}"
+        )
+    # joint
+    return root / "a549" / "joint_evaluations" / f"eval_{_joint_key(code_model)}_joint_{organelle_paper}_{test_plate}"

--- a/applications/dynacell/src/dynacell/evaluation/utils.py
+++ b/applications/dynacell/src/dynacell/evaluation/utils.py
@@ -1,10 +1,9 @@
 # ruff: noqa: I001 — matplotlib.use() must be called before pyplot import
-"""Feature extraction utilities and metric helpers for evaluation."""
+"""Feature extraction utilities and plotting helpers for evaluation."""
 
 import numpy as np
 import torch
 import matplotlib
-from scipy import linalg
 
 try:
     from transformers import AutoModel, AutoImageProcessor
@@ -128,109 +127,9 @@ class DinoV3FeatureExtractor:
         return outputs.pooler_output
 
 
-def _frechet_distance(features_a: np.ndarray, features_b: np.ndarray) -> float:
-    """Compute Frechet distance between two feature distributions."""
-    if features_a.shape[0] == 0 or features_b.shape[0] == 0:
-        return float("nan")
-
-    mean_a = features_a.mean(axis=0)
-    mean_b = features_b.mean(axis=0)
-
-    if features_a.shape[0] > 1:
-        cov_a = np.cov(features_a, rowvar=False)
-    else:
-        cov_a = np.zeros((features_a.shape[1], features_a.shape[1]), dtype=np.float64)
-
-    if features_b.shape[0] > 1:
-        cov_b = np.cov(features_b, rowvar=False)
-    else:
-        cov_b = np.zeros((features_b.shape[1], features_b.shape[1]), dtype=np.float64)
-
-    cov_a = np.atleast_2d(np.asarray(cov_a, dtype=np.float64))
-    cov_b = np.atleast_2d(np.asarray(cov_b, dtype=np.float64))
-
-    eps = 1e-3
-    offset = np.eye(cov_a.shape[0]) * eps
-    cov_prod_sqrt, _ = linalg.sqrtm((cov_a + offset) @ (cov_b + offset), disp=False)
-
-    if np.iscomplexobj(cov_prod_sqrt):
-        cov_prod_sqrt = cov_prod_sqrt.real
-
-    mean_diff = mean_a - mean_b
-    fid = mean_diff @ mean_diff + np.trace(cov_a + cov_b - 2.0 * cov_prod_sqrt)
-
-    return float(max(fid, 0.0))
-
-
-def _polynomial_mmd(features_a: np.ndarray, features_b: np.ndarray) -> float:
-    """Compute biased KID estimate with a degree-3 polynomial kernel."""
-    features_a = np.asarray(features_a, dtype=np.float64)
-    features_b = np.asarray(features_b, dtype=np.float64)
-
-    if features_a.ndim != 2 or features_b.ndim != 2:
-        raise ValueError("features_a and features_b must be 2D arrays")
-    if features_a.shape[1] != features_b.shape[1]:
-        raise ValueError("Feature dimensions must match")
-
-    num_a = features_a.shape[0]
-    num_b = features_b.shape[0]
-    if num_a == 0 or num_b == 0:
-        return float("nan")
-
-    feature_dim = features_a.shape[1]
-    gamma = 1.0 / feature_dim
-
-    kernel_aa = (gamma * (features_a @ features_a.T) + 1.0) ** 3
-    kernel_bb = (gamma * (features_b @ features_b.T) + 1.0) ** 3
-    kernel_ab = (gamma * (features_a @ features_b.T) + 1.0) ** 3
-
-    sum_aa = kernel_aa.mean()
-    sum_bb = kernel_bb.mean()
-    sum_ab = kernel_ab.mean()
-
-    kid = sum_aa + sum_bb - 2.0 * sum_ab
-    return float(kid)
-
-
 def _minmax_norm(x: np.ndarray, eps: float = 1e-8) -> np.ndarray:
     """Min-max normalize array to [0, 1]."""
     return (x - x.min()) / (x.max() - x.min() + eps)
-
-
-def _pairwise_feature_metrics(pred_features: np.ndarray, target_features: np.ndarray, prefix: str) -> dict[str, float]:
-    """Compute median cosine similarity, FID, and KID between two feature matrices.
-
-    Filters out rows with non-finite values and zero-norm vectors before
-    computing metrics. Returns NaN for all metrics if no valid rows remain.
-    """
-    nan_result = {
-        f"{prefix}_Median_Cosine_Similarity": float("nan"),
-        f"{prefix}_FID": float("nan"),
-        f"{prefix}_KID": float("nan"),
-    }
-
-    valid_rows = np.isfinite(pred_features).all(axis=1) & np.isfinite(target_features).all(axis=1)
-    if not np.any(valid_rows):
-        return nan_result
-
-    pred_features = pred_features[valid_rows]
-    target_features = target_features[valid_rows]
-
-    numerator = np.einsum("ij,ij->i", pred_features, target_features)
-    denominator = np.linalg.norm(pred_features, axis=1) * np.linalg.norm(target_features, axis=1)
-    nonzero = denominator > 0
-    if not np.any(nonzero):
-        return nan_result
-
-    cosine_similarities = np.clip(numerator[nonzero] / denominator[nonzero], -1.0, 1.0)
-    pred_features = pred_features[nonzero]
-    target_features = target_features[nonzero]
-
-    return {
-        f"{prefix}_Median_Cosine_Similarity": float(np.median(cosine_similarities)),
-        f"{prefix}_FID": _frechet_distance(pred_features, target_features),
-        f"{prefix}_KID": _polynomial_mmd(pred_features, target_features),
-    }
 
 
 def plot_metrics(df: pd.DataFrame, save_dir: Path, metric_type: str) -> None:

--- a/applications/dynacell/src/dynacell/evaluation/utils.py
+++ b/applications/dynacell/src/dynacell/evaluation/utils.py
@@ -56,7 +56,8 @@ def _require_cell_dino():
     if CellDinoModel is None:
         raise ImportError(
             "viscy_models.foundation.CellDinoModel is required for CellDinoFeatureExtractor. "
-            "Install it with: pip install viscy-models"
+            "Install the in-tree workspace package via `uv sync --all-packages --all-extras` "
+            "from the VisCy repo root, or `pip install -e packages/viscy-models`."
         )
 
 

--- a/applications/dynacell/src/dynacell/evaluation/utils.py
+++ b/applications/dynacell/src/dynacell/evaluation/utils.py
@@ -21,6 +21,11 @@ try:
 except ImportError:
     ContrastiveEncoder = None  # type: ignore[assignment, misc]
 
+try:
+    from viscy_models.foundation import CellDinoModel
+except ImportError:
+    CellDinoModel = None  # type: ignore[assignment, misc]
+
 matplotlib.use("Agg")
 from pathlib import Path
 
@@ -44,6 +49,14 @@ def _require_viscy_models():
     if ContrastiveEncoder is None:
         raise ImportError(
             "viscy_models is required for DynaCLRFeatureExtractor. Install it with: pip install viscy-models"
+        )
+
+
+def _require_cell_dino():
+    if CellDinoModel is None:
+        raise ImportError(
+            "viscy_models.foundation.CellDinoModel is required for CellDinoFeatureExtractor. "
+            "Install it with: pip install viscy-models"
         )
 
 
@@ -125,6 +138,57 @@ class DinoV3FeatureExtractor:
         with torch.inference_mode():
             outputs = self.model(**inputs)
         return outputs.pooler_output
+
+
+class CellDinoFeatureExtractor:
+    """CELL-DINO foundation model (DINOv2 ViT-L/16 pretrained on HPA) for cell images.
+
+    Wraps :class:`viscy_models.foundation.CellDinoModel` so the eval pipeline
+    can use it via the same ``extract_features(image_2d)`` contract as the
+    DINOv3 and DynaCLR extractors. The underlying model's ``preprocess_2d``
+    handles the 224×224 resize and per-image min/max scaling, so the caller
+    can feed the same masked 2-D cell crop used for the other backbones.
+    """
+
+    def __init__(self, weights_path: str, img_size: int = 224, patch_size: int = 16):
+        """Load a CELL-DINO checkpoint from a local ``.pth`` state_dict.
+
+        Parameters
+        ----------
+        weights_path :
+            Absolute path to the CELL-DINO ``.pth`` state_dict (e.g. the
+            ``channel_adaptive_dino_vitl16_pretrain_cells-*.pth`` published
+            at ``/hpc/projects/organelle_phenotyping/models/CELL-DINO/``).
+        img_size :
+            Spatial size the model interpolates inputs to, by default 224.
+        patch_size :
+            ViT patch size, by default 16.
+        """
+        _require_cell_dino()
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = CellDinoModel(weights_path=weights_path, img_size=img_size, patch_size=patch_size, freeze=True)
+        self.model.to(device)
+        self.model.eval()
+        self.device = device
+
+    def extract_features(self, image: np.ndarray) -> torch.Tensor:
+        """Extract the channel-mean cls token from a 2-D image patch.
+
+        Parameters
+        ----------
+        image :
+            2-D array (H, W); wrapped to ``(1, 1, H, W)`` so CellDinoModel
+            treats it as a single-channel, single-batch input.
+
+        Returns
+        -------
+        torch.Tensor
+            1-D embedding vector of shape ``(1024,)``.
+        """
+        x = torch.as_tensor(image, device=self.device, dtype=torch.float32)[None, None, ...]
+        with torch.inference_mode():
+            features, _ = self.model(x)
+        return features
 
 
 def _minmax_norm(x: np.ndarray, eps: float = 1e-8) -> np.ndarray:

--- a/applications/dynacell/src/dynacell/evaluation/utils.py
+++ b/applications/dynacell/src/dynacell/evaluation/utils.py
@@ -99,6 +99,21 @@ class DynaCLRFeatureExtractor:
             features, _ = self.model(image)
         return features
 
+    def extract_features_batch(self, images: list[np.ndarray], batch_size: int = 64) -> torch.Tensor:
+        """Run the encoder over a batch of 2-D crops in one or more chunks.
+
+        Stacks the crops to ``(N, 1, 1, H, W)`` so the contrastive encoder
+        sees a real batch. Chunks at ``batch_size`` to bound VRAM.
+        """
+        out_chunks: list[torch.Tensor] = []
+        for i in range(0, len(images), batch_size):
+            chunk = np.stack(images[i : i + batch_size], axis=0)
+            batch = torch.as_tensor(chunk, device=self.model.device)[:, None, None, ...]
+            with torch.inference_mode():
+                features, _ = self.model(batch)
+            out_chunks.append(features)
+        return torch.cat(out_chunks, dim=0)
+
 
 class DinoV3FeatureExtractor:
     """DINOv3-based feature extractor for cell images."""
@@ -138,6 +153,21 @@ class DinoV3FeatureExtractor:
         with torch.inference_mode():
             outputs = self.model(**inputs)
         return outputs.pooler_output
+
+    def extract_features_batch(self, images: list[np.ndarray], batch_size: int = 32) -> torch.Tensor:
+        """Run the ViT backbone over a batch of 2-D crops in one or more chunks.
+
+        AutoImageProcessor accepts a list of 3-channel images and produces
+        a stacked tensor; we chunk at ``batch_size`` to bound VRAM.
+        """
+        out_chunks: list[torch.Tensor] = []
+        for i in range(0, len(images), batch_size):
+            chunk = [np.stack([img] * 3, axis=0) for img in images[i : i + batch_size]]
+            inputs = self.processor(images=chunk, return_tensors="pt").to(self.model.device)
+            with torch.inference_mode():
+                outputs = self.model(**inputs)
+            out_chunks.append(outputs.pooler_output)
+        return torch.cat(out_chunks, dim=0)
 
 
 class CellDinoFeatureExtractor:
@@ -189,6 +219,23 @@ class CellDinoFeatureExtractor:
         with torch.inference_mode():
             features, _ = self.model(x)
         return features
+
+    def extract_features_batch(self, images: list[np.ndarray], batch_size: int = 32) -> torch.Tensor:
+        """Run CELL-DINO over a batch of 2-D crops in one or more chunks.
+
+        Stacks the crops to ``(N, 1, H, W)`` so the ViT-L/16 backbone runs
+        once per chunk. Chunks at ``batch_size`` to bound VRAM — at
+        ``img_size=224, patch_size=16``, ViT-L activations are ~1 GB per
+        32 cells in fp32.
+        """
+        out_chunks: list[torch.Tensor] = []
+        for i in range(0, len(images), batch_size):
+            chunk = np.stack(images[i : i + batch_size], axis=0)
+            batch = torch.as_tensor(chunk, device=self.device, dtype=torch.float32)[:, None, ...]
+            with torch.inference_mode():
+                features, _ = self.model(batch)
+            out_chunks.append(features)
+        return torch.cat(out_chunks, dim=0)
 
 
 def _minmax_norm(x: np.ndarray, eps: float = 1e-8) -> np.ndarray:

--- a/applications/dynacell/tests/test_evaluation_metrics.py
+++ b/applications/dynacell/tests/test_evaluation_metrics.py
@@ -214,3 +214,53 @@ def test_deep_target_features_shape_mismatch_raises(monkeypatch) -> None:
     cell_seg = np.zeros((1, 4, 5), dtype=np.int32)
     with pytest.raises(ValueError, match="Shape mismatch"):
         metrics.deep_target_features(target, cell_seg, _IdentityExtractor(), patch_size=2)
+
+
+class _BatchAwareExtractor:
+    """Extractor that records whether ``extract_features_batch`` was used.
+
+    Returns the flattened crop as the embedding, same as ``_IdentityExtractor``,
+    so the row alignment of the batched path is checkable against the per-cell
+    path.
+    """
+
+    def __init__(self) -> None:
+        self.batch_calls = 0
+        self.per_cell_calls = 0
+
+    def extract_features(self, img: np.ndarray):  # pragma: no cover - exercised via fallback path
+        self.per_cell_calls += 1
+        return torch.from_numpy(np.asarray(img, dtype=np.float32).reshape(-1))
+
+    def extract_features_batch(self, images: list[np.ndarray]):
+        self.batch_calls += 1
+        stacked = np.stack([np.asarray(img, dtype=np.float32).reshape(-1) for img in images], axis=0)
+        return torch.from_numpy(stacked)
+
+
+def test_features_from_crops_prefers_batched_path(monkeypatch) -> None:
+    """When the extractor exposes ``extract_features_batch``, it is used once per call."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+    crops = [np.ones((4, 4), dtype=np.float32) * k for k in range(1, 4)]
+    extractor = _BatchAwareExtractor()
+    out = metrics.features_from_crops(crops, extractor)
+    assert out.shape == (3, 16)
+    # One batched call covers all three crops; no per-cell fallback.
+    assert extractor.batch_calls == 1
+    assert extractor.per_cell_calls == 0
+
+
+def test_features_from_crops_falls_back_when_no_batch(monkeypatch) -> None:
+    """Extractors without ``extract_features_batch`` get one ``extract_features`` per crop."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+    crops = [np.ones((4, 4), dtype=np.float32) * k for k in range(1, 4)]
+    extractor = _IdentityExtractor()
+    out = metrics.features_from_crops(crops, extractor)
+    assert out.shape == (3, 16)
+
+
+def test_features_from_crops_empty_returns_empty(monkeypatch) -> None:
+    """No crops -> empty (0, 0) feature matrix."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+    out = metrics.features_from_crops([], _IdentityExtractor())
+    assert out.shape == (0, 0)

--- a/applications/dynacell/tests/test_evaluation_metrics.py
+++ b/applications/dynacell/tests/test_evaluation_metrics.py
@@ -168,51 +168,6 @@ class _IdentityExtractor:
         return torch.from_numpy(np.asarray(img, dtype=np.float32).reshape(-1))
 
 
-def test_cp_pairwise_empty_returns_nan(monkeypatch) -> None:
-    """Empty feature matrices produce NaN metrics without touching downstream code."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    empty = np.empty((0, 0), dtype=np.float32)
-    result = metrics.cp_pairwise(empty, empty)
-    assert np.isnan(result["CP_Median_Cosine_Similarity"])
-    assert np.isnan(result["CP_FID"])
-    assert np.isnan(result["CP_KID"])
-
-
-def test_cp_pairwise_shape_mismatch_raises(monkeypatch) -> None:
-    """Mismatched pred and target shapes raise ValueError."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    with pytest.raises(ValueError, match="Feature shape mismatch"):
-        metrics.cp_pairwise(np.zeros((3, 4)), np.zeros((2, 4)))
-
-
-def test_cp_pairwise_drops_target_zero_columns(monkeypatch) -> None:
-    """All-zero target columns are dropped before z-scoring."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    # cols 0, 2 vary; col 1 is all-zero on the target side and must be dropped.
-    pred = np.array([[1.0, 9.0, 2.0], [3.0, 8.0, 5.0], [2.0, 7.0, 4.0]], dtype=np.float32)
-    target = pred.copy()
-    target[:, 1] = 0.0
-    result = metrics.cp_pairwise(pred, target)
-    # After dropping col 1, surviving cols are identical between pred and target.
-    # Per-side z-score preserves that identity → near-perfect median cosine similarity.
-    assert result["CP_Median_Cosine_Similarity"] == pytest.approx(1.0, abs=1e-3)
-
-
-def test_deep_pairwise_empty_returns_nan(monkeypatch) -> None:
-    """Zero-cell timepoint produces NaN for deep feature metrics."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    empty = np.empty((0, 0), dtype=np.float32)
-    result = metrics.deep_pairwise(empty, empty, "DINOv3")
-    assert np.isnan(result["DINOv3_FID"])
-
-
-def test_deep_pairwise_rejects_unknown_name(monkeypatch) -> None:
-    """Unknown extractor name raises."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    with pytest.raises(ValueError, match="Unsupported feature extractor"):
-        metrics.deep_pairwise(np.zeros((2, 4)), np.zeros((2, 4)), "Bogus")
-
-
 def test_deep_target_and_pred_features_same_cell_order(monkeypatch) -> None:
     """GT and pred iterate the shared cell_segmentation → rows align by cell."""
     metrics = _import_metrics_with_stubs(monkeypatch)
@@ -259,44 +214,3 @@ def test_deep_target_features_shape_mismatch_raises(monkeypatch) -> None:
     cell_seg = np.zeros((1, 4, 5), dtype=np.int32)
     with pytest.raises(ValueError, match="Shape mismatch"):
         metrics.deep_target_features(target, cell_seg, _IdentityExtractor(), patch_size=2)
-
-
-# --- Golden-value regression tests for the split-feature pairing stages ---
-
-
-def test_cp_pairwise_pinned_values(monkeypatch) -> None:
-    """Regression guard: pinned CP metrics on a seeded synthetic input.
-
-    Catches drift in the column-drop, per-side z-score, and FID/KID/cosine
-    stages after the GT/pred split. If this test starts failing, either the
-    pairing pipeline changed (intentional → update the pinned values and
-    note it in the commit) or a dependency shifted numerics (investigate).
-    """
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    rng = np.random.default_rng(42)
-    n_cells, n_props = 8, 6
-    target_raw = rng.standard_normal((n_cells, n_props)).astype(np.float32)
-    pred_raw = target_raw + 0.5 * rng.standard_normal((n_cells, n_props)).astype(np.float32)
-
-    result = metrics.cp_pairwise(pred_raw, target_raw)
-    assert result["CP_Median_Cosine_Similarity"] == pytest.approx(0.93217182, rel=1e-5)
-    assert result["CP_FID"] == pytest.approx(0.19191332, rel=1e-5)
-    assert result["CP_KID"] == pytest.approx(0.10570750, rel=1e-5)
-
-
-def test_deep_pairwise_pinned_values(monkeypatch) -> None:
-    """Regression guard: pinned deep-feature metrics on a seeded synthetic input."""
-    metrics = _import_metrics_with_stubs(monkeypatch)
-    rng = np.random.default_rng(42)
-    # Consume the same RNG draws as the CP test so CP and deep fixtures stay in one seed.
-    rng.standard_normal((8, 6))
-    rng.standard_normal((8, 6))
-
-    dim = 32
-    gt_deep = rng.standard_normal((5, dim)).astype(np.float32)
-    pred_deep = gt_deep + 0.1 * rng.standard_normal((5, dim)).astype(np.float32)
-
-    result = metrics.deep_pairwise(pred_deep, gt_deep, "DINOv3")
-    assert result["DINOv3_Median_Cosine_Similarity"] == pytest.approx(0.99563897, rel=1e-5)
-    assert result["DINOv3_FID"] == pytest.approx(0.29004036, rel=1e-5)
-    assert result["DINOv3_KID"] == pytest.approx(0.02735842, rel=1e-5)

--- a/applications/dynacell/tests/test_evaluation_pipeline.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline.py
@@ -19,6 +19,7 @@ def _import_pipeline_with_stubs(monkeypatch):
     utils_module = types.ModuleType("dynacell.evaluation.utils")
     utils_module.DinoV3FeatureExtractor = object
     utils_module.DynaCLRFeatureExtractor = object
+    utils_module.CellDinoFeatureExtractor = object
     utils_module.plot_metrics = lambda *args, **kwargs: None
 
     metrics_module = types.ModuleType("dynacell.evaluation.metrics")

--- a/applications/dynacell/tests/test_evaluation_pipeline.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline.py
@@ -30,6 +30,9 @@ def _import_pipeline_with_stubs(monkeypatch):
     metrics_module.cp_pred_regionprops = lambda *args, **kwargs: None
     metrics_module.deep_target_features = lambda *args, **kwargs: None
     metrics_module.deep_pred_features = lambda *args, **kwargs: None
+    metrics_module.build_pred_crops = lambda *args, **kwargs: []
+    metrics_module.build_target_crops = lambda *args, **kwargs: []
+    metrics_module.features_from_crops = lambda *args, **kwargs: np.empty((0, 0), dtype=np.float32)
 
     feature_metrics_module = types.ModuleType("dynacell.evaluation.feature_metrics")
     feature_metrics_module.compute_feature_similarity = lambda *args, **kwargs: {}

--- a/applications/dynacell/tests/test_evaluation_pipeline.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline.py
@@ -44,6 +44,9 @@ def _import_pipeline_with_stubs(monkeypatch):
         pred,
         np.ones(gt.shape[1] if gt is not None and gt.ndim >= 2 else 0, dtype=bool),
     )
+    feature_select_module.DEFAULT_FREQ_CUT = 0.05
+    feature_select_module.DEFAULT_UNIQUE_CUT = 0.01
+    feature_select_module.DEFAULT_CORR_THRESHOLD = 0.9
 
     linear_probe_module = types.ModuleType("dynacell.evaluation.linear_probe")
     _nan_auroc = {"auroc_mean": float("nan"), "auroc_std": float("nan"), "n_folds": 0}

--- a/applications/dynacell/tests/test_evaluation_pipeline.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline.py
@@ -27,10 +27,25 @@ def _import_pipeline_with_stubs(monkeypatch):
     metrics_module.evaluate_segmentations = lambda *args, **kwargs: {}
     metrics_module.cp_target_regionprops = lambda *args, **kwargs: None
     metrics_module.cp_pred_regionprops = lambda *args, **kwargs: None
-    metrics_module.cp_pairwise = lambda *args, **kwargs: {}
     metrics_module.deep_target_features = lambda *args, **kwargs: None
     metrics_module.deep_pred_features = lambda *args, **kwargs: None
-    metrics_module.deep_pairwise = lambda *args, **kwargs: {}
+
+    feature_metrics_module = types.ModuleType("dynacell.evaluation.feature_metrics")
+    feature_metrics_module.compute_feature_similarity = lambda *args, **kwargs: {}
+    feature_metrics_module.compute_feature_similarity_pairwise = lambda *args, **kwargs: {}
+
+    feature_select_module = types.ModuleType("dynacell.evaluation.feature_select")
+    feature_select_module.select_features = lambda gt, pred, **kw: (
+        gt,
+        pred,
+        np.ones(gt.shape[1] if gt is not None and gt.ndim >= 2 else 0, dtype=bool),
+    )
+
+    linear_probe_module = types.ModuleType("dynacell.evaluation.linear_probe")
+    _nan_auroc = {"auroc_mean": float("nan"), "auroc_std": float("nan"), "n_folds": 0}
+    linear_probe_module.fov_stratified_auroc = lambda *a, **kw: _nan_auroc
+    linear_probe_module.paired_auroc = lambda *a, **kw: _nan_auroc
+    linear_probe_module.indistinguishability = lambda auroc: float("nan")
 
     segmentation_module = types.ModuleType("dynacell.evaluation.segmentation")
     segmentation_module.segment = lambda *args, **kwargs: None
@@ -44,6 +59,9 @@ def _import_pipeline_with_stubs(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "dynacell.evaluation.utils", utils_module)
     monkeypatch.setitem(sys.modules, "dynacell.evaluation.metrics", metrics_module)
+    monkeypatch.setitem(sys.modules, "dynacell.evaluation.feature_metrics", feature_metrics_module)
+    monkeypatch.setitem(sys.modules, "dynacell.evaluation.feature_select", feature_select_module)
+    monkeypatch.setitem(sys.modules, "dynacell.evaluation.linear_probe", linear_probe_module)
     monkeypatch.setitem(sys.modules, "dynacell.evaluation.segmentation", segmentation_module)
     # Don't stub iohub globally — it's used by viscy_data in the same process
     sys.modules.pop("dynacell.evaluation.pipeline", None)

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -52,6 +52,7 @@ def _make_config(**overrides: Any):
             "gt_cp": False,
             "gt_dinov3": False,
             "gt_dynaclr": False,
+            "gt_celldino": False,
             "final_metrics": False,
         },
     }
@@ -95,6 +96,7 @@ def test_resolve_force_all_propagates() -> None:
             "gt_cp": False,
             "gt_dinov3": False,
             "gt_dynaclr": False,
+            "gt_celldino": False,
             "final_metrics": False,
         }
     )
@@ -111,6 +113,7 @@ def test_resolve_force_individual() -> None:
             "gt_cp": True,
             "gt_dinov3": False,
             "gt_dynaclr": False,
+            "gt_celldino": False,
             "final_metrics": False,
         }
     )

--- a/applications/dynacell/tests/test_save_paths.py
+++ b/applications/dynacell/tests/test_save_paths.py
@@ -1,0 +1,71 @@
+"""Pin canonical eval save_dir paths emitted by save_paths.eval_save_dir.
+
+These paths are deliberately duplicated with the paper repo's
+``compute_all_organelle_precision_recall.py::eval_dir_for``. Any drift here
+must be matched in that file or downstream paper aggregation scripts will
+fail to find the metrics. These pins are the cross-repo contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dynacell.evaluation.save_paths import eval_save_dir
+
+_DATA_ROOT = "/hpc/projects/virtual_staining/training/dynacell"
+
+# (organelle, code_model, train_set, test_plate) -> expected relative path
+# under _DATA_ROOT. Pins one representative case from each branch of
+# `eval_save_dir`. Match the paper script convention exactly.
+_PINS: list[tuple[tuple[str, str, str, str], str]] = [
+    # iPSC test, iPSC train: bare paper-key + paper organelle.
+    (
+        ("er", "fnet3d_paper", "ipsc_confocal", "ipsc"),
+        "ipsc/evaluations/eval_fnet3d_er",
+    ),
+    (
+        ("mito", "fcmae_vscyto3d_scratch", "ipsc_confocal", "ipsc"),
+        "ipsc/evaluations/eval_unext2_mitochondria",
+    ),
+    # iPSC test, A549 train: a549trained subdir + a549trained suffix; celldiff
+    # variants collapse to "celldiff".
+    (
+        ("nucleus", "celldiff_iterative", "a549_mantis", "ipsc"),
+        "ipsc/evaluations_a549trained_with_embeddings/eval_celldiff_a549trained_nucleus",
+    ),
+    # iPSC test, joint train: joint subdir + joint suffix.
+    (
+        ("membrane", "fcmae_vscyto3d_pretrained", "joint_ipsc_confocal_a549_mantis", "ipsc"),
+        "ipsc/joint_evaluations/eval_vscyto3d_joint_membrane",
+    ),
+    # A549 test, iPSC train.
+    (
+        ("er", "fnet3d_paper", "ipsc_confocal", "mock"),
+        "a549/evaluations_with_embeddings/eval_fnet3d_er_mock",
+    ),
+    # A549 test, A549 train: celldiff variant collapses.
+    (
+        ("mito", "celldiff_sliding_window", "a549_mantis", "denv"),
+        "a549/evaluations_a549trained_with_embeddings/eval_celldiff_a549trained_mitochondria_denv",
+    ),
+    # A549 test, joint train.
+    (
+        ("nucleus", "unetvit3d", "joint_ipsc_confocal_a549_mantis", "zikv"),
+        "a549/joint_evaluations/eval_unetvit3d_joint_nucleus_zikv",
+    ),
+]
+
+
+@pytest.mark.parametrize(("inputs", "expected_rel"), _PINS)
+def test_eval_save_dir_matches_paper_convention(inputs: tuple[str, str, str, str], expected_rel: str) -> None:
+    organelle, code_model, train_set, test_plate = inputs
+    got = eval_save_dir(
+        organelle=organelle,
+        code_model=code_model,
+        train_set=train_set,
+        test_plate=test_plate,
+        data_root=_DATA_ROOT,
+    )
+    assert got == Path(_DATA_ROOT) / expected_rel

--- a/applications/dynacell/tools/evaluate_batch.sh
+++ b/applications/dynacell/tools/evaluate_batch.sh
@@ -74,28 +74,17 @@ if [ ${#LEAVES[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Composite job name follows the EVAL_<ORG>_<MODEL>_<TRAIN>_ON_<TEST> shape.
-# Uppercase paper key mapping done inside submit_evaluation_batch.py; here we
-# only emit the train/test scope (the python tool defaults to the same shape).
-case "$TRAIN_SET" in
-  ipsc_confocal) TRAIN_KEY=IPSC ;;
-  a549_mantis)   TRAIN_KEY=A549 ;;
-  joint_ipsc_confocal_a549_mantis) TRAIN_KEY=JOINT ;;
-esac
-case "$TEST_SET" in
-  ipsc_confocal) TEST_KEY=IPSC ;;
-  a549_mantis)   TEST_KEY=A549 ;;
-esac
-JOB_NAME="EVAL_${ORGANELLE^^}_${MODEL^^}_${TRAIN_KEY}_ON_${TEST_KEY}"
-
 echo "[evaluate_batch] organelle=$ORGANELLE model=$MODEL train=$TRAIN_SET test=$TEST_SET leaves=${#LEAVES[@]}"
 for leaf in "${LEAVES[@]}"; do
   echo "  - $(basename "$leaf")"
 done
-echo "[evaluate_batch] composite job_name=$JOB_NAME"
 
+# Job name is composed inside submit_evaluation_batch.py via
+# `_composite_job_name`, which applies `paper_key()` to the code-side model
+# (e.g. fcmae_vscyto3d_scratch -> UNEXT2). Don't override here — the bash
+# shorthand `${MODEL^^}` would keep the raw config key and produce a
+# different SLURM job name than the Python tool's default.
 cd "$VISCY_ROOT"
 exec uv run python applications/dynacell/tools/submit_evaluation_batch.py \
   "${LEAVES[@]}" \
-  --job-name "$JOB_NAME" \
   "$@"

--- a/applications/dynacell/tools/evaluate_batch.sh
+++ b/applications/dynacell/tools/evaluate_batch.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Submit ONE sbatch job that runs `dynacell evaluate` for every per-plate
+# predict leaf for a given (organelle, model, train_set, test_set) tuple,
+# in series. Path-1 batching: amortizes queue submission + GPU allocation.
+#
+# Usage:
+#   evaluate_batch.sh <organelle> <model> <train_set> <test_set> \
+#       [submit_evaluation_batch.py args...]
+#
+# Args:
+#   <organelle>  e.g. nucleus, membrane, er, mito
+#   <model>      e.g. fnet3d_paper, fcmae_vscyto3d_scratch,
+#                fcmae_vscyto3d_pretrained, unetvit3d, celldiff_*
+#   <train_set>  ipsc | a549 | joint
+#                (or: ipsc_confocal, a549_mantis,
+#                joint_ipsc_confocal_a549_mantis)
+#   <test_set>   ipsc | a549   (or: ipsc_confocal, a549_mantis)
+#
+# Examples:
+#   evaluate_batch.sh er    fnet3d_paper             ipsc  a549
+#   evaluate_batch.sh er    fnet3d_paper             ipsc  a549 --dry-run
+#   evaluate_batch.sh nucleus fcmae_vscyto3d_scratch a549  ipsc
+#   evaluate_batch.sh nucleus fcmae_vscyto3d_scratch joint a549 --overwrite
+#
+# Extra args are forwarded verbatim to submit_evaluation_batch.py —
+# including --overwrite (force_recompute.all=true on every leaf),
+# --cross-condition-probe (handled by the python tool / runner), and
+# --dry-run.
+
+set -euo pipefail
+
+if [ $# -lt 4 ]; then
+  echo "usage: $0 <organelle> <model> <train_set> <test_set> [submit_evaluation_batch.py args...]" >&2
+  exit 2
+fi
+
+ORGANELLE=$1
+MODEL=$2
+TRAIN_RAW=$3
+TEST_RAW=$4
+shift 4
+
+case "$TRAIN_RAW" in
+  ipsc)        TRAIN_SET=ipsc_confocal ;;
+  a549)        TRAIN_SET=a549_mantis ;;
+  joint)       TRAIN_SET=joint_ipsc_confocal_a549_mantis ;;
+  ipsc_confocal|a549_mantis|joint_ipsc_confocal_a549_mantis) TRAIN_SET="$TRAIN_RAW" ;;
+  *) echo "error: unknown train_set '$TRAIN_RAW' (want ipsc | a549 | joint)" >&2; exit 2 ;;
+esac
+case "$TEST_RAW" in
+  ipsc)         TEST_SET=ipsc_confocal ;;
+  a549)         TEST_SET=a549_mantis ;;
+  ipsc_confocal|a549_mantis) TEST_SET="$TEST_RAW" ;;
+  *) echo "error: unknown test_set '$TEST_RAW' (want ipsc | a549)" >&2; exit 2 ;;
+esac
+
+VISCY_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+LEAF_DIR=$VISCY_ROOT/applications/dynacell/configs/benchmarks/virtual_staining/$ORGANELLE/$MODEL/$TRAIN_SET
+
+if [ ! -d "$LEAF_DIR" ]; then
+  echo "error: leaf directory does not exist: $LEAF_DIR" >&2
+  echo "       (no $MODEL trained on $TRAIN_SET for $ORGANELLE?)" >&2
+  exit 1
+fi
+
+if [ "$TEST_SET" = "ipsc_confocal" ]; then
+  GLOB="$LEAF_DIR/predict__ipsc_confocal.yml"
+else
+  GLOB="$LEAF_DIR/predict__${TEST_SET}_*.yml"
+fi
+mapfile -t LEAVES < <(ls $GLOB 2>/dev/null | sort)
+if [ ${#LEAVES[@]} -eq 0 ]; then
+  echo "error: no leaves match $GLOB" >&2
+  exit 1
+fi
+
+# Composite job name follows the EVAL_<ORG>_<MODEL>_<TRAIN>_ON_<TEST> shape.
+# Uppercase paper key mapping done inside submit_evaluation_batch.py; here we
+# only emit the train/test scope (the python tool defaults to the same shape).
+case "$TRAIN_SET" in
+  ipsc_confocal) TRAIN_KEY=IPSC ;;
+  a549_mantis)   TRAIN_KEY=A549 ;;
+  joint_ipsc_confocal_a549_mantis) TRAIN_KEY=JOINT ;;
+esac
+case "$TEST_SET" in
+  ipsc_confocal) TEST_KEY=IPSC ;;
+  a549_mantis)   TEST_KEY=A549 ;;
+esac
+JOB_NAME="EVAL_${ORGANELLE^^}_${MODEL^^}_${TRAIN_KEY}_ON_${TEST_KEY}"
+
+echo "[evaluate_batch] organelle=$ORGANELLE model=$MODEL train=$TRAIN_SET test=$TEST_SET leaves=${#LEAVES[@]}"
+for leaf in "${LEAVES[@]}"; do
+  echo "  - $(basename "$leaf")"
+done
+echo "[evaluate_batch] composite job_name=$JOB_NAME"
+
+cd "$VISCY_ROOT"
+exec uv run python applications/dynacell/tools/submit_evaluation_batch.py \
+  "${LEAVES[@]}" \
+  --job-name "$JOB_NAME" \
+  "$@"

--- a/applications/dynacell/tools/evaluate_local.sh
+++ b/applications/dynacell/tools/evaluate_local.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+# Run `dynacell evaluate` for a (organelle, model, train_set, test_set) tuple
+# locally on the current host's GPU. Discovers per-plate predict leaves the
+# same way predict_local.sh does, stages each leaf's eval invocation via
+# submit_evaluation_job.py, then executes `uv run dynacell evaluate ...` in
+# series (or in parallel batches of N with --parallel).
+#
+# Usage:
+#   evaluate_local.sh <organelle> <model> <train_set> <test_set> \
+#       [--overwrite] [--parallel N] [--cross-condition-probe]
+#
+# Args:
+#   <organelle>  e.g. nucleus, membrane, er, mito
+#   <model>      e.g. fnet3d_paper, fcmae_vscyto3d_scratch,
+#                fcmae_vscyto3d_pretrained, unetvit3d, celldiff_*
+#   <train_set>  ipsc | a549 | joint
+#                (or: ipsc_confocal, a549_mantis,
+#                joint_ipsc_confocal_a549_mantis)
+#   <test_set>   ipsc | a549   (or: ipsc_confocal, a549_mantis)
+#
+# Flags:
+#   --overwrite               adds force_recompute.all=true on every leaf
+#   --parallel N              run N evals concurrently on the same GPU
+#   --cross-condition-probe   after all per-plate evals succeed AND
+#                             test_set=a549_mantis, run
+#                             `python -m dynacell.evaluation.cross_condition_probe
+#                              --eval_dirs <save_dir_mock> <save_dir_denv>
+#                              <save_dir_zikv>
+#                              --out <save_dir_mock>/../cross_condition_probe.csv`
+#
+# Examples:
+#   evaluate_local.sh er    fnet3d_paper             ipsc  ipsc
+#   evaluate_local.sh er    fnet3d_paper             ipsc  a549 --parallel 2
+#   evaluate_local.sh er    fnet3d_paper             ipsc  a549 --cross-condition-probe
+
+set -euo pipefail
+
+if [ $# -lt 4 ]; then
+  echo "usage: $0 <organelle> <model> <train_set> <test_set> [--overwrite] [--parallel N] [--cross-condition-probe]" >&2
+  exit 2
+fi
+
+ORGANELLE=$1
+MODEL=$2
+TRAIN_RAW=$3
+TEST_RAW=$4
+shift 4
+
+OVERWRITE=""
+PARALLEL=1
+CROSS_PROBE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --overwrite)              OVERWRITE="--overwrite"; shift ;;
+    --parallel)               PARALLEL="$2"; shift 2 ;;
+    --parallel=*)             PARALLEL="${1#--parallel=}"; shift ;;
+    --cross-condition-probe)  CROSS_PROBE=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$PARALLEL" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: --parallel must be a positive integer (got '$PARALLEL')" >&2
+  exit 2
+fi
+
+# Map shorthand to the directory / filename names actually on disk.
+case "$TRAIN_RAW" in
+  ipsc)        TRAIN_SET=ipsc_confocal ;;
+  a549)        TRAIN_SET=a549_mantis ;;
+  joint)       TRAIN_SET=joint_ipsc_confocal_a549_mantis ;;
+  ipsc_confocal|a549_mantis|joint_ipsc_confocal_a549_mantis) TRAIN_SET="$TRAIN_RAW" ;;
+  *) echo "error: unknown train_set '$TRAIN_RAW' (want ipsc | a549 | joint)" >&2; exit 2 ;;
+esac
+case "$TEST_RAW" in
+  ipsc)         TEST_SET=ipsc_confocal ;;
+  a549)         TEST_SET=a549_mantis ;;
+  ipsc_confocal|a549_mantis) TEST_SET="$TEST_RAW" ;;
+  *) echo "error: unknown test_set '$TEST_RAW' (want ipsc | a549)" >&2; exit 2 ;;
+esac
+
+VISCY_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+LEAF_DIR=$VISCY_ROOT/applications/dynacell/configs/benchmarks/virtual_staining/$ORGANELLE/$MODEL/$TRAIN_SET
+if [ ! -d "$LEAF_DIR" ]; then
+  echo "error: leaf directory does not exist: $LEAF_DIR" >&2
+  echo "       (no $MODEL trained on $TRAIN_SET for $ORGANELLE?)" >&2
+  exit 1
+fi
+
+if [ "$TEST_SET" = "ipsc_confocal" ]; then
+  GLOB="$LEAF_DIR/predict__ipsc_confocal.yml"
+else
+  GLOB="$LEAF_DIR/predict__${TEST_SET}_*.yml"
+fi
+mapfile -t LEAVES < <(ls $GLOB 2>/dev/null | sort)
+if [ ${#LEAVES[@]} -eq 0 ]; then
+  echo "error: no leaves match $GLOB" >&2
+  exit 1
+fi
+
+cd "$VISCY_ROOT"
+
+# Stage every leaf via --dry-run --print-cmd to (a) validate output_store
+# exists and (b) capture the resolved command line + save_dir for execution
+# and the optional cross-condition probe.
+declare -a CMDS=()
+declare -a PLATES=()
+declare -a SAVE_DIRS=()
+for leaf in "${LEAVES[@]}"; do
+  base=$(basename "$leaf" .yml)
+  plate=${base#predict__${TEST_SET}_}
+  if [ "$plate" = "$base" ]; then
+    plate=$TEST_SET
+  fi
+  PLATES+=("$plate")
+
+  # Capture the literal eval command tokens (one per line).
+  cmd_text=$(uv run python applications/dynacell/tools/submit_evaluation_job.py \
+    "$leaf" $OVERWRITE --dry-run --print-cmd 2>/dev/null | grep -v '^\[dry-run\]')
+  CMDS+=("$cmd_text")
+
+  # Extract save.save_dir override from the printed command.
+  save_dir=$(printf '%s\n' "$cmd_text" | sed -n 's/^save\.save_dir=//p')
+  if [ -z "$save_dir" ]; then
+    echo "error: failed to extract save.save_dir from staged command for $leaf" >&2
+    exit 1
+  fi
+  SAVE_DIRS+=("$save_dir")
+done
+
+# Single timestamp for the whole batch.
+TS=$(date +%Y%m%d-%H%M%S)
+LOG_ROOT=$(dirname "${SAVE_DIRS[0]}")
+mkdir -p "$LOG_ROOT/slurm"
+echo "[evaluate_local] leaves=${#LEAVES[@]} parallel=$PARALLEL log_root=$LOG_ROOT"
+
+# Trap to kill backgrounded evals on early exit.
+trap 'kill 0 2>/dev/null || true' EXIT
+
+declare -a PIDS=()
+declare -a PID_PLATES=()
+declare -a PID_LOGS=()
+declare -a FAILED_PLATES=()
+
+flush_batch() {
+  local idx pid status
+  for idx in "${!PIDS[@]}"; do
+    pid=${PIDS[$idx]}
+    if wait "$pid"; then
+      status=0
+    else
+      status=$?
+    fi
+    if [ "$status" -ne 0 ]; then
+      FAILED_PLATES+=("${PID_PLATES[$idx]} (exit=$status, log=$(basename "${PID_LOGS[$idx]}"))")
+    fi
+  done
+  PIDS=()
+  PID_PLATES=()
+  PID_LOGS=()
+}
+
+i=0
+for idx in "${!LEAVES[@]}"; do
+  plate=${PLATES[$idx]}
+  cmd_text=${CMDS[$idx]}
+  log="$LOG_ROOT/slurm/local_${TS}_eval_${ORGANELLE}_${MODEL}_${plate}.log"
+  echo "  [start] plate=$plate log=$(basename "$log")"
+  # Pass the tokens to bash via xargs so the printed command runs as one
+  # process (xargs handles word-splitting more safely than `eval`).
+  printf '%s\n' "$cmd_text" | xargs -d '\n' -I {} echo {} > /dev/null  # validate parse
+  (
+    # shellcheck disable=SC2086
+    args=()
+    while IFS= read -r line; do args+=("$line"); done <<< "$cmd_text"
+    exec "${args[@]}"
+  ) >"$log" 2>&1 &
+  PIDS+=($!)
+  PID_PLATES+=("$plate")
+  PID_LOGS+=("$log")
+  i=$((i + 1))
+  if [ $((i % PARALLEL)) -eq 0 ]; then
+    flush_batch
+  fi
+done
+
+flush_batch
+trap - EXIT
+
+if [ ${#FAILED_PLATES[@]} -gt 0 ]; then
+  echo "[fail] ${#FAILED_PLATES[@]}/${#LEAVES[@]} plate(s) failed:" >&2
+  for f in "${FAILED_PLATES[@]}"; do
+    echo "  - $f" >&2
+  done
+  exit 1
+fi
+echo "[done] all evals complete; logs: $LOG_ROOT/slurm/local_${TS}_eval_${ORGANELLE}_${MODEL}_*.log"
+
+# Optional cross-condition probe (a549 test only; requires all 3 plates).
+if [ "$CROSS_PROBE" -eq 1 ]; then
+  if [ "$TEST_SET" != "a549_mantis" ]; then
+    echo "[cross-probe] skipped: requires test_set=a549_mantis (got $TEST_SET)" >&2
+  elif [ ${#SAVE_DIRS[@]} -lt 3 ]; then
+    echo "[cross-probe] skipped: need >= 3 save_dirs (mock/denv/zikv); got ${#SAVE_DIRS[@]}" >&2
+  else
+    out_csv="$(dirname "${SAVE_DIRS[0]}")/cross_condition_probe.csv"
+    echo "[cross-probe] running on ${#SAVE_DIRS[@]} eval dirs -> $out_csv"
+    uv run python -m dynacell.evaluation.cross_condition_probe \
+      --eval_dirs "${SAVE_DIRS[@]}" \
+      --out "$out_csv"
+  fi
+fi

--- a/applications/dynacell/tools/submit_evaluation_batch.py
+++ b/applications/dynacell/tools/submit_evaluation_batch.py
@@ -90,7 +90,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def _resolve_one_leaf(
     leaf_path: Path,
-) -> tuple[dict[str, object], str, str, Path, str]:
+) -> tuple[dict[str, object], str, str, str, Path, str]:
     """Compose a predict leaf and derive its eval-side overrides + identifiers.
 
     Returns
@@ -101,6 +101,8 @@ def _resolve_one_leaf(
         Config-side organelle key.
     code_model : str
         Config-side model name.
+    trained_on : str
+        Config-side train-set key (e.g. ``ipsc_confocal``).
     save_dir : Path
         Canonical eval save_dir.
     test_plate : str
@@ -164,7 +166,7 @@ def _resolve_one_leaf(
         "save.save_dir": str(save_dir),
         "compute_feature_metrics": True,
     }
-    return overrides, organelle, code_model, save_dir, test_plate
+    return overrides, organelle, code_model, trained_on, save_dir, test_plate
 
 
 def _composite_job_name(organelle: str, code_model: str, trained_on: str, test_plates: list[str]) -> str:
@@ -235,15 +237,17 @@ def submit(argv: list[str] | None = None) -> int:
     overrides_list: list[dict[str, object]] = []
     organelles: list[str] = []
     code_models: list[str] = []
+    trained_ons: list[str] = []
     save_dirs: list[Path] = []
     test_plates: list[str] = []
     for leaf in args.leaves:
-        overrides, organelle, code_model, save_dir, test_plate = _resolve_one_leaf(leaf)
+        overrides, organelle, code_model, trained_on, save_dir, test_plate = _resolve_one_leaf(leaf)
         if args.overwrite:
             overrides["force_recompute.all"] = True
         overrides_list.append(overrides)
         organelles.append(organelle)
         code_models.append(code_model)
+        trained_ons.append(trained_on)
         save_dirs.append(save_dir)
         test_plates.append(test_plate)
 
@@ -251,14 +255,11 @@ def submit(argv: list[str] | None = None) -> int:
         raise SystemExit(f"all leaves must share benchmark.organelle (got {sorted(set(organelles))})")
     if len(set(code_models)) != 1:
         raise SystemExit(f"all leaves must share benchmark.model_name (got {sorted(set(code_models))})")
+    if len(set(trained_ons)) != 1:
+        raise SystemExit(f"all leaves must share benchmark.trained_on (got {sorted(set(trained_ons))})")
     organelle = organelles[0]
     code_model = code_models[0]
-    # Re-pull trained_on from first leaf for naming (already validated above per-leaf).
-    from dynacell._compose_hook import _dynacell_ref_resolver  # noqa: PLC0415
-    from viscy_utils.compose import load_composed_config  # noqa: PLC0415
-
-    head_composed = load_composed_config(args.leaves[0], resolver=_dynacell_ref_resolver)
-    trained_on = head_composed["benchmark"]["trained_on"]
+    trained_on = trained_ons[0]
 
     job_name = args.job_name or _composite_job_name(organelle, code_model, trained_on, test_plates)
 

--- a/applications/dynacell/tools/submit_evaluation_batch.py
+++ b/applications/dynacell/tools/submit_evaluation_batch.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+r"""Submit a sequence of dynacell evaluate calls (one per predict leaf) as ONE sbatch job.
+
+For each leaf, the eval invocation is rendered the same way
+``submit_evaluation_job.py`` would render it (same predict_set / target /
+io.pred_path / save.save_dir Hydra overrides). All invocations run in
+series on a single GPU within one sbatch allocation.
+
+Eval doesn't need Lightning's DDP profile — it's a single-GPU Hydra job —
+so a fixed single-GPU sbatch profile is baked into this script (no separate
+``.sbatch`` template).
+
+Usage::
+
+    LEAF=applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis
+    uv run python applications/dynacell/tools/submit_evaluation_batch.py \
+        $LEAF/predict__a549_mantis_mock.yml \
+        $LEAF/predict__a549_mantis_denv.yml \
+        $LEAF/predict__a549_mantis_zikv.yml \
+        --job-name EVAL_MEMBRANE_FNET3D_A549_ON_A549 \
+        --dry-run
+
+Re-running plates whose save_dir already contains metrics requires
+``--overwrite`` (which adds ``force_recompute.all=true`` to every per-leaf
+eval invocation).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from dynacell.evaluation.save_paths import (
+    DEFAULT_EVAL_RUN_ROOT as _DEFAULT_RUN_ROOT,
+)
+from dynacell.evaluation.save_paths import (
+    ORGANELLE_EVAL_TARGET as _ORGANELLE_EVAL_TARGET,
+)
+from dynacell.evaluation.save_paths import (
+    eval_predict_set_group as _eval_predict_set_group,
+)
+from dynacell.evaluation.save_paths import (
+    eval_save_dir,
+)
+from dynacell.evaluation.save_paths import (
+    extract_predict_output_store as _extract_output_store,
+)
+from dynacell.evaluation.save_paths import (
+    paper_key as _paper_key,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("leaves", nargs="+", type=Path, help="paths to predict leaf YAMLs (>=1)")
+    ap.add_argument(
+        "--job-name",
+        default=None,
+        help="composite SLURM job name. Default: EVAL_<ORG>_<MODEL>_<TRAIN>_ON_<TEST>.",
+    )
+    ap.add_argument(
+        "--time",
+        default="8:00:00",
+        help="SLURM walltime (default 8:00:00). PRC bootstrap + 3 plates × DINOv3/DynaCLR/CP is generous.",
+    )
+    ap.add_argument(
+        "--run-root",
+        type=Path,
+        default=None,
+        help="directory under which `resolved/` and `slurm/` land. "
+        "Default: first leaf's save_dir grandparent if it exists, else "
+        f"{_DEFAULT_RUN_ROOT}.",
+    )
+    ap.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="add force_recompute.all=true to every per-leaf eval invocation.",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="render sbatch script but do not submit")
+    ap.add_argument("--print-script", action="store_true", help="print rendered sbatch to stdout, no writes")
+    ap.add_argument("--parsable", action="store_true", help="invoke sbatch with --parsable")
+    return ap.parse_args(argv)
+
+
+def _resolve_one_leaf(
+    leaf_path: Path,
+) -> tuple[dict[str, object], str, str, Path, str]:
+    """Compose a predict leaf and derive its eval-side overrides + identifiers.
+
+    Returns
+    -------
+    overrides : dict
+        Flat dict of Hydra overrides (dotted keys preserved).
+    organelle : str
+        Config-side organelle key.
+    code_model : str
+        Config-side model name.
+    save_dir : Path
+        Canonical eval save_dir.
+    test_plate : str
+        ``ipsc`` | ``mock`` | ``denv`` | ``zikv``.
+    """
+    from dynacell._compose_hook import _dynacell_ref_resolver  # noqa: PLC0415
+    from viscy_utils.compose import load_composed_config  # noqa: PLC0415
+
+    if not leaf_path.is_file():
+        raise SystemExit(f"leaf does not exist: {leaf_path}")
+    composed = load_composed_config(leaf_path, resolver=_dynacell_ref_resolver)
+    benchmark = composed.get("benchmark") or {}
+    organelle = benchmark.get("organelle")
+    code_model = benchmark.get("model_name")
+    trained_on = benchmark.get("trained_on")
+    dataset_ref = benchmark.get("dataset_ref") or {}
+    dataset_name = dataset_ref.get("dataset")
+    if not organelle or not code_model or not trained_on:
+        raise SystemExit(f"{leaf_path}: missing benchmark.{{organelle, model_name, trained_on}}")
+    if not dataset_name:
+        raise SystemExit(f"{leaf_path}: missing benchmark.dataset_ref.dataset (needed to pick predict_set group)")
+    output_store = _extract_output_store(composed, leaf_path)
+    if not output_store.exists():
+        raise SystemExit(
+            f"predict output zarr does not exist: {output_store}\n  referenced by:                    {leaf_path}"
+        )
+
+    target_group = _ORGANELLE_EVAL_TARGET[organelle]
+    predict_set_group = _eval_predict_set_group(organelle, dataset_name)
+
+    target_yaml = (
+        _REPO_ROOT
+        / "applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/eval/target"
+        / f"{target_group}.yaml"
+    )
+    if not target_yaml.is_file():
+        raise SystemExit(f"eval target group YAML missing: {target_yaml}")
+
+    leaf_stem = leaf_path.stem
+    if leaf_stem == "predict__ipsc_confocal":
+        test_plate = "ipsc"
+    elif leaf_stem.endswith("_mock"):
+        test_plate = "mock"
+    elif leaf_stem.endswith("_denv"):
+        test_plate = "denv"
+    elif leaf_stem.endswith("_zikv"):
+        test_plate = "zikv"
+    else:
+        raise SystemExit(f"cannot infer test plate from leaf filename: {leaf_path.name}")
+
+    save_dir = eval_save_dir(
+        organelle=organelle,
+        code_model=code_model,
+        train_set=trained_on,
+        test_plate=test_plate,
+    )
+    overrides: dict[str, object] = {
+        "predict_set": predict_set_group,
+        "target": target_group,
+        "io.pred_path": str(output_store),
+        "save.save_dir": str(save_dir),
+        "compute_feature_metrics": True,
+    }
+    return overrides, organelle, code_model, save_dir, test_plate
+
+
+def _composite_job_name(organelle: str, code_model: str, trained_on: str, test_plates: list[str]) -> str:
+    train_key_short = {
+        "ipsc_confocal": "IPSC",
+        "a549_mantis": "A549",
+        "joint_ipsc_confocal_a549_mantis": "JOINT",
+    }[trained_on]
+    # Test scope: all-iPSC, all-A549, or mixed (the local runner enforces single test_set,
+    # but support graceful naming if a user batches arbitrary leaves).
+    if test_plates == ["ipsc"]:
+        test_scope = "IPSC"
+    elif set(test_plates) <= {"mock", "denv", "zikv"}:
+        test_scope = "A549"
+    else:
+        test_scope = "MIXED"
+    return f"EVAL_{organelle.upper()}_{_paper_key(code_model).upper()}_{train_key_short}_ON_{test_scope}"
+
+
+# Single-GPU sbatch profile. Eval is single-process Hydra; no DDP.
+_SBATCH_DIRECTIVES = (
+    ("--partition", "gpu"),
+    ("--nodes", "1"),
+    ("--ntasks-per-node", "1"),
+    ("--gpus", "1"),
+    ("--cpus-per-task", "8"),
+    ("--mem", "64G"),
+)
+
+
+def _render_sbatch(
+    job_name: str,
+    walltime: str,
+    run_root: Path,
+    cmds: list[list[str]],
+) -> str:
+    lines = ["#!/bin/bash", ""]
+    lines.append(f"#SBATCH --job-name={job_name}")
+    lines.append(f"#SBATCH --time={walltime}")
+    for flag, val in _SBATCH_DIRECTIVES:
+        lines.append(f"#SBATCH {flag}={val}")
+    lines.append(f"#SBATCH --output={run_root}/slurm/%j.out")
+    lines.append(f"#SBATCH --error={run_root}/slurm/%j.err")
+    lines.append("")
+    lines.append("set -euo pipefail")
+    lines.append("umask 0002")
+    lines.append(f"mkdir -p -m 775 {run_root}/slurm")
+    lines.append("")
+    lines.append("ml uv 2>/dev/null || true")
+    lines.append(f"cd {_REPO_ROOT}")
+    lines.append("")
+    lines.append("scontrol show job $SLURM_JOB_ID || true")
+    lines.append("nvidia-smi || true")
+    lines.append("")
+    for i, cmd in enumerate(cmds, 1):
+        joined = " ".join(cmd)
+        lines.append(f"echo '[batch] step {i}/{len(cmds)}'")
+        lines.append(f"srun {joined}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def submit(argv: list[str] | None = None) -> int:
+    """Render and submit a chained-eval sbatch from N predict leaves."""
+    os.umask(0o002)
+    args = _parse_args(argv)
+
+    overrides_list: list[dict[str, object]] = []
+    organelles: list[str] = []
+    code_models: list[str] = []
+    save_dirs: list[Path] = []
+    test_plates: list[str] = []
+    for leaf in args.leaves:
+        overrides, organelle, code_model, save_dir, test_plate = _resolve_one_leaf(leaf)
+        if args.overwrite:
+            overrides["force_recompute.all"] = True
+        overrides_list.append(overrides)
+        organelles.append(organelle)
+        code_models.append(code_model)
+        save_dirs.append(save_dir)
+        test_plates.append(test_plate)
+
+    if len(set(organelles)) != 1:
+        raise SystemExit(f"all leaves must share benchmark.organelle (got {sorted(set(organelles))})")
+    if len(set(code_models)) != 1:
+        raise SystemExit(f"all leaves must share benchmark.model_name (got {sorted(set(code_models))})")
+    organelle = organelles[0]
+    code_model = code_models[0]
+    # Re-pull trained_on from first leaf for naming (already validated above per-leaf).
+    from dynacell._compose_hook import _dynacell_ref_resolver  # noqa: PLC0415
+    from viscy_utils.compose import load_composed_config  # noqa: PLC0415
+
+    head_composed = load_composed_config(args.leaves[0], resolver=_dynacell_ref_resolver)
+    trained_on = head_composed["benchmark"]["trained_on"]
+
+    job_name = args.job_name or _composite_job_name(organelle, code_model, trained_on, test_plates)
+
+    if args.run_root is not None:
+        run_root = args.run_root
+    else:
+        gp = save_dirs[0].parent.parent
+        run_root = gp if gp.exists() else _DEFAULT_RUN_ROOT
+
+    # Build per-leaf command lines.
+    cmds: list[list[str]] = []
+    for overrides in overrides_list:
+        cmd = ["uv", "run", "dynacell", "evaluate"]
+        for k, v in overrides.items():
+            token = "true" if v is True else "false" if v is False else str(v)
+            cmd.append(f"{k}={token}")
+        cmds.append(cmd)
+
+    rendered = _render_sbatch(job_name, args.time, run_root, cmds)
+
+    if args.print_script:
+        sys.stdout.write(rendered)
+        return 0
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S_%f")
+    resolved_dir = run_root / "resolved"
+    slurm_dir = run_root / "slurm"
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+    slurm_dir.mkdir(parents=True, exist_ok=True)
+
+    sbatch_path = slurm_dir / f"{timestamp}_{job_name}.sbatch"
+    sbatch_path.write_text(rendered)
+
+    # Also drop a per-leaf overrides YAML for provenance, matching the
+    # single-leaf submitter's --dry-run output shape.
+    import yaml  # noqa: PLC0415
+
+    for i, overrides in enumerate(overrides_list):
+        plate = test_plates[i]
+        yml_path = resolved_dir / f"evaluate_{job_name}_{plate}_{timestamp}.yml"
+        yml_path.write_text(yaml.safe_dump(overrides, default_flow_style=False))
+
+    if args.dry_run:
+        print(f"[dry-run] sbatch:    {sbatch_path}")
+        for i in range(len(overrides_list)):
+            plate = test_plates[i]
+            print(f"[dry-run] overrides: {resolved_dir / f'evaluate_{job_name}_{plate}_{timestamp}.yml'}")
+        return 0
+
+    sbatch_cmd = ["sbatch"]
+    if args.parsable:
+        sbatch_cmd.append("--parsable")
+    sbatch_cmd.append(str(sbatch_path))
+    if args.parsable:
+        result = subprocess.run(sbatch_cmd, check=True, stdout=subprocess.PIPE, text=True)
+        print(result.stdout.strip())
+    else:
+        subprocess.run(sbatch_cmd, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(submit())

--- a/applications/dynacell/tools/submit_evaluation_job.py
+++ b/applications/dynacell/tools/submit_evaluation_job.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+r"""Stage a ``dynacell evaluate`` invocation from a predict leaf.
+
+Reads a per-plate predict leaf (the same YAML consumed by
+``submit_benchmark_job.py``), composes it via
+:func:`viscy_utils.compose.load_composed_config`, extracts the predicted
+zarr path (``output_store``) and the eval-side ``predict_set`` group name
+(via ``benchmark.dataset_ref.dataset``), maps the leaf's organelle to the
+eval ``target`` group, and builds the literal ``dynacell evaluate``
+override token list.
+
+Output:
+  * ``--print-cmd``: print the command (one token per line) to stdout.
+  * ``--dry-run``: write the command + a flat YAML of overrides to
+    ``<run_root>/resolved/evaluate_<job_name>_<timestamp>.{cmd,yml}``.
+  * default: execute the command via ``subprocess.run``.
+
+Usage::
+
+    LEAF=applications/dynacell/configs/benchmarks/virtual_staining/membrane
+    uv run python applications/dynacell/tools/submit_evaluation_job.py \
+        $LEAF/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml \
+        --dry-run --print-cmd
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from dynacell.evaluation.save_paths import (
+    DEFAULT_EVAL_RUN_ROOT as _DEFAULT_RUN_ROOT,
+)
+from dynacell.evaluation.save_paths import (
+    ORGANELLE_EVAL_TARGET as _ORGANELLE_EVAL_TARGET,
+)
+from dynacell.evaluation.save_paths import (
+    eval_predict_set_group as _eval_predict_set_group,
+)
+from dynacell.evaluation.save_paths import (
+    eval_save_dir,
+)
+from dynacell.evaluation.save_paths import (
+    extract_predict_output_store as _extract_output_store,
+)
+from dynacell.evaluation.save_paths import (
+    paper_key as _paper_key,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("leaf", type=Path, help="path to a predict leaf YAML")
+    ap.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="add ``force_recompute.all=true`` to the override list. Required to "
+        "regenerate metrics already present in save_dir.",
+    )
+    ap.add_argument(
+        "--run-root",
+        type=Path,
+        default=None,
+        help=(
+            "directory under which `resolved/` provenance lands. "
+            f"Default: derived from save_dir's grandparent, fallback {_DEFAULT_RUN_ROOT}."
+        ),
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="render command + overrides yaml to <run_root>/resolved/ but do not exec.",
+    )
+    ap.add_argument(
+        "--print-cmd",
+        action="store_true",
+        help="print the literal `dynacell evaluate` command to stdout (no exec). "
+        "Combine with --dry-run to also write provenance files.",
+    )
+    return ap.parse_args(argv)
+
+
+def submit(argv: list[str] | None = None) -> int:
+    """Stage and (optionally) submit a `dynacell evaluate` call."""
+    os.umask(0o002)
+    args = _parse_args(argv)
+
+    # Compose lazily so --help works without an editable dynacell install.
+    from dynacell._compose_hook import _dynacell_ref_resolver  # noqa: PLC0415
+    from viscy_utils.compose import load_composed_config  # noqa: PLC0415
+
+    leaf_path = args.leaf.resolve()
+    if not leaf_path.is_file():
+        raise SystemExit(f"leaf does not exist: {leaf_path}")
+    composed = load_composed_config(leaf_path, resolver=_dynacell_ref_resolver)
+    benchmark = composed.get("benchmark") or {}
+    organelle = benchmark.get("organelle")
+    code_model = benchmark.get("model_name")
+    trained_on = benchmark.get("trained_on")
+    dataset_ref = benchmark.get("dataset_ref") or {}
+    dataset_name = dataset_ref.get("dataset")
+    if not organelle or not code_model or not trained_on:
+        raise SystemExit(
+            f"{leaf_path}: missing benchmark.{{organelle, model_name, trained_on}} "
+            f"(got organelle={organelle!r}, model_name={code_model!r}, trained_on={trained_on!r})"
+        )
+    if not dataset_name:
+        raise SystemExit(f"{leaf_path}: missing benchmark.dataset_ref.dataset (needed to pick eval predict_set group)")
+
+    # Resolve the predict output zarr (must exist on disk — predict already ran).
+    output_store = _extract_output_store(composed, leaf_path)
+    if not output_store.exists():
+        raise SystemExit(
+            f"predict output zarr does not exist: {output_store}\n"
+            f"  referenced by:                    {leaf_path}\n"
+            f"  (run `dynacell predict -c <resolved>` first)"
+        )
+
+    # Map predict-side identifiers to eval-side Hydra groups.
+    target_group = _ORGANELLE_EVAL_TARGET[organelle]
+    predict_set_group = _eval_predict_set_group(organelle, dataset_name)
+
+    # Eval `target` group must exist on disk under the external searchpath.
+    target_yaml = (
+        _REPO_ROOT
+        / "applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/eval/target"
+        / f"{target_group}.yaml"
+    )
+    if not target_yaml.is_file():
+        raise SystemExit(f"eval target group YAML missing: {target_yaml}")
+
+    # Plate label for save_dir: ipsc | mock | denv | zikv.
+    # Predict leaves are named predict__<test_set>[_<cond>].yml. Extract the
+    # trailing condition for a549; the bare ipsc_confocal predict leaf is iPSC.
+    leaf_stem = leaf_path.stem  # predict__a549_mantis_mock
+    if leaf_stem == "predict__ipsc_confocal":
+        test_plate = "ipsc"
+    elif leaf_stem.endswith("_mock"):
+        test_plate = "mock"
+    elif leaf_stem.endswith("_denv"):
+        test_plate = "denv"
+    elif leaf_stem.endswith("_zikv"):
+        test_plate = "zikv"
+    else:
+        raise SystemExit(
+            f"cannot infer test plate from leaf filename: {leaf_path.name} "
+            f"(expected predict__ipsc_confocal.yml or predict__*_{{mock,denv,zikv}}.yml)"
+        )
+
+    save_dir = eval_save_dir(
+        organelle=organelle,
+        code_model=code_model,
+        train_set=trained_on,
+        test_plate=test_plate,
+    )
+
+    # job_name: EVAL_<ORG>_<MODEL_PAPER>_<TRAIN>_<PLATE>.
+    train_key_short = {
+        "ipsc_confocal": "IPSC",
+        "a549_mantis": "A549",
+        "joint_ipsc_confocal_a549_mantis": "JOINT",
+    }[trained_on]
+    plate_upper = "IPSC" if test_plate == "ipsc" else test_plate.upper()
+    job_name = f"EVAL_{organelle.upper()}_{_paper_key(code_model).upper()}_{train_key_short}_{plate_upper}"
+
+    # run_root: prefer save_dir's grandparent if it exists; else flag; else default.
+    if args.run_root is not None:
+        run_root = args.run_root
+    else:
+        grandparent = save_dir.parent.parent
+        run_root = grandparent if grandparent.exists() else _DEFAULT_RUN_ROOT
+
+    overrides: dict[str, object] = {
+        "predict_set": predict_set_group,
+        "target": target_group,
+        "io.pred_path": str(output_store),
+        "save.save_dir": str(save_dir),
+        "compute_feature_metrics": True,
+    }
+    if args.overwrite:
+        overrides["force_recompute.all"] = True
+
+    cmd_tokens = ["uv", "run", "dynacell", "evaluate"]
+    for k, v in overrides.items():
+        # Hydra wants lowercase booleans; everything else is straight repr.
+        if isinstance(v, bool):
+            token_val = "true" if v else "false"
+        else:
+            token_val = str(v)
+        cmd_tokens.append(f"{k}={token_val}")
+
+    if args.print_cmd:
+        sys.stdout.write("\n".join(cmd_tokens) + "\n")
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S_%f")
+    resolved_dir = run_root / "resolved"
+    cmd_path = resolved_dir / f"evaluate_{job_name}_{timestamp}.cmd"
+    yml_path = resolved_dir / f"evaluate_{job_name}_{timestamp}.yml"
+
+    if args.dry_run:
+        resolved_dir.mkdir(parents=True, exist_ok=True)
+        cmd_path.write_text("\n".join(cmd_tokens) + "\n")
+        yml_path.write_text(yaml.safe_dump(overrides, default_flow_style=False))
+        if not args.print_cmd:
+            print(f"[dry-run] cmd:       {cmd_path}")
+            print(f"[dry-run] overrides: {yml_path}")
+            print(f"[dry-run] job_name:  {job_name}")
+            print(f"[dry-run] save_dir:  {save_dir}")
+        return 0
+
+    # Execute. Surface stdout/stderr live; raise on non-zero.
+    subprocess.run(cmd_tokens, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(submit())

--- a/applications/dynacell/tools/submit_evaluation_job.py
+++ b/applications/dynacell/tools/submit_evaluation_job.py
@@ -216,6 +216,11 @@ def submit(argv: list[str] | None = None) -> int:
             print(f"[dry-run] save_dir:  {save_dir}")
         return 0
 
+    if args.print_cmd:
+        # `--print-cmd` alone (without `--dry-run`) emits the resolved command
+        # to stdout for shell-level chaining (used by evaluate_local.sh).
+        return 0
+
     # Execute. Surface stdout/stderr live; raise on non-zero.
     subprocess.run(cmd_tokens, check=True)
     return 0

--- a/packages/viscy-models/src/viscy_models/foundation/__init__.py
+++ b/packages/viscy-models/src/viscy_models/foundation/__init__.py
@@ -1,6 +1,7 @@
 """Pretrained foundation model wrappers."""
 
+from viscy_models.foundation.cell_dino import CellDinoModel
 from viscy_models.foundation.dinov3 import DINOv3Model
 from viscy_models.foundation.openphenom import OpenPhenomModel
 
-__all__ = ["DINOv3Model", "OpenPhenomModel"]
+__all__ = ["CellDinoModel", "DINOv3Model", "OpenPhenomModel"]

--- a/packages/viscy-models/src/viscy_models/foundation/_dinov2_vit.py
+++ b/packages/viscy-models/src/viscy_models/foundation/_dinov2_vit.py
@@ -1,0 +1,344 @@
+"""Vendored DINOv2 vision transformer (eval-only subset) for CELL-DINO.
+
+Vendored from https://github.com/facebookresearch/dinov2 (Apache-2.0).
+Stripped to what is needed to load CELL-DINO checkpoints and run frozen
+inference: ``DinoVisionTransformer`` + ``Block`` + standard ``Attention``
+(no xformers, no NestedTensorBlock, no stochastic depth machinery, no
+CausalAttentionBlock).
+
+Module layout matches the original so the published CELL-DINO state_dicts
+(``cls_token``, ``pos_embed``, ``patch_embed.proj.*``, ``blocks.X.Y.*``,
+``norm.*``) load cleanly.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import partial
+from typing import Callable, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+
+def _make_2tuple(x: int | Tuple[int, int]) -> Tuple[int, int]:
+    if isinstance(x, tuple):
+        if len(x) != 2:
+            raise ValueError(f"expected 2-tuple, got {x!r}")
+        return x
+    return (x, x)
+
+
+class PatchEmbed(nn.Module):
+    """2D image to patch embedding: (B, C, H, W) -> (B, N, D)."""
+
+    def __init__(
+        self,
+        img_size: int | Tuple[int, int] = 224,
+        patch_size: int | Tuple[int, int] = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+        flatten_embedding: bool = True,
+    ) -> None:
+        super().__init__()
+        image_hw = _make_2tuple(img_size)
+        patch_hw = _make_2tuple(patch_size)
+        self.img_size = image_hw
+        self.patch_size = patch_hw
+        self.patches_resolution = (image_hw[0] // patch_hw[0], image_hw[1] // patch_hw[1])
+        self.num_patches = self.patches_resolution[0] * self.patches_resolution[1]
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+        self.flatten_embedding = flatten_embedding
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_hw, stride=patch_hw)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        _, _, h, w = x.shape
+        ph, pw = self.patch_size
+        if h % ph != 0 or w % pw != 0:
+            raise ValueError(f"input {h}x{w} not divisible by patch {ph}x{pw}")
+        x = self.proj(x)
+        h_out, w_out = x.size(2), x.size(3)
+        x = x.flatten(2).transpose(1, 2)
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = x.reshape(-1, h_out, w_out, self.embed_dim)
+        return x
+
+
+class LayerScale(nn.Module):
+    """Per-channel learnable gain applied after attention/MLP."""
+
+    def __init__(self, dim: int, init_values: float = 1e-5, inplace: bool = False) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(torch.full((dim,), float(init_values)))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+class Attention(nn.Module):
+    """Standard multi-head self-attention using PyTorch SDPA (no xformers)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        attn_drop: float = 0.0,
+        proj_drop: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = attn_drop
+        self.proj = nn.Linear(dim, dim, bias=proj_bias)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x: Tensor) -> Tensor:
+        b, n, c = x.shape
+        qkv = self.qkv(x).reshape(b, n, 3, self.num_heads, c // self.num_heads)
+        q, k, v = torch.unbind(qkv, 2)
+        q, k, v = (t.transpose(1, 2) for t in (q, k, v))
+        x = nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=self.attn_drop if self.training else 0.0)
+        x = x.transpose(1, 2).contiguous().view(b, n, c)
+        return self.proj_drop(self.proj(x))
+
+
+class Mlp(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+        drop: float = 0.0,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features, bias=bias)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features, bias=bias)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.drop(self.act(self.fc1(x)))
+        return self.drop(self.fc2(x))
+
+
+class Block(nn.Module):
+    """Pre-norm transformer block with LayerScale (eval-only, no drop_path)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = False,
+        proj_bias: bool = True,
+        ffn_bias: bool = True,
+        init_values: Optional[float] = None,
+        norm_layer: Callable[..., nn.Module] = nn.LayerNorm,
+        act_layer: Callable[..., nn.Module] = nn.GELU,
+    ) -> None:
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+        self.attn = Attention(dim, num_heads=num_heads, qkv_bias=qkv_bias, proj_bias=proj_bias)
+        self.ls1 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=act_layer, bias=ffn_bias)
+        self.ls2 = LayerScale(dim, init_values=init_values) if init_values else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = x + self.ls1(self.attn(self.norm1(x)))
+        x = x + self.ls2(self.mlp(self.norm2(x)))
+        return x
+
+
+class BlockChunk(nn.ModuleList):
+    """Sequential block group used when ``block_chunks > 0`` (matches state_dict layout)."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        for blk in self:
+            x = blk(x)
+        return x
+
+
+class DinoVisionTransformer(nn.Module):
+    """Eval-only DINOv2 ViT.
+
+    Parameters
+    ----------
+    img_size, patch_size, in_chans : int
+        Patch-embedding geometry.  CELL-DINO ``channel_adaptive_dino_vitl16``
+        was trained at ``img_size=224, patch_size=16, in_chans=1``.
+    embed_dim, depth, num_heads, mlp_ratio : int / float
+        Backbone size.  ViT-L = ``(1024, 24, 16, 4.0)``.
+    init_values : float
+        LayerScale init.  CELL-DINO uses ``1.0``.
+    block_chunks : int
+        Splits blocks into ``block_chunks`` ``BlockChunk`` groups so that
+        parameter names match published checkpoints (``blocks.<chunk>.<idx>.*``).
+        CELL-DINO uses ``4``.
+    channel_adaptive : bool
+        Stored as ``self.bag_of_channels``.  Wrapper code outside this module
+        is responsible for the ``(B,C,H,W) -> (B*C,1,H,W)`` reshape; this flag
+        is recorded so the wrapper can branch.
+    """
+
+    def __init__(
+        self,
+        img_size: int = 224,
+        patch_size: int = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        depth: int = 12,
+        num_heads: int = 12,
+        mlp_ratio: float = 4.0,
+        qkv_bias: bool = True,
+        ffn_bias: bool = True,
+        proj_bias: bool = True,
+        init_values: Optional[float] = None,
+        block_chunks: int = 1,
+        num_register_tokens: int = 0,
+        interpolate_antialias: bool = False,
+        interpolate_offset: float = 0.1,
+        channel_adaptive: bool = False,
+    ) -> None:
+        super().__init__()
+        if num_register_tokens < 0:
+            raise ValueError("num_register_tokens must be >= 0")
+        norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.num_features = self.embed_dim = embed_dim
+        self.num_tokens = 1
+        self.n_blocks = depth
+        self.num_heads = num_heads
+        self.patch_size = patch_size
+        self.num_register_tokens = num_register_tokens
+        self.interpolate_antialias = interpolate_antialias
+        self.interpolate_offset = interpolate_offset
+        self.bag_of_channels = channel_adaptive
+
+        self.patch_embed = PatchEmbed(img_size=img_size, patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim)
+        num_patches = self.patch_embed.num_patches
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + self.num_tokens, embed_dim))
+        self.register_tokens = (
+            nn.Parameter(torch.zeros(1, num_register_tokens, embed_dim)) if num_register_tokens else None
+        )
+
+        blocks_list = [
+            Block(
+                dim=embed_dim,
+                num_heads=num_heads,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                proj_bias=proj_bias,
+                ffn_bias=ffn_bias,
+                init_values=init_values,
+                norm_layer=norm_layer,
+            )
+            for _ in range(depth)
+        ]
+        if block_chunks > 0:
+            self.chunked_blocks = True
+            chunked = []
+            chunksize = depth // block_chunks
+            for i in range(0, depth, chunksize):
+                chunked.append([nn.Identity()] * i + blocks_list[i : i + chunksize])
+            self.blocks = nn.ModuleList([BlockChunk(p) for p in chunked])
+        else:
+            self.chunked_blocks = False
+            self.blocks = nn.ModuleList(blocks_list)
+
+        self.norm = norm_layer(embed_dim)
+        self.head = nn.Identity()
+        self.mask_token = nn.Parameter(torch.zeros(1, embed_dim))
+
+    def interpolate_pos_encoding(self, x: Tensor, w: int, h: int) -> Tensor:
+        previous_dtype = x.dtype
+        npatch = x.shape[1] - 1
+        n = self.pos_embed.shape[1] - 1
+        if npatch == n and w == h:
+            return self.pos_embed
+        pos_embed = self.pos_embed.float()
+        class_pos = pos_embed[:, 0]
+        patch_pos = pos_embed[:, 1:]
+        dim = x.shape[-1]
+        w0 = w // self.patch_size
+        h0 = h // self.patch_size
+        m = int(math.sqrt(n))
+        if n != m * m:
+            raise AssertionError("non-square positional grid not supported")
+        if self.interpolate_offset:
+            sx = float(w0 + self.interpolate_offset) / m
+            sy = float(h0 + self.interpolate_offset) / m
+            kwargs = {"scale_factor": (sx, sy)}
+        else:
+            kwargs = {"size": (w0, h0)}
+        patch_pos = nn.functional.interpolate(
+            patch_pos.reshape(1, m, m, dim).permute(0, 3, 1, 2),
+            mode="bicubic",
+            antialias=self.interpolate_antialias,
+            **kwargs,
+        )
+        patch_pos = patch_pos.permute(0, 2, 3, 1).view(1, -1, dim)
+        return torch.cat((class_pos.unsqueeze(0), patch_pos), dim=1).to(previous_dtype)
+
+    def prepare_tokens_with_masks(self, x: Tensor, masks: Optional[Tensor] = None) -> Tensor:
+        _, _, w, h = x.shape
+        x = self.patch_embed(x)
+        if masks is not None:
+            x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)
+        x = torch.cat((self.cls_token.expand(x.shape[0], -1, -1), x), dim=1)
+        x = x + self.interpolate_pos_encoding(x, w, h)
+        if self.register_tokens is not None:
+            x = torch.cat(
+                (x[:, :1], self.register_tokens.expand(x.shape[0], -1, -1), x[:, 1:]),
+                dim=1,
+            )
+        return x
+
+    def forward_features(self, x: Tensor, masks: Optional[Tensor] = None) -> dict:
+        x = self.prepare_tokens_with_masks(x, masks)
+        for blk in self.blocks:
+            x = blk(x)
+        x_norm = self.norm(x)
+        return {
+            "x_norm_clstoken": x_norm[:, 0],
+            "x_norm_regtokens": x_norm[:, 1 : self.num_register_tokens + 1],
+            "x_norm_patchtokens": x_norm[:, self.num_register_tokens + 1 :],
+            "x_prenorm": x,
+            "masks": masks,
+        }
+
+    def forward(self, x: Tensor, is_training: bool = False) -> Tensor | dict:
+        ret = self.forward_features(x)
+        return ret if is_training else self.head(ret["x_norm_clstoken"])
+
+
+def vit_large(
+    patch_size: int = 16,
+    in_chans: int = 3,
+    channel_adaptive: bool = False,
+    **kwargs,
+) -> DinoVisionTransformer:
+    """ViT-L factory matching ``dinov2.models.vision_transformer.vit_large``."""
+    return DinoVisionTransformer(
+        patch_size=patch_size,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        mlp_ratio=4.0,
+        in_chans=in_chans,
+        channel_adaptive=channel_adaptive,
+        **kwargs,
+    )

--- a/packages/viscy-models/src/viscy_models/foundation/_dinov2_vit.py
+++ b/packages/viscy-models/src/viscy_models/foundation/_dinov2_vit.py
@@ -249,6 +249,11 @@ class DinoVisionTransformer(nn.Module):
             for _ in range(depth)
         ]
         if block_chunks > 0:
+            if depth % block_chunks != 0:
+                # `range(0, depth, depth // block_chunks)` produces more than
+                # `block_chunks` iterations when this divides unevenly, which
+                # silently breaks the published state_dict layout.
+                raise ValueError(f"depth ({depth}) must be divisible by block_chunks ({block_chunks}).")
             self.chunked_blocks = True
             chunked = []
             chunksize = depth // block_chunks

--- a/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
+++ b/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
@@ -1,0 +1,154 @@
+"""CELL-DINO foundation model wrapper for frozen feature extraction.
+
+CELL-DINO is a DINOv2-architecture ViT pretrained on fluorescence microscopy
+(Human Protein Atlas).  The ``channel_adaptive_dino_vitl16`` checkpoint
+processes one channel at a time through a single-channel ViT-L/16 stem; the
+wrapper reshapes ``(B, C, H, W) -> (B*C, 1, H, W)``, runs the backbone, and
+mean-pools the cls token across channels to produce a fixed-dimension
+embedding regardless of the input channel count.
+
+Weights are loaded from a local ``.pth`` state_dict; nothing is fetched
+from the network.  See
+``/hpc/projects/organelle_phenotyping/models/CELL-DINO/model_weights/weights/``
+for the published checkpoints.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from viscy_models.foundation._dinov2_vit import vit_large
+
+
+class CellDinoModel(nn.Module):
+    """Wrap CELL-DINO (channel-adaptive ViT-L/16) for microscopy embeddings.
+
+    The model accepts raw dataloader tensors ``(B, C, D, H, W)`` directly in
+    :meth:`forward` — preprocessing is applied inline.  Z-slice selection is
+    **not** handled here — configure ``z_range`` on the dataloader so it
+    delivers the correct focal plane.
+
+    Parameters
+    ----------
+    weights_path : str
+        Path to the local ``.pth`` state_dict.  The default
+        ``channel_adaptive_dino_vitl16_pretrain_cells-ef7c17ff.pth`` is a
+        single-channel ViT-L/16 trained at 224 px with ``init_values=1.0``
+        and ``block_chunks=4``.
+    img_size : int
+        Spatial size after :meth:`preprocess_2d`, by default ``224``.
+    patch_size : int
+        Patch size for the ViT, by default ``16``.
+    freeze : bool
+        If ``True`` (default), all backbone parameters are frozen and the
+        model is kept in eval mode.
+    projection : nn.Module or None
+        Optional trainable projection head applied to backbone features.
+        When provided, :meth:`forward` returns ``(features, projection(features))``.
+        When ``None`` (default), returns ``(features, features)``.
+    """
+
+    def __init__(
+        self,
+        weights_path: str,
+        img_size: int = 224,
+        patch_size: int = 16,
+        freeze: bool = True,
+        projection: nn.Module | None = None,
+    ) -> None:
+        super().__init__()
+        self.projection = projection
+        self.target_size = (img_size, img_size)
+
+        self.model = vit_large(
+            patch_size=patch_size,
+            in_chans=1,
+            channel_adaptive=True,
+            img_size=img_size,
+            init_values=1.0,
+            block_chunks=4,
+            num_register_tokens=0,
+            interpolate_antialias=False,
+            interpolate_offset=0.1,
+        )
+
+        state_dict = torch.load(weights_path, map_location="cpu", weights_only=True)
+        if "state_dict" in state_dict and isinstance(state_dict["state_dict"], dict):
+            state_dict = state_dict["state_dict"]
+        missing, unexpected = self.model.load_state_dict(state_dict, strict=True)
+        if missing or unexpected:
+            raise RuntimeError(f"CELL-DINO state_dict mismatch — missing={missing}, unexpected={unexpected}")
+
+        self.freeze = freeze
+        if freeze:
+            self.model.requires_grad_(False)
+            self.model.eval()
+
+    def train(self, mode: bool = True) -> "CellDinoModel":
+        """Override train to keep backbone in eval when frozen."""
+        super().train(mode)
+        if self.freeze:
+            self.model.eval()
+        return self
+
+    def preprocess_2d(self, x: Tensor) -> Tensor:
+        """Convert a raw dataloader tensor to CELL-DINO input.
+
+        Squeezes singleton Z (or takes the middle slice if Z>1), resizes to
+        ``self.target_size``, and per-image min/max scales each
+        ``(B*C)`` map to ``[0, 1]``.  No ImageNet mean/std is applied —
+        CELL-DINO uses simple ``[0,1]`` normalization in training.
+
+        Parameters
+        ----------
+        x : Tensor
+            ``(B, C, D, H, W)`` or ``(B, C, H, W)``.
+
+        Returns
+        -------
+        Tensor
+            ``(B, C, H_target, W_target)`` ready for :meth:`forward`.  The
+            wrapper reshapes ``(B, C, ...) -> (B*C, 1, ...)`` inside
+            :meth:`forward`, so this method preserves the channel axis.
+        """
+        if x.ndim == 5:
+            if x.shape[2] == 1:
+                x = x[:, :, 0]
+            else:
+                x = x[:, :, x.shape[2] // 2]
+
+        x = F.interpolate(x, size=self.target_size, mode="bilinear", align_corners=False)
+
+        b, c, h, w = x.shape
+        x = x.view(b * c, 1, h, w)
+        x_min = x.amin(dim=(2, 3), keepdim=True)
+        x_max = x.amax(dim=(2, 3), keepdim=True)
+        x = (x - x_min) / (x_max - x_min).clamp(min=1e-8)
+        return x.view(b, c, h, w)
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Run CELL-DINO on an image batch and mean-pool over channels.
+
+        Preprocessing is applied inline, so raw dataloader tensors
+        ``(B, C, D, H, W)`` or ``(B, C, H, W)`` can be passed directly.
+
+        Returns
+        -------
+        tuple[Tensor, Tensor]
+            ``(features, projections)`` where features are the
+            channel-mean-pooled cls token of shape ``(B, 1024)``.  If
+            ``projection`` was provided at init, projections are
+            ``self.projection(features)``; otherwise both elements are the
+            same features tensor.
+        """
+        x = self.preprocess_2d(x)
+        b, c, h, w = x.shape
+        x = x.reshape(b * c, 1, h, w)
+        cls = self.model(x)
+        cls = cls.view(b, c, -1).mean(dim=1)
+        if self.projection is not None:
+            return (cls, self.projection(cls))
+        return (cls, cls)

--- a/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
+++ b/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
@@ -8,9 +8,9 @@ mean-pools the cls token across channels to produce a fixed-dimension
 embedding regardless of the input channel count.
 
 Weights are loaded from a local ``.pth`` state_dict; nothing is fetched
-from the network.  See
-``/hpc/projects/organelle_phenotyping/models/CELL-DINO/model_weights/weights/``
-for the published checkpoints.
+from the network.  The caller passes the path explicitly via
+``weights_path``; one example location (Biohub HPC) is
+``/hpc/projects/organelle_phenotyping/models/CELL-DINO/model_weights/weights/``.
 """
 
 from __future__ import annotations
@@ -34,9 +34,9 @@ class CellDinoModel(nn.Module):
     Parameters
     ----------
     weights_path : str
-        Path to the local ``.pth`` state_dict.  The default
-        ``channel_adaptive_dino_vitl16_pretrain_cells-ef7c17ff.pth`` is a
-        single-channel ViT-L/16 trained at 224 px with ``init_values=1.0``
+        Path to a local ``.pth`` state_dict (required, no default). An
+        example is ``channel_adaptive_dino_vitl16_pretrain_cells-ef7c17ff.pth``
+        — a single-channel ViT-L/16 trained at 224 px with ``init_values=1.0``
         and ``block_chunks=4``.
     img_size : int
         Spatial size after :meth:`preprocess_2d`, by default ``224``.

--- a/uv.lock
+++ b/uv.lock
@@ -1157,8 +1157,10 @@ eval = [
     { name = "microssim" },
     { name = "pandas" },
     { name = "scikit-image" },
+    { name = "scikit-learn" },
     { name = "scipy" },
     { name = "segmenter-model-zoo" },
+    { name = "torch-fidelity" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -1216,8 +1218,10 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'report'" },
     { name = "pydantic", specifier = ">=2" },
     { name = "scikit-image", marker = "extra == 'eval'" },
+    { name = "scikit-learn", marker = "extra == 'eval'", specifier = ">=1.4" },
     { name = "scipy", marker = "extra == 'eval'" },
     { name = "segmenter-model-zoo", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/segmenter_model_zoo.git?branch=main" },
+    { name = "torch-fidelity", marker = "extra == 'eval'", git = "https://github.com/toshas/torch-fidelity.git?rev=5e211a9" },
     { name = "tqdm", marker = "extra == 'eval'" },
     { name = "tqdm", marker = "extra == 'preprocess'" },
     { name = "transformers", marker = "extra == 'eval'" },
@@ -5682,6 +5686,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
     { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
     { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
+]
+
+[[package]]
+name = "torch-fidelity"
+version = "0.4.0"
+source = { git = "https://github.com/toshas/torch-fidelity.git?rev=5e211a9#5e211a950a7b45206bd4976813ffd6aed6cf4ccc" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrate dynacell's eval pipeline to **torch-fidelity** for FID/KID/PRC/MIND, adding KID std + non-parametric P/R/F1 bootstrap + MIND (kernel-free, motivated by the paper's Appendix I mode-collapse analysis).
- Add **CP feature selection** (vendored pycytominer variance + correlation pruning, BSD-3), **FOV-stratified linear probes** (real-vs-pred + cross-condition), and the **`dynacell.evaluation.cross_condition_probe` CLI** with per-plate MAD scaling to cancel illumination/exposure offsets.
- Add high-level **eval-runner scripts** (`evaluate_local.sh`, `evaluate_batch.sh`) plus `submit_evaluation_{job,batch}.py` Hydra-override staging tools; save-dir naming routes through a new `save_paths.py` that stays bit-identical to the paper aggregation scripts.

Stacks on `dynacell-models` (PR #404).

## Test plan

- [x] `uv run pytest applications/dynacell/src/dynacell/evaluation/ applications/dynacell/tests/test_evaluation_metrics.py applications/dynacell/tests/test_evaluation_pipeline.py --deselect applications/dynacell/tests/test_evaluation_metrics.py::test_gain_and_offset_errors_are_not_scale_invariant` → 41/41 pass (10 feature_metrics, 8 feature_select, 9 linear_probe, 13 evaluation_metrics, 1 evaluation_pipeline). The one deselected test is a pre-existing failure on `dynacell-models` (commit `bfc61891` made `nrmse` scale-invariant).
- [x] `uvx ruff check` clean on all touched files.
- [x] `submit_evaluation_job.py --dry-run` on `membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml` produces canonical `eval_fnet3d_a549trained_membrane_mock` save_dir with correct `.cmd` + `.yml` provenance.
- [x] `eval_save_dir` matches `paper/scripts/compute_all_organelle_precision_recall.py:eval_dir_for` on 5 spot-checked (organelle, model, train_set, plate) combos including iPSC-trained, A549-trained, and joint flavors.
- [x] Real-data `cross_condition_probe` on three celldiff joint membrane A549 plates: CP AUROCs in [0.46, 0.71] (no longer 1.0 after per-plate MAD + select_features), DINOv3/DynaCLR at ceiling consistent with cross-condition morphology being learnable in deep embedding space.
- [ ] End-to-end `uv run dynacell evaluate ...` on a real predict zarr (requires DINOv3 + DynaCLR weights cached + segmentation; left for reviewer to drive once stacked PR lands).

## Notes

- `torch-fidelity` is pinned via git URL to commit `5e211a9` because MIND is not in any tagged release yet.
- `save_paths.py` is deliberately duplicated with the paper repo's `compute_all_organelle_precision_recall.py:eval_dir_for`; both files carry a comment pointing at the other.
- Per-(FOV, timepoint) KID columns on ~50-cell A549 cohorts are noisy and flagged as exploratory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)