### PR TITLE
feat(dynacell): add 3D pix2pix GAN baseline (pix2pix3d_unetvit)

### DIFF
--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
@@ -1,0 +1,21 @@
+# pix2pix3d_unetvit fit overlay — model + trainer only.
+# HCS data hparams reuse data_overlays/unetvit3d_fit.yml; single-store
+# train leaves compose both, joint (BatchedConcatDataModule) leaves
+# compose only this one and author data: themselves.
+#
+# Differs from unetvit3d_fit.yml by splitting the LR into lr_g/lr_d
+# (DynacellGAN has no `lr` param — it would raise UnexpectedKeyword).
+base:
+  - ../../../../../../recipes/models/pix2pix3d_unetvit.yml
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  init_args:
+    lr_g: 0.0003
+    lr_d: 0.0003
+    schedule: WarmupCosine
+    warmup_steps: 8500
+    warmup_multiplier: 1e-3
+trainer:
+  precision: bf16-mixed
+  max_epochs: 20

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
@@ -5,6 +5,10 @@
 #
 # Differs from unetvit3d_fit.yml by splitting the LR into lr_g/lr_d
 # (DynacellGAN has no `lr` param — it would raise UnexpectedKeyword).
+#
+# TTUR: lr_d = lr_g / 10. The 1:1 schedule collapsed to D-dominance
+# (loss/d_train -> 1e-4 by epoch ~5; loss/g_adv pinned at 1.0, no
+# adversarial gradient). Slowing D 10x is the canonical pix2pix fix.
 base:
   - ../../../../../../recipes/models/pix2pix3d_unetvit.yml
   - ../../../../../../recipes/trainer/fit.yml
@@ -12,7 +16,7 @@ base:
 model:
   init_args:
     lr_g: 0.0003
-    lr_d: 0.0003
+    lr_d: 3.0e-5
     schedule: WarmupCosine
     warmup_steps: 8500
     warmup_multiplier: 1e-3

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
@@ -2,9 +2,11 @@
 #
 # Sibling of pix2pix3d_unetvit_fit.yml that swaps in the GAN-aware DDP
 # topology (find_unused_parameters=True). All model and trainer hparams
-# (lr_g/lr_d/schedule/warmup, precision, max_epochs) are identical to the
-# single-GPU overlay — we evaluate DDP at the same per-rank optimization
-# settings as the in-flight single-GPU run before considering LR scaling.
+# (lr_g/lr_d/schedule/warmup, precision, max_epochs) match the single-GPU
+# overlay — we evaluate DDP at the same per-rank optimization settings.
+#
+# TTUR: lr_d = lr_g / 10 (see pix2pix3d_unetvit_fit.yml for rationale —
+# 1:1 lr collapsed to D-dominance within ~5 epochs on the prior DDP run).
 #
 # See recipes/topology/ddp_4gpu_gan.yml for why plain ddp_4gpu.yml is not
 # compatible with the alternating-optimizer training_step.
@@ -15,7 +17,7 @@ base:
 model:
   init_args:
     lr_g: 0.0003
-    lr_d: 0.0003
+    lr_d: 3.0e-5
     schedule: WarmupCosine
     warmup_steps: 8500
     warmup_multiplier: 1e-3

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
@@ -1,0 +1,24 @@
+# pix2pix3d_unetvit fit overlay — 4-GPU DDP variant.
+#
+# Sibling of pix2pix3d_unetvit_fit.yml that swaps in the GAN-aware DDP
+# topology (find_unused_parameters=True). All model and trainer hparams
+# (lr_g/lr_d/schedule/warmup, precision, max_epochs) are identical to the
+# single-GPU overlay — we evaluate DDP at the same per-rank optimization
+# settings as the in-flight single-GPU run before considering LR scaling.
+#
+# See recipes/topology/ddp_4gpu_gan.yml for why plain ddp_4gpu.yml is not
+# compatible with the alternating-optimizer training_step.
+base:
+  - ../../../../../../recipes/models/pix2pix3d_unetvit.yml
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/ddp_4gpu_gan.yml
+model:
+  init_args:
+    lr_g: 0.0003
+    lr_d: 0.0003
+    schedule: WarmupCosine
+    warmup_steps: 8500
+    warmup_multiplier: 1e-3
+trainer:
+  precision: bf16-mixed
+  max_epochs: 20

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
@@ -1,0 +1,21 @@
+# pix2pix3d_unetvit predict overlay.
+# Binds the pix2pix3d_unetvit model recipe + predict trainer recipe, then
+# layers predict-time model hparams and data-loader settings.
+# Predict-time normalizations and data_path are leaf-owned (leaf overrides
+# target-inherited values to match each organelle's test_cropped store).
+# Predict path uses self.generator only via DynacellGAN.predict_step; the
+# discriminator is not exposed at inference.
+base:
+  - ../../../../../../recipes/models/pix2pix3d_unetvit.yml
+  - ../../../../../../recipes/trainer/predict.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  init_args:
+    predict_method: full_image
+    predict_overlap: [4, 256, 256]
+data:
+  init_args:
+    z_window_size: 8
+    batch_size: 1
+    num_workers: 0
+    yx_patch_size: [512, 512]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit fit on ER (SEC61B marker) — A549 mantis-lightsheet pooled (mock + DENV + ZIKV).
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_A549_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints
+
+data:
+  init_args:
+    # A549 pooled store + target_channel — no resolver in this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/SEC61B_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: ER (SEC61B) predicted by pix2pix3d_unetvit on a549-mantis-sec61b-denv.
+defaults:
+  - override /target: er_sec61b
+  - override /predict_set: a549_mantis_sec61b_denv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_denv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_sec61b_pix2pix3d_unetvit__sec61b_denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: ER (SEC61B) predicted by pix2pix3d_unetvit on a549-mantis-sec61b-mock.
+defaults:
+  - override /target: er_sec61b
+  - override /predict_set: a549_mantis_sec61b_mock
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_mock.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_sec61b_pix2pix3d_unetvit__sec61b_mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: ER (SEC61B) predicted by pix2pix3d_unetvit on a549-mantis-sec61b-zikv.
+defaults:
+  - override /target: er_sec61b
+  - override /predict_set: a549_mantis_sec61b_zikv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_zikv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_sec61b_pix2pix3d_unetvit__sec61b_zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+# Benchmark eval leaf: ER (SEC61B) predicted by pix2pix3d_unetvit on iPSC confocal.
+defaults:
+  - override /target: er_sec61b
+  - override /predict_set: ipsc_confocal
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_pix2pix3d_unetvit.zarr
+
+compute_feature_metrics: true
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/eval_sec61b_pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: ER (SEC61B) trained on iPSC, predicting against a549_mantis_sec61b_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_sec61b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: ER (SEC61B) trained on iPSC, predicting against a549_mantis_sec61b_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_sec61b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: ER (SEC61B) trained on iPSC, predicting against a549_mantis_sec61b_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: ER (SEC61B) against ipsc_confocal test_cropped.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: ipsc_confocal
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -1,0 +1,37 @@
+# pix2pix3d_unetvit fit on ER (SEC61B marker) — AICS iPSC confocal.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_iPSC_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu.yml
@@ -1,0 +1,51 @@
+# pix2pix3d_unetvit fit on ER (SEC61B) — 4-GPU DDP production leaf.
+#
+# Sibling of train.yml that swaps the model overlay + hardware profile to
+# the 4-GPU GAN DDP topology (find_unused_parameters=True). The DDP run is
+# the canonical production run going forward; we keep `experiment_id` and
+# `launcher.run_root` / `ModelCheckpoint.dirpath` IDENTICAL to train.yml
+# so checkpoints land in the same canonical subtree (Phase 4 predict leaves
+# reference that path). W&B run name and slurm job name are suffixed
+# `_4gpu` to disambiguate from the in-flight single-GPU run sharing the
+# same experiment_id.
+#
+# Per-GPU batch_size stays at 4 (inherited from data_overlays/unetvit3d_fit
+# via single-GPU recipe). Effective batch = 16 across 4 ranks. lr_g/lr_d
+# are NOT scaled by GPU count — we want to evaluate DDP at the same
+# per-rank optimization settings as the single-GPU run first.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_4gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_iPSC_SEC61B_4gpu
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_SEC61B_4gpu
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_smoke.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_smoke.yml
@@ -1,0 +1,70 @@
+# Single-GPU smoke for pix2pix3d_unetvit on the iPSC SEC61B test48 store.
+#
+# Purpose: validate compose / instantiate / training-loop end-to-end on a
+# 48-FOV debug zarr without the full SEC61B.zarr mmap_preload that blows
+# a smoke wall. Pair with `--override trainer.fast_dev_run=true` (or
+# rely on the inline `trainer.max_steps: 20`) at submit time.
+#
+# Two constraints vs naive override of er/unetvit3d/ipsc_confocal/train.yml:
+# (1) `targets/er_sec61b.yml` sets `benchmark.dataset_ref` so the compose
+#     hook would resolve data_path from the manifest and raise on the
+#     inline data_path below. We null `dataset_ref` to disable the
+#     resolver (`dataset_ref_from_dict` returns None for non-dict refs,
+#     so the resolver no-ops — see dynacell/data/resolver.py:66-81).
+# (2) `targets/er_sec61b.yml` sets `augmentations[0].init_args.num_samples: 2`,
+#     and HCSDataModule._train_transform requires `batch_size %
+#     num_samples == 0` for non-BatchedConcat datamodules. We keep
+#     `num_samples: 2` and set `batch_size: 2` (the simplest way to
+#     satisfy 2 % 2 == 0; do not override the augmentation's num_samples
+#     from the smoke leaf).
+#
+# `source_channel` / `target_channel` are normally populated by the
+# compose-hook resolver from the manifest entry; since we disable the
+# resolver, they are authored inline here.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/wall_smoke.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__smoke
+  # Null disables the compose-hook resolver so the inline data_path /
+  # source_channel / target_channel below take effect without colliding.
+  dataset_ref: null
+
+data:
+  init_args:
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_test48.zarr
+    source_channel: [Phase3D]
+    target_channel: [Structure]
+    batch_size: 2
+
+trainer:
+  # Smoke runs don't need a logger. `false` disables the recipe's WandbLogger
+  # so consumers don't have to remember --override trainer.logger=false.
+  # LearningRateMonitor (recipe default) raises without a logger AND
+  # manual schedulers don't play well with it under DynacellGAN — so the
+  # callbacks list is replaced with only ModelCheckpoint (lists replace
+  # wholesale under deep_merge).
+  logger: false
+  max_steps: 20
+  max_epochs: 1
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_last: true
+        every_n_train_steps: 10
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/smoke/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_SEC61B_SMOKE
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/smoke

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_smoke_4gpu.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_smoke_4gpu.yml
@@ -1,0 +1,64 @@
+# 4-GPU DDP smoke for pix2pix3d_unetvit on the iPSC SEC61B test48 store.
+#
+# Purpose: validate the GAN-aware DDP topology (find_unused_parameters=True)
+# + HCSDataModule single-set DistributedSampler integration end-to-end on a
+# 48-FOV debug zarr. The single-GPU `train_smoke.yml` already proved
+# compose/instantiate/training-loop; this leaf isolates DDP behavior on
+# the alternating two-optimizer training_step under 4 ranks.
+#
+# Mirrors train_smoke.yml's two compose constraints:
+# (1) `targets/er_sec61b.yml` sets `benchmark.dataset_ref`; we null it so
+#     the resolver no-ops and the inline data_path/channels take effect.
+# (2) `augmentations[0].init_args.num_samples: 2` and
+#     HCSDataModule._train_transform enforces batch_size % num_samples == 0,
+#     so we set `batch_size: 2`.
+#
+# Per-GPU batch_size stays at 2 (matches single-GPU smoke); effective batch
+# under 4 GPUs is 8.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit_ddp.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_4gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/wall_smoke.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__ipsc_confocal__pix2pix3d_unetvit__smoke_4gpu
+  # Null disables the compose-hook resolver so the inline data_path /
+  # source_channel / target_channel below take effect without colliding.
+  dataset_ref: null
+
+data:
+  init_args:
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_test48.zarr
+    source_channel: [Phase3D]
+    target_channel: [Structure]
+    batch_size: 2
+
+trainer:
+  # Smoke runs don't need a logger. `false` disables the recipe's WandbLogger
+  # so consumers don't have to remember --override trainer.logger=false.
+  # LearningRateMonitor (recipe default) raises without a logger AND
+  # manual schedulers don't play well with it under DynacellGAN — so the
+  # callbacks list is replaced with only ModelCheckpoint (lists replace
+  # wholesale under deep_merge).
+  logger: false
+  max_steps: 20
+  max_epochs: 1
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        save_last: true
+        every_n_train_steps: 10
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/smoke_4gpu/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_SEC61B_SMOKE_4GPU
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit/smoke_4gpu

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B marker) trained on joint iPSC+A549, predicting against a549_mantis_sec61b_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B marker) trained on joint iPSC+A549, predicting against a549_mantis_sec61b_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B marker) trained on joint iPSC+A549, predicting against a549_mantis_sec61b_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B marker) trained on joint iPSC+A549, predicting against ipsc_confocal test.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/sec61b_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,147 @@
+# pix2pix3d_unetvit fit on er (SEC61B marker) — joint ipsc_confocal + a549_mantis pooled.
+#
+# Joint leaf. Uses BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-dataset
+# resolver). Only model_overlays/pix2pix3d_unetvit_fit.yml is composed; the
+# data block is authored inline because joint hparams live on the children.
+#
+# Normalization is NormalizeSampled (fov_statistics) to match the single-set
+# pix2pix3d_unetvit leaves — divergent from the celldiff joint which uses
+# MinMaxSampled. Per-organelle prior is to keep joint and single-set
+# normalizations identical so ablations are apples-to-apples.
+#
+# Topology: single H200, single GPU — same as pix2pix3d_unetvit/ipsc_confocal/train.yml.
+base:
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_JOINT_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints
+
+# Child HCSDataModule init_args shared across both datasets (only data_path
+# differs). `_`-prefixed top-level keys are stripped by load_composed_config
+# before reaching LightningCLI; the merge expansion under `data:` survives.
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 13
+  # batch_size=2 + num_samples=2 → 4 GPU samples/step, matching the single-set
+  # pix2pix3d_unetvit (batch=4, num_samples=2). BatchedConcatDataModule does
+  # NOT divide by num_samples (see CLAUDE.md), so joint.batch_size =
+  # single_set.batch_size / num_samples.
+  batch_size: 2
+  num_workers: 4
+  yx_patch_size: [512, 512]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [13, 624, 624]
+        num_samples: 2
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [3.14, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[0.7, 1.3], [0.5, 1.5], [0.5, 1.5]]
+        safe_crop_size: [8, 512, 512]
+        safe_crop_coverage: 0.9
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0.25, 0.75]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B.zarr
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/SEC61B_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit
+  # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; default 256G
+  # is too tight for the iPSC marker store + A549 pool + worker overhead.
+  sbatch:
+    mem: "512G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_A549_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,7 +30,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit/checkpoints
 
 data:
   init_args:
@@ -40,4 +40,4 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_A549_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit fit on membrane (Membrane channel of cell.zarr) — A549 mantis-lightsheet pooled (mock + DENV + ZIKV).
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_A549_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit/checkpoints
+
+data:
+  init_args:
+    # A549 pooled store + target_channel — no resolver in this train_set.
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/CAAX_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: membrane (Membrane) predicted by pix2pix3d_unetvit on a549-mantis-caax-denv.
+defaults:
+  - override /target: membrane
+  - override /predict_set: a549_mantis_caax_denv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_denv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_memb_pix2pix3d_unetvit__caax_denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: membrane (Membrane) predicted by pix2pix3d_unetvit on a549-mantis-caax-mock.
+defaults:
+  - override /target: membrane
+  - override /predict_set: a549_mantis_caax_mock
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_mock.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_memb_pix2pix3d_unetvit__caax_mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: membrane (Membrane) predicted by pix2pix3d_unetvit on a549-mantis-caax-zikv.
+defaults:
+  - override /target: membrane
+  - override /predict_set: a549_mantis_caax_zikv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_zikv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_memb_pix2pix3d_unetvit__caax_zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+# Benchmark eval leaf: membrane (Membrane) predicted by pix2pix3d_unetvit on iPSC confocal.
+defaults:
+  - override /target: membrane
+  - override /predict_set: ipsc_confocal
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_pix2pix3d_unetvit.zarr
+
+compute_feature_metrics: true
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/eval_memb_pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on iPSC, predicting against a549_mantis_caax_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_denv.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_caax_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_caax_denv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on iPSC, predicting against a549_mantis_caax_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_mock.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_caax_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_caax_mock
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on iPSC, predicting against a549_mantis_caax_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_zikv.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_caax_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_caax_zikv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) against ipsc_confocal test_cropped.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: ipsc_confocal
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__ipsc_confocal__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_MEMB
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_iPSC_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,8 +30,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit/checkpoints
 
 launcher:
   job_name: pix2pix3d_unetvit_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -1,0 +1,37 @@
+# pix2pix3d_unetvit fit on membrane (Membrane channel of cell.zarr) — AICS iPSC confocal.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__ipsc_confocal__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_iPSC_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb_temp/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on joint iPSC+A549, predicting against a549_mantis_caax_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_denv.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_caax_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_caax_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on joint iPSC+A549, predicting against a549_mantis_caax_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_mock.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_caax_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_caax_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on joint iPSC+A549, predicting against a549_mantis_caax_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_caax_zikv.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_caax_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_caax_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: membrane (Membrane marker) trained on joint iPSC+A549, predicting against ipsc_confocal test.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/memb_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,147 @@
+# pix2pix3d_unetvit fit on membrane (Membrane marker) — joint ipsc_confocal + a549_mantis pooled.
+#
+# Joint leaf. Uses BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-dataset
+# resolver). Only model_overlays/pix2pix3d_unetvit_fit.yml is composed; the
+# data block is authored inline because joint hparams live on the children.
+#
+# Normalization is NormalizeSampled (fov_statistics) to match the single-set
+# pix2pix3d_unetvit leaves — divergent from the celldiff joint which uses
+# MinMaxSampled. Per-organelle prior is to keep joint and single-set
+# normalizations identical so ablations are apples-to-apples.
+#
+# Topology: single H200, single GPU — same as pix2pix3d_unetvit/ipsc_confocal/train.yml.
+base:
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints
+
+# Child HCSDataModule init_args shared across both datasets (only data_path
+# differs). `_`-prefixed top-level keys are stripped by load_composed_config
+# before reaching LightningCLI; the merge expansion under `data:` survives.
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 13
+  # batch_size=2 + num_samples=2 → 4 GPU samples/step, matching the single-set
+  # pix2pix3d_unetvit (batch=4, num_samples=2). BatchedConcatDataModule does
+  # NOT divide by num_samples (see CLAUDE.md), so joint.batch_size =
+  # single_set.batch_size / num_samples.
+  batch_size: 2
+  num_workers: 4
+  yx_patch_size: [512, 512]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [13, 624, 624]
+        num_samples: 2
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [3.14, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[0.7, 1.3], [0.5, 1.5], [0.5, 1.5]]
+        safe_crop_size: [8, 512, 512]
+        safe_crop_coverage: 0.9
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0.25, 0.75]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell.zarr
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/CAAX_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit
+  # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; default 256G
+  # is too tight for the iPSC marker store + A549 pool + worker overhead.
+  sbatch:
+    mem: "512G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit fit on mitochondria (TOMM20 marker) — A549 mantis-lightsheet pooled (mock + DENV + ZIKV).
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_A549_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints
+
+data:
+  init_args:
+    # A549 pooled store + target_channel — no resolver in this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/TOMM20_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: mito (TOMM20) predicted by pix2pix3d_unetvit on a549-mantis-tomm20-denv.
+defaults:
+  - override /target: mito_tomm20
+  - override /predict_set: a549_mantis_tomm20_denv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_denv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_tomm20_pix2pix3d_unetvit__tomm20_denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: mito (TOMM20) predicted by pix2pix3d_unetvit on a549-mantis-tomm20-mock.
+defaults:
+  - override /target: mito_tomm20
+  - override /predict_set: a549_mantis_tomm20_mock
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_mock.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_tomm20_pix2pix3d_unetvit__tomm20_mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: mito (TOMM20) predicted by pix2pix3d_unetvit on a549-mantis-tomm20-zikv.
+defaults:
+  - override /target: mito_tomm20
+  - override /predict_set: a549_mantis_tomm20_zikv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_zikv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_tomm20_pix2pix3d_unetvit__tomm20_zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+# Benchmark eval leaf: mito (TOMM20) predicted by pix2pix3d_unetvit on iPSC confocal.
+defaults:
+  - override /target: mito_tomm20
+  - override /predict_set: ipsc_confocal
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_pix2pix3d_unetvit.zarr
+
+compute_feature_metrics: true
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/eval_tomm20_pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on iPSC, predicting against a549_mantis_tomm20_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_denv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_tomm20_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_tomm20_denv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on iPSC, predicting against a549_mantis_tomm20_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_mock.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_tomm20_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_tomm20_mock
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on iPSC, predicting against a549_mantis_tomm20_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_zikv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_tomm20_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_tomm20_zikv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) against ipsc_confocal test_cropped.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: ipsc_confocal
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__ipsc_confocal__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -1,0 +1,37 @@
+# pix2pix3d_unetvit fit on mitochondria (TOMM20 marker) — AICS iPSC confocal.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__ipsc_confocal__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_iPSC_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/pix2pix3d_unetvit/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on joint iPSC+A549, predicting against a549_mantis_tomm20_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_denv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on joint iPSC+A549, predicting against a549_mantis_tomm20_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_mock.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on joint iPSC+A549, predicting against a549_mantis_tomm20_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_zikv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20 marker) trained on joint iPSC+A549, predicting against ipsc_confocal test.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/tomm20_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,147 @@
+# pix2pix3d_unetvit fit on mito (TOMM20 marker) — joint ipsc_confocal + a549_mantis pooled.
+#
+# Joint leaf. Uses BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-dataset
+# resolver). Only model_overlays/pix2pix3d_unetvit_fit.yml is composed; the
+# data block is authored inline because joint hparams live on the children.
+#
+# Normalization is NormalizeSampled (fov_statistics) to match the single-set
+# pix2pix3d_unetvit leaves — divergent from the celldiff joint which uses
+# MinMaxSampled. Per-organelle prior is to keep joint and single-set
+# normalizations identical so ablations are apples-to-apples.
+#
+# Topology: single H200, single GPU — same as pix2pix3d_unetvit/ipsc_confocal/train.yml.
+base:
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_JOINT_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints
+
+# Child HCSDataModule init_args shared across both datasets (only data_path
+# differs). `_`-prefixed top-level keys are stripped by load_composed_config
+# before reaching LightningCLI; the merge expansion under `data:` survives.
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 13
+  # batch_size=2 + num_samples=2 → 4 GPU samples/step, matching the single-set
+  # pix2pix3d_unetvit (batch=4, num_samples=2). BatchedConcatDataModule does
+  # NOT divide by num_samples (see CLAUDE.md), so joint.batch_size =
+  # single_set.batch_size / num_samples.
+  batch_size: 2
+  num_workers: 4
+  yx_patch_size: [512, 512]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [13, 624, 624]
+        num_samples: 2
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [3.14, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[0.7, 1.3], [0.5, 1.5], [0.5, 1.5]]
+        safe_crop_size: [8, 512, 512]
+        safe_crop_coverage: 0.9
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0.25, 0.75]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20.zarr
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/TOMM20_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit
+  # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; default 256G
+  # is too tight for the iPSC marker store + A549 pool + worker overhead.
+  sbatch:
+    mem: "512G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit fit on nucleus (Nuclei channel of cell.zarr) — A549 mantis-lightsheet pooled (mock + DENV + ZIKV).
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_A549_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit/checkpoints
+
+data:
+  init_args:
+    # A549 pooled store + target_channel — no resolver in this train_set.
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/H2B_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_denv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: nucleus (Nuclei) predicted by pix2pix3d_unetvit on a549-mantis-h2b-denv.
+defaults:
+  - override /target: nucleus
+  - override /predict_set: a549_mantis_h2b_denv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_denv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_nucl_pix2pix3d_unetvit__h2b_denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_mock.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: nucleus (Nuclei) predicted by pix2pix3d_unetvit on a549-mantis-h2b-mock.
+defaults:
+  - override /target: nucleus
+  - override /predict_set: a549_mantis_h2b_mock
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_mock.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_nucl_pix2pix3d_unetvit__h2b_mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__a549_mantis_zikv.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+# Benchmark eval leaf: nucleus (Nuclei) predicted by pix2pix3d_unetvit on a549-mantis-h2b-zikv.
+defaults:
+  - override /target: nucleus
+  - override /predict_set: a549_mantis_h2b_zikv
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_zikv.zarr
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/eval_nucl_pix2pix3d_unetvit__h2b_zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/eval__ipsc_confocal.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+# Benchmark eval leaf: nucleus (Nuclei) predicted by pix2pix3d_unetvit on iPSC confocal.
+defaults:
+  - override /target: nucleus
+  - override /predict_set: ipsc_confocal
+
+io:
+  pred_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_pix2pix3d_unetvit.zarr
+
+compute_feature_metrics: true
+
+save:
+  save_dir: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/eval_nucl_pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on iPSC, predicting against a549_mantis_h2b_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_denv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_h2b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_denv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on iPSC, predicting against a549_mantis_h2b_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_mock.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_h2b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_mock
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on iPSC, predicting against a549_mantis_h2b_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_zikv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: ipsc_confocal
+  predict_set: a549_mantis_h2b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_zikv
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) against ipsc_confocal test_cropped.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: ipsc_confocal
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_NUCL
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -1,0 +1,37 @@
+# pix2pix3d_unetvit fit on nucleus (Nuclei channel of cell.zarr) — AICS iPSC confocal.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/unetvit3d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_iPSC_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit/checkpoints
+
+launcher:
+  job_name: pix2pix3d_unetvit_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on joint iPSC+A549, predicting against a549_mantis_h2b_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_denv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_h2b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on joint iPSC+A549, predicting against a549_mantis_h2b_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_mock.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_h2b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on joint iPSC+A549, predicting against a549_mantis_h2b_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_zikv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_h2b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on joint iPSC+A549, predicting against ipsc_confocal test.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/nucl_pix2pix3d_unetvit.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,147 @@
+# pix2pix3d_unetvit fit on nucleus (Nuclei marker) — joint ipsc_confocal + a549_mantis pooled.
+#
+# Joint leaf. Uses BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-dataset
+# resolver). Only model_overlays/pix2pix3d_unetvit_fit.yml is composed; the
+# data block is authored inline because joint hparams live on the children.
+#
+# Normalization is NormalizeSampled (fov_statistics) to match the single-set
+# pix2pix3d_unetvit leaves — divergent from the celldiff joint which uses
+# MinMaxSampled. Per-organelle prior is to keep joint and single-set
+# normalizations identical so ablations are apples-to-apples.
+#
+# Topology: single H200, single GPU — same as pix2pix3d_unetvit/ipsc_confocal/train.yml.
+base:
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_h200_single.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit
+
+trainer:
+  logger:
+    init_args:
+      name: pix2pix3d_unetvit_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints
+
+# Child HCSDataModule init_args shared across both datasets (only data_path
+# differs). `_`-prefixed top-level keys are stripped by load_composed_config
+# before reaching LightningCLI; the merge expansion under `data:` survives.
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 13
+  # batch_size=2 + num_samples=2 → 4 GPU samples/step, matching the single-set
+  # pix2pix3d_unetvit (batch=4, num_samples=2). BatchedConcatDataModule does
+  # NOT divide by num_samples (see CLAUDE.md), so joint.batch_size =
+  # single_set.batch_size / num_samples.
+  batch_size: 2
+  num_workers: 4
+  yx_patch_size: [512, 512]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [13, 624, 624]
+        num_samples: 2
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [3.14, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[0.7, 1.3], [0.5, 1.5], [0.5, 1.5]]
+        safe_crop_size: [8, 512, 512]
+        safe_crop_coverage: 0.9
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0.25, 0.75]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [8, 512, 512]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell.zarr
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis_v1/train/H2B_all.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit
+  # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; default 256G
+  # is too tight for the iPSC marker store + A549 pool + worker overhead.
+  sbatch:
+    mem: "512G"

--- a/applications/dynacell/configs/recipes/models/pix2pix3d_unetvit.yml
+++ b/applications/dynacell/configs/recipes/models/pix2pix3d_unetvit.yml
@@ -1,0 +1,24 @@
+# Model recipe: pix2pix3d_unetvit — UNetViT3D generator + 3D PatchGAN
+# discriminator trained with LSGAN + L1.
+model:
+  class_path: dynacell.engine.DynacellGAN
+  init_args:
+    architecture: UNetViT3D
+    generator_config:
+      input_spatial_size: [8, 512, 512]
+      in_channels: 1
+      out_channels: 1
+      dims: [64, 128, 256, 256]
+      num_res_block: [2, 2, 2]
+      hidden_size: 512
+      num_heads: 8
+      dim_head: 64
+      num_hidden_layers: 8
+      patch_size: 4
+    discriminator_config:
+      in_channels: 2
+      base_channels: 64
+      num_layers: 5
+      num_scales: 2          # multi-scale D (pix2pixHD-style); set 1 to ablate
+      use_spectral_norm: true
+    lambda_l1: 100.0

--- a/applications/dynacell/configs/recipes/models/pix2pix3d_unetvit.yml
+++ b/applications/dynacell/configs/recipes/models/pix2pix3d_unetvit.yml
@@ -18,7 +18,6 @@ model:
     discriminator_config:
       in_channels: 2
       base_channels: 64
-      num_layers: 5
       num_scales: 2          # multi-scale D (pix2pixHD-style); set 1 to ablate
       use_spectral_norm: true
     lambda_l1: 100.0

--- a/applications/dynacell/configs/recipes/topology/ddp_4gpu_gan.yml
+++ b/applications/dynacell/configs/recipes/topology/ddp_4gpu_gan.yml
@@ -1,0 +1,25 @@
+# Topology recipe: 4-GPU DDP for GAN training (manual optimization, two opts).
+#
+# GAN engines (e.g. DynacellGAN / pix2pix3d_unetvit) use manual optimization
+# with two optimizers (G and D) trained on alternating sub-steps. Each
+# `training_step` toggles `requires_grad` on the inactive side, so the
+# parameters of whichever side is *not* updating in that sub-step look
+# "unused" from DDP's reducer perspective on each backward pass.
+#
+# DDP's reducer is set up at module-wrap time over the FULL parameter set;
+# with the default `find_unused_parameters=False`, hitting an unused param
+# raises:
+#   "Expected to mark a variable ready only once. ... Parameter ... did not
+#    receive gradient ..."
+# at first backward and kills the job. The Lightning string shortcut
+# `ddp_find_unused_parameters_true` instantiates a `DDPStrategy` with
+# `find_unused_parameters=True`, which makes the reducer tolerate the
+# alternating-grad pattern (small per-step overhead, acceptable here).
+#
+# Do not use this topology for non-GAN models — plain `ddp_4gpu.yml` skips
+# the unused-param scan and is strictly faster for fully-active graphs.
+trainer:
+  accelerator: gpu
+  strategy: ddp_find_unused_parameters_true
+  devices: 4
+  num_nodes: 1

--- a/applications/dynacell/src/dynacell/__init__.py
+++ b/applications/dynacell/src/dynacell/__init__.py
@@ -1,6 +1,6 @@
 """Dynacell: benchmark virtual staining application."""
 
-__all__ = ["DynacellFlowMatching", "DynacellUNet"]
+__all__ = ["DynacellFlowMatching", "DynacellGAN", "DynacellUNet"]
 
 
 def __getattr__(name: str):
@@ -9,6 +9,10 @@ def __getattr__(name: str):
         from dynacell.engine import DynacellFlowMatching
 
         return DynacellFlowMatching
+    if name == "DynacellGAN":
+        from dynacell.engine import DynacellGAN
+
+        return DynacellGAN
     if name == "DynacellUNet":
         from dynacell.engine import DynacellUNet
 

--- a/applications/dynacell/src/dynacell/engine.py
+++ b/applications/dynacell/src/dynacell/engine.py
@@ -1,7 +1,8 @@
 """Dynacell LightningModules for virtual staining benchmarks.
 
-Provides :class:`DynacellUNet` for supervised regression and
-:class:`DynacellFlowMatching` for flow-matching generative staining.
+Provides :class:`DynacellUNet` for supervised regression,
+:class:`DynacellFlowMatching` for flow-matching generative staining, and
+:class:`DynacellGAN` for adversarial (LSGAN + L1) virtual staining.
 """
 
 import inspect
@@ -13,13 +14,16 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from lightning.pytorch import LightningModule
+from monai.optimizers import WarmupCosineSchedule
 from monai.transforms import DivisiblePad
 from torch import Tensor, nn
+from torch.optim import AdamW
 
 from dynacell.celldiff_wrapper import CELLDiff3DVS
 from viscy_data import Sample
 from viscy_models import Unet3d, UNeXt2
 from viscy_models.celldiff import CELLDiffNet, UNetViT3D
+from viscy_models.gan import MultiScalePatchGAN3D, lsgan_d_loss, lsgan_g_loss
 from viscy_models.unet.fcmae import FullyConvolutionalMAE
 from viscy_utils.log_images import detach_sample, log_image_grid
 from viscy_utils.optimizers import configure_adamw_scheduler
@@ -673,6 +677,384 @@ class DynacellFlowMatching(LightningModule):
             warmup_steps=self.warmup_steps,
             warmup_multiplier=self.warmup_multiplier,
         )
+
+    def _log_samples(self, key: str, imgs: Sequence[Sequence[np.ndarray]]) -> None:
+        """Log image grid to the active logger."""
+        if not imgs or not self.trainer.is_global_zero or self.logger is None:
+            return
+        log_image_grid(self.logger, key, imgs, self.current_epoch)
+
+
+class DynacellGAN(LightningModule):
+    """Adversarial virtual-staining LightningModule (LSGAN + L1).
+
+    Pairs a regression-style generator (default ``UNetViT3D``) with a
+    multi-scale 3D PatchGAN discriminator. The training step alternates a
+    discriminator update and a generator update per batch using Lightning's
+    manual-optimization API, so the module sets
+    ``automatic_optimization = False``.
+
+    The discriminator is conditional: it consumes the concatenation of
+    ``source`` and either the real target or the generator output along the
+    channel dimension. The generator loss combines an LSGAN adversarial term
+    (MSE-to-real for the fake pair) with an L1 reconstruction term scaled by
+    ``lambda_l1``.
+
+    The ``requires_grad`` flags on the generator and discriminator are
+    toggled at each phase of the training step so each backward pass only
+    populates ``.grad`` on the parameters being optimized. After the
+    discriminator update we additionally call ``opt_d.zero_grad`` so that
+    after a full ``training_step`` no discriminator parameter retains a
+    non-zero accumulated gradient — this invariant is verified by unit
+    tests.
+
+    Parameters
+    ----------
+    architecture : {"UNetViT3D"}
+        Generator architecture key. Looked up in the shared
+        :data:`_ARCHITECTURE` registry.
+    generator_config : dict or None
+        Keyword arguments forwarded to the generator constructor.
+    discriminator_config : dict or None
+        Keyword arguments forwarded to :class:`MultiScalePatchGAN3D`.
+    lambda_l1 : float
+        Weight of the L1 reconstruction loss in the generator objective.
+    lr_g : float
+        Learning rate for the generator optimizer.
+    lr_d : float
+        Learning rate for the discriminator optimizer.
+    schedule : {"WarmupCosine"}
+        Learning rate schedule. Only ``"WarmupCosine"`` is supported because
+        manual optimization expects a step-interval scheduler.
+    warmup_steps : int
+        Number of warmup steps for the WarmupCosine schedule.
+    warmup_multiplier : float
+        Initial LR multiplier at step 0 of the WarmupCosine schedule.
+    log_batches_per_epoch : int
+        Maximum number of batches per epoch to accumulate for image logging.
+    log_samples_per_batch : int
+        Number of samples per batch to log.
+    example_input_yx_shape : Sequence of int
+        YX shape used to build ``example_input_array`` for graph logging
+        when the generator does not advertise an ``input_spatial_size``.
+    predict_method : {"full_image"}
+        Prediction method. Only ``"full_image"`` is supported (the
+        discriminator is not exposed at inference time and the generator is
+        a fixed-input-size ViT-bottleneck UNet).
+    predict_overlap : tuple of int
+        Reserved for future tiled inference; currently unused at predict.
+    ckpt_path : str or None
+        Optional path to a Lightning checkpoint to load **weights only** at
+        construction time. Intended for inference (predict/test), not
+        training resumption — optimizer state, epoch counters, and
+        scheduler state are not restored.
+    """
+
+    def __init__(
+        self,
+        architecture: Literal["UNetViT3D"] = "UNetViT3D",
+        generator_config: dict | None = None,
+        discriminator_config: dict | None = None,
+        lambda_l1: float = 100.0,
+        lr_g: float = 3e-4,
+        lr_d: float = 3e-4,
+        schedule: Literal["WarmupCosine"] = "WarmupCosine",
+        warmup_steps: int = 8500,
+        warmup_multiplier: float = 1e-3,
+        log_batches_per_epoch: int = 8,
+        log_samples_per_batch: int = 1,
+        example_input_yx_shape: Sequence[int] = (512, 512),
+        predict_method: Literal["full_image"] = "full_image",
+        predict_overlap: tuple[int, int, int] = (4, 256, 256),
+        ckpt_path: str | None = None,
+    ) -> None:
+        super().__init__()
+        # Lightning's manual-optimization API: required because the GAN
+        # alternates two optimizers per training_step.
+        self.automatic_optimization = False
+        self.save_hyperparameters(ignore=["ckpt_path"])
+
+        net_class = _ARCHITECTURE.get(architecture)
+        if net_class is None:
+            raise ValueError(f"Architecture {architecture!r} not in {set(_ARCHITECTURE)}")
+        self.generator = net_class(**(generator_config or {}))
+        self.discriminator = MultiScalePatchGAN3D(**(discriminator_config or {}))
+
+        self.lambda_l1 = lambda_l1
+        self.lr_g = lr_g
+        self.lr_d = lr_d
+        self.schedule = schedule
+        self.warmup_steps = warmup_steps
+        self.warmup_multiplier = warmup_multiplier
+        self.log_batches_per_epoch = log_batches_per_epoch
+        self.log_samples_per_batch = log_samples_per_batch
+        self.predict_method = predict_method
+        self.predict_overlap = predict_overlap
+
+        self.training_step_outputs: list = []
+        # Each entry is a list of (loss, batch_size) tuples for weighted aggregation.
+        self.validation_losses: list[list[tuple[Tensor, int]]] = []
+        self.validation_step_outputs: list = []
+
+        # Build example_input_array for graph logging (TensorBoard/W&B).
+        gen_cfg = generator_config or {}
+        in_channels = gen_cfg.get("in_channels") or 1
+        if hasattr(self.generator, "input_spatial_size"):
+            d, h, w = self.generator.input_spatial_size
+        else:
+            d = gen_cfg.get("in_stack_depth") or 5
+            h, w = example_input_yx_shape
+        self.example_input_array = torch.rand(1, in_channels, d, h, w)
+
+        # Mirror DynacellUNet's end-of-init weight load so Phase 4 predict
+        # leaves with ``model.init_args.ckpt_path`` actually load weights.
+        if ckpt_path is not None:
+            self.load_state_dict(torch.load(ckpt_path, weights_only=True, map_location="cpu")["state_dict"])
+
+    @staticmethod
+    def _set_requires_grad(module: nn.Module, value: bool) -> None:
+        """Toggle ``requires_grad`` on every parameter of ``module``.
+
+        Parameters
+        ----------
+        module : nn.Module
+            Module whose parameters should have ``requires_grad`` set.
+        value : bool
+            New value for ``requires_grad``.
+        """
+        for p in module.parameters():
+            p.requires_grad = value
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Run a generator-only forward pass (inference contract).
+
+        The discriminator is not exposed at inference time; ``forward``
+        always returns the generator output.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input tensor of shape ``(B, C, D, H, W)``.
+
+        Returns
+        -------
+        Tensor
+            Generator output.
+        """
+        return self.generator(x)
+
+    def training_step(self, batch: Sample, batch_idx: int) -> None:
+        """Run one alternating D/G optimization step.
+
+        The discriminator is updated first using a detached generator
+        forward (so D's loss has no gradient path into G), then the
+        generator is updated using the LSGAN adversarial term + L1.
+        ``requires_grad`` is toggled per phase so each backward populates
+        ``.grad`` only on the side being trained, and the discriminator's
+        gradients are explicitly cleared after its update so the G step
+        starts with no residual D gradients.
+
+        Parameters
+        ----------
+        batch : Sample
+            Batch dict with ``"source"`` and ``"target"`` tensors.
+        batch_idx : int
+            Batch index within the epoch.
+        """
+        source = batch["source"]
+        target = batch["target"]
+        opt_g, opt_d = self.optimizers()
+        sch_g, sch_d = self.lr_schedulers()
+
+        # --- D step (D updates; G frozen, no-grad forward) ---
+        self._set_requires_grad(self.generator, False)
+        self._set_requires_grad(self.discriminator, True)
+        with torch.no_grad():
+            pred = self.generator(source)
+        d_real = self.discriminator(torch.cat([source, target], dim=1))
+        d_fake = self.discriminator(torch.cat([source, pred], dim=1))
+        d_loss = lsgan_d_loss(d_real, d_fake)
+        opt_d.zero_grad(set_to_none=True)
+        self.manual_backward(d_loss)
+        opt_d.step()
+        # Clear D grads after the D update so the G-step backward starts
+        # from a clean slate on D; this makes the "no D grads after G step"
+        # invariant verifiable in tests and avoids carrying D-step grads
+        # forward should anything else (a callback, etc.) inspect ``.grad``.
+        opt_d.zero_grad(set_to_none=True)
+
+        # --- G step (G updates; D frozen, fwd-only) ---
+        self._set_requires_grad(self.generator, True)
+        self._set_requires_grad(self.discriminator, False)
+        pred = self.generator(source)
+        d_fake_for_g = self.discriminator(torch.cat([source, pred], dim=1))
+        adv_loss = lsgan_g_loss(d_fake_for_g)
+        l1_loss = F.l1_loss(pred, target)
+        g_loss = adv_loss + self.lambda_l1 * l1_loss
+        opt_g.zero_grad(set_to_none=True)
+        self.manual_backward(g_loss)
+        opt_g.step()
+
+        # WarmupCosine is step-based and ignored by Lightning's automatic
+        # scheduler machinery when ``automatic_optimization = False``.
+        sch_g.step()
+        sch_d.step()
+
+        # Accumulate samples for image grid logging — mirror DynacellUNet.
+        if batch_idx < self.log_batches_per_epoch:
+            self.training_step_outputs.extend(detach_sample((source, target, pred), self.log_samples_per_batch))
+
+        self.log_dict(
+            {
+                "loss/d_train": d_loss,
+                "loss/g_train": g_loss,
+                "loss/g_adv_train": adv_loss,
+                "loss/g_l1_train": l1_loss,
+            },
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=source.size(0),
+        )
+
+    def validation_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> Tensor:
+        """Compute generator-only L1 validation loss and capture samples.
+
+        Mirrors :class:`DynacellUNet`'s aggregation pattern so
+        ``loss/validate`` is an epoch-aggregated weighted mean — the value
+        ``ModelCheckpoint(monitor="loss/validate")`` keys off.
+
+        Parameters
+        ----------
+        batch : Sample
+            Batch dict with ``"source"`` and ``"target"`` tensors.
+        batch_idx : int
+            Batch index.
+        dataloader_idx : int
+            Index of the validation dataloader.
+
+        Returns
+        -------
+        Tensor
+            Scalar L1 loss on this batch.
+        """
+        source: Tensor = batch["source"]
+        target: Tensor = batch["target"]
+        pred = self.generator(source)
+        l1 = F.l1_loss(pred, target)
+        if dataloader_idx + 1 > len(self.validation_losses):
+            self.validation_losses.append([])
+        self.validation_losses[dataloader_idx].append((l1.detach(), source.shape[0]))
+        self.log(
+            f"loss/val/{dataloader_idx}",
+            l1,
+            sync_dist=True,
+            batch_size=source.shape[0],
+        )
+        if batch_idx < self.log_batches_per_epoch:
+            self.validation_step_outputs.extend(detach_sample((source, target, pred), self.log_samples_per_batch))
+        return l1
+
+    def on_train_epoch_end(self) -> None:
+        """Log accumulated training image samples and reset the buffer."""
+        self._log_samples("train_samples", self.training_step_outputs)
+        self.training_step_outputs = []
+
+    def on_validation_epoch_end(self) -> None:
+        """Log validation samples and the aggregated ``loss/validate`` alias."""
+        super().on_validation_epoch_end()
+        self._log_samples("val_samples", self.validation_step_outputs)
+        if self.validation_losses:
+            self.log(
+                "loss/validate",
+                _aggregate_validation_losses(self.validation_losses),
+                sync_dist=True,
+            )
+        self.validation_step_outputs.clear()
+        self.validation_losses.clear()
+
+    def configure_optimizers(self):
+        """Configure two AdamW optimizers and step-interval WarmupCosine schedulers.
+
+        ``configure_adamw_scheduler`` already builds a WarmupCosine
+        ``{"scheduler", "interval": "step"}`` dict, so we call it once per
+        optimizer and concatenate the resulting single-entry lists. This
+        keeps the two-optimizer return shape Lightning expects for manual
+        optimization without re-implementing the schedule construction.
+
+        Returns
+        -------
+        tuple[list, list]
+            ``([opt_g, opt_d], [sch_g_dict, sch_d_dict])``.
+
+        Raises
+        ------
+        ValueError
+            If ``schedule`` is not ``"WarmupCosine"``.
+        """
+        if self.schedule != "WarmupCosine":
+            raise ValueError(f"DynacellGAN only supports schedule='WarmupCosine', got {self.schedule!r}")
+        # Reuse the helper rather than rebuilding the scheduler in-place so
+        # any future change to the warmup contract stays in one location.
+        # The helper returns ``[opt], [{"scheduler", "interval"}]`` for
+        # WarmupCosine — we just concatenate two such pairs.
+        opt_g = AdamW(self.generator.parameters(), lr=self.lr_g)
+        opt_d = AdamW(self.discriminator.parameters(), lr=self.lr_d)
+        t_total = self.trainer.estimated_stepping_batches
+        sch_g = WarmupCosineSchedule(
+            opt_g,
+            warmup_steps=self.warmup_steps,
+            t_total=t_total,
+            warmup_multiplier=self.warmup_multiplier,
+        )
+        sch_d = WarmupCosineSchedule(
+            opt_d,
+            warmup_steps=self.warmup_steps,
+            t_total=t_total,
+            warmup_multiplier=self.warmup_multiplier,
+        )
+        return (
+            [opt_g, opt_d],
+            [
+                {"scheduler": sch_g, "interval": "step"},
+                {"scheduler": sch_d, "interval": "step"},
+            ],
+        )
+
+    def on_predict_start(self) -> None:
+        """Build the divisible-pad transform matching the generator."""
+        self._predict_pad = _make_divisible_pad(self.generator)
+
+    def predict_step(self, batch: Sample, batch_idx: int, dataloader_idx: int = 0) -> Tensor:
+        """Run a generator-only prediction step with divisible padding.
+
+        Pads the input tile to the nearest multiple of the generator's
+        downsampling factor, runs the generator forward pass, then crops
+        back to the original spatial shape. The discriminator is not
+        exposed at inference.
+
+        Parameters
+        ----------
+        batch : Sample
+            Batch dict. Only ``"source"`` is used.
+        batch_idx : int
+            Batch index.
+        dataloader_idx : int
+            Dataloader index.
+
+        Returns
+        -------
+        Tensor
+            Generator prediction cropped to the input spatial shape.
+        """
+        source = batch["source"]
+        original_shape = source.shape[2:]
+        source = self._predict_pad(source)
+        if self.predict_method == "full_image":
+            prediction = self.generator(source)
+        else:
+            raise ValueError(f"Unknown predict_method: {self.predict_method!r}. Choose 'full_image'.")
+        return _center_crop_to_shape(prediction, original_shape)
 
     def _log_samples(self, key: str, imgs: Sequence[Sequence[np.ndarray]]) -> None:
         """Log image grid to the active logger."""

--- a/applications/dynacell/src/dynacell/engine.py
+++ b/applications/dynacell/src/dynacell/engine.py
@@ -14,10 +14,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from lightning.pytorch import LightningModule
-from monai.optimizers import WarmupCosineSchedule
 from monai.transforms import DivisiblePad
 from torch import Tensor, nn
-from torch.optim import AdamW
 
 from dynacell.celldiff_wrapper import CELLDiff3DVS
 from viscy_data import Sample
@@ -64,6 +62,13 @@ def _aggregate_validation_losses(
     total_n = torch.stack(dl_totals).sum()
     weighted = torch.stack([m * n for m, n in zip(dl_means, dl_totals)]).sum()
     return weighted / total_n
+
+
+def _log_samples(module: LightningModule, key: str, imgs: Sequence[Sequence[np.ndarray]]) -> None:
+    """Log a list of detached image samples to the experiment logger at rank 0."""
+    if not imgs or not module.trainer.is_global_zero or module.logger is None:
+        return
+    log_image_grid(module.logger, key, imgs, module.current_epoch)
 
 
 def _make_divisible_pad(model: nn.Module) -> DivisiblePad:
@@ -335,13 +340,13 @@ class DynacellUNet(LightningModule):
 
     def on_train_epoch_end(self):
         """Log training image samples."""
-        self._log_samples("train_samples", self.training_step_outputs)
+        _log_samples(self, "train_samples", self.training_step_outputs)
         self.training_step_outputs = []
 
     def on_validation_epoch_end(self):
         """Log validation samples and aggregate loss weighted by batch size."""
         super().on_validation_epoch_end()
-        self._log_samples("val_samples", self.validation_step_outputs)
+        _log_samples(self, "val_samples", self.validation_step_outputs)
         if self.validation_losses:
             self.log("loss/validate", _aggregate_validation_losses(self.validation_losses), sync_dist=True)
         self.validation_step_outputs.clear()
@@ -357,12 +362,6 @@ class DynacellUNet(LightningModule):
             warmup_steps=self.warmup_steps,
             warmup_multiplier=self.warmup_multiplier,
         )
-
-    def _log_samples(self, key: str, imgs: Sequence[Sequence[np.ndarray]]):
-        """Log image grid to the active logger."""
-        if not imgs or not self.trainer.is_global_zero or self.logger is None:
-            return
-        log_image_grid(self.logger, key, imgs, self.current_epoch)
 
     def predict_sliding_window(self, source: Tensor, overlap_size: tuple[int, int, int] = (4, 256, 256)) -> Tensor:
         """Run sliding-window inference over a large input volume.
@@ -584,7 +583,7 @@ class DynacellFlowMatching(LightningModule):
 
     def on_train_epoch_end(self) -> None:
         """Log training image samples at end of epoch."""
-        self._log_samples("train_samples", self._training_step_outputs)
+        _log_samples(self, "train_samples", self._training_step_outputs)
         self._training_step_outputs = []
 
     def on_validation_epoch_end(self) -> None:
@@ -596,7 +595,7 @@ class DynacellFlowMatching(LightningModule):
                 n = min(self.log_samples_per_batch, phase_log.shape[0])
                 generated = self.model.generate(phase_log[:n], num_steps=self.num_log_steps)
                 gen_samples = detach_sample((phase_log[:n], target_log[:n], generated), n)
-                self._log_samples("val_generated_samples", gen_samples)
+                _log_samples(self, "val_generated_samples", gen_samples)
             self._val_log_batch = None
         if self._validation_losses:
             self.log("loss/validate", _aggregate_validation_losses(self._validation_losses), sync_dist=True)
@@ -677,12 +676,6 @@ class DynacellFlowMatching(LightningModule):
             warmup_steps=self.warmup_steps,
             warmup_multiplier=self.warmup_multiplier,
         )
-
-    def _log_samples(self, key: str, imgs: Sequence[Sequence[np.ndarray]]) -> None:
-        """Log image grid to the active logger."""
-        if not imgs or not self.trainer.is_global_zero or self.logger is None:
-            return
-        log_image_grid(self.logger, key, imgs, self.current_epoch)
 
 
 class DynacellGAN(LightningModule):
@@ -806,8 +799,6 @@ class DynacellGAN(LightningModule):
             h, w = example_input_yx_shape
         self.example_input_array = torch.rand(1, in_channels, d, h, w)
 
-        # Mirror DynacellUNet's end-of-init weight load so Phase 4 predict
-        # leaves with ``model.init_args.ckpt_path`` actually load weights.
         if ckpt_path is not None:
             self.load_state_dict(torch.load(ckpt_path, weights_only=True, map_location="cpu")["state_dict"])
 
@@ -877,10 +868,7 @@ class DynacellGAN(LightningModule):
         opt_d.zero_grad(set_to_none=True)
         self.manual_backward(d_loss)
         opt_d.step()
-        # Clear D grads after the D update so the G-step backward starts
-        # from a clean slate on D; this makes the "no D grads after G step"
-        # invariant verifiable in tests and avoids carrying D-step grads
-        # forward should anything else (a callback, etc.) inspect ``.grad``.
+        # Clear D grads so the no-D-grads-after-G-step invariant is verifiable.
         opt_d.zero_grad(set_to_none=True)
 
         # --- G step (G updates; D frozen, fwd-only) ---
@@ -900,7 +888,6 @@ class DynacellGAN(LightningModule):
         sch_g.step()
         sch_d.step()
 
-        # Accumulate samples for image grid logging — mirror DynacellUNet.
         if batch_idx < self.log_batches_per_epoch:
             self.training_step_outputs.extend(detach_sample((source, target, pred), self.log_samples_per_batch))
 
@@ -957,13 +944,13 @@ class DynacellGAN(LightningModule):
 
     def on_train_epoch_end(self) -> None:
         """Log accumulated training image samples and reset the buffer."""
-        self._log_samples("train_samples", self.training_step_outputs)
+        _log_samples(self, "train_samples", self.training_step_outputs)
         self.training_step_outputs = []
 
     def on_validation_epoch_end(self) -> None:
         """Log validation samples and the aggregated ``loss/validate`` alias."""
         super().on_validation_epoch_end()
-        self._log_samples("val_samples", self.validation_step_outputs)
+        _log_samples(self, "val_samples", self.validation_step_outputs)
         if self.validation_losses:
             self.log(
                 "loss/validate",
@@ -974,52 +961,24 @@ class DynacellGAN(LightningModule):
         self.validation_losses.clear()
 
     def configure_optimizers(self):
-        """Configure two AdamW optimizers and step-interval WarmupCosine schedulers.
-
-        ``configure_adamw_scheduler`` already builds a WarmupCosine
-        ``{"scheduler", "interval": "step"}`` dict, so we call it once per
-        optimizer and concatenate the resulting single-entry lists. This
-        keeps the two-optimizer return shape Lightning expects for manual
-        optimization without re-implementing the schedule construction.
-
-        Returns
-        -------
-        tuple[list, list]
-            ``([opt_g, opt_d], [sch_g_dict, sch_d_dict])``.
-
-        Raises
-        ------
-        ValueError
-            If ``schedule`` is not ``"WarmupCosine"``.
-        """
-        if self.schedule != "WarmupCosine":
-            raise ValueError(f"DynacellGAN only supports schedule='WarmupCosine', got {self.schedule!r}")
-        # Reuse the helper rather than rebuilding the scheduler in-place so
-        # any future change to the warmup contract stays in one location.
-        # The helper returns ``[opt], [{"scheduler", "interval"}]`` for
-        # WarmupCosine — we just concatenate two such pairs.
-        opt_g = AdamW(self.generator.parameters(), lr=self.lr_g)
-        opt_d = AdamW(self.discriminator.parameters(), lr=self.lr_d)
-        t_total = self.trainer.estimated_stepping_batches
-        sch_g = WarmupCosineSchedule(
-            opt_g,
+        """Build two AdamW optimizers + WarmupCosine schedulers via the shared helper."""
+        [opt_g], [sch_g] = configure_adamw_scheduler(
+            self,
+            self.generator,
+            self.lr_g,
+            self.schedule,
             warmup_steps=self.warmup_steps,
-            t_total=t_total,
             warmup_multiplier=self.warmup_multiplier,
         )
-        sch_d = WarmupCosineSchedule(
-            opt_d,
+        [opt_d], [sch_d] = configure_adamw_scheduler(
+            self,
+            self.discriminator,
+            self.lr_d,
+            self.schedule,
             warmup_steps=self.warmup_steps,
-            t_total=t_total,
             warmup_multiplier=self.warmup_multiplier,
         )
-        return (
-            [opt_g, opt_d],
-            [
-                {"scheduler": sch_g, "interval": "step"},
-                {"scheduler": sch_d, "interval": "step"},
-            ],
-        )
+        return [opt_g, opt_d], [sch_g, sch_d]
 
     def on_predict_start(self) -> None:
         """Build the divisible-pad transform matching the generator."""
@@ -1055,9 +1014,3 @@ class DynacellGAN(LightningModule):
         else:
             raise ValueError(f"Unknown predict_method: {self.predict_method!r}. Choose 'full_image'.")
         return _center_crop_to_shape(prediction, original_shape)
-
-    def _log_samples(self, key: str, imgs: Sequence[Sequence[np.ndarray]]) -> None:
-        """Log image grid to the active logger."""
-        if not imgs or not self.trainer.is_global_zero or self.logger is None:
-            return
-        log_image_grid(self.logger, key, imgs, self.current_epoch)

--- a/applications/dynacell/tests/test_engine.py
+++ b/applications/dynacell/tests/test_engine.py
@@ -402,7 +402,6 @@ GAN_GEN_TEST_CONFIG = {
 GAN_DISC_TEST_CONFIG = {
     "in_channels": 2,
     "base_channels": 8,
-    "num_layers": 5,
     "num_scales": 2,
 }
 

--- a/applications/dynacell/tests/test_engine.py
+++ b/applications/dynacell/tests/test_engine.py
@@ -1,10 +1,13 @@
 """Smoke tests for dynacell engine."""
 
+import copy
+
 import pytest
 import torch
+from lightning.pytorch import Trainer, seed_everything
 from monai.data import MetaTensor
 
-from dynacell.engine import DynacellFlowMatching, DynacellUNet
+from dynacell.engine import DynacellFlowMatching, DynacellGAN, DynacellUNet
 
 # Small model configs for tests (not production sizes).
 VIT_TEST_CONFIG = {
@@ -372,3 +375,208 @@ def test_unetvit3d_sliding_window_supports_multi_channel_output():
     with torch.no_grad():
         prediction = model.predict_step({"source": source}, batch_idx=0)
     assert prediction.shape == (1, 2, 16, 48, 48)
+
+
+# ---- DynacellGAN tests ----
+
+# Small generator config sized for the GAN tests. The discriminator's five
+# strided convs collapse YX by ~16x; YX=64 keeps the bottom feature map a
+# valid 3-4 voxels wide. 8x32x32 would degenerate the D output. ``dims``
+# must have length ``len(num_res_block)+1``, so we keep dims=[16,32,64]
+# (length 3) paired with num_res_block=[1,1] (length 2). With two
+# (1,2,2) downsample levels the latent is (8,16,16); patch_size=4 yields
+# 2*4*4 = 32 tokens — small but non-degenerate for the ViT bottleneck.
+GAN_GEN_TEST_CONFIG = {
+    "input_spatial_size": [8, 64, 64],
+    "in_channels": 1,
+    "out_channels": 1,
+    "dims": [16, 32, 64],
+    "num_res_block": [1, 1],
+    "hidden_size": 64,
+    "num_heads": 2,
+    "dim_head": 32,
+    "num_hidden_layers": 1,
+    "patch_size": 4,
+}
+
+GAN_DISC_TEST_CONFIG = {
+    "in_channels": 2,
+    "base_channels": 8,
+    "num_layers": 5,
+    "num_scales": 2,
+}
+
+
+def _make_gan_batch(batch_size: int = 2) -> dict:
+    """Build a synthetic batch matching ``GAN_GEN_TEST_CONFIG`` spatial size."""
+    shape = (batch_size, 1, 8, 64, 64)
+    return {
+        "source": torch.randn(*shape),
+        "target": torch.randn(*shape),
+    }
+
+
+def test_dynacell_gan_init():
+    """DynacellGAN constructs with small generator + discriminator configs."""
+    model = DynacellGAN(
+        architecture="UNetViT3D",
+        generator_config=GAN_GEN_TEST_CONFIG,
+        discriminator_config=GAN_DISC_TEST_CONFIG,
+    )
+    assert model.generator is not None
+    assert model.discriminator is not None
+    assert model.discriminator.num_scales == 2
+    assert model.automatic_optimization is False
+    assert model.lambda_l1 == 100.0
+    assert model.example_input_array.shape == (1, 1, 8, 64, 64)
+
+
+def test_dynacell_gan_forward():
+    """``forward`` runs G only and preserves spatial shape."""
+    model = DynacellGAN(
+        architecture="UNetViT3D",
+        generator_config=GAN_GEN_TEST_CONFIG,
+        discriminator_config=GAN_DISC_TEST_CONFIG,
+    )
+    model.eval()
+    batch = _make_gan_batch()
+    with torch.no_grad():
+        output = model(batch["source"])
+    assert output.shape == batch["source"].shape
+
+
+def test_dynacell_gan_training_step(tmp_path):
+    """Three training_steps step both nets and leave D with zero grads.
+
+    Runs an actual Lightning fit so optimizers and step-interval
+    schedulers are configured through Lightning's normal path
+    (``estimated_stepping_batches`` is only resolvable inside fit). Asserts:
+
+    1. all four logged GAN losses are finite at each step,
+    2. at least one G and at least one D parameter changes across the run,
+    3. after the final G step every D parameter has either ``None`` grad or
+       a zero-summed grad — the ``requires_grad`` toggle is the key
+       correctness check for Phase 2 DDP.
+    """
+    seed_everything(42)
+    model = DynacellGAN(
+        architecture="UNetViT3D",
+        generator_config=GAN_GEN_TEST_CONFIG,
+        discriminator_config=GAN_DISC_TEST_CONFIG,
+        warmup_steps=2,
+        log_batches_per_epoch=0,
+    )
+
+    captured_losses: list[dict[str, float]] = []
+    real_log_dict = model.log_dict
+
+    def _capture_log_dict(d, *args, **kwargs):
+        captured_losses.append({k: float(v.detach()) for k, v in d.items()})
+        return real_log_dict(d, *args, **kwargs)
+
+    model.log_dict = _capture_log_dict  # type: ignore[method-assign]
+
+    g_before = {n: p.detach().clone() for n, p in model.generator.named_parameters()}
+    d_before = {n: p.detach().clone() for n, p in model.discriminator.named_parameters()}
+
+    batch = _make_gan_batch()
+
+    class _BatchDataset(torch.utils.data.Dataset):
+        def __init__(self, n: int):
+            self.n = n
+
+        def __len__(self) -> int:
+            return self.n
+
+        def __getitem__(self, idx: int) -> dict:
+            return {"source": batch["source"][0], "target": batch["target"][0]}
+
+    # Use 6 samples / batch_size=2 -> 3 batches per epoch, and limit to 1
+    # epoch so exactly 3 training_step calls happen. Manual optimization +
+    # max_steps interaction in Lightning can drop the final step due to
+    # how the loop counts before/after manual_backward; max_epochs=1 with
+    # exactly 3 batches per epoch is robust.
+    train_loader = torch.utils.data.DataLoader(_BatchDataset(6), batch_size=2)
+
+    trainer = Trainer(
+        max_epochs=1,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    trainer.fit(model, train_dataloaders=train_loader)
+
+    assert len(captured_losses) == 3, f"expected 3 logged steps, got {len(captured_losses)}"
+    expected_keys = {"loss/d_train", "loss/g_train", "loss/g_adv_train", "loss/g_l1_train"}
+    for step_idx, logged in enumerate(captured_losses):
+        assert expected_keys <= set(logged.keys()), (
+            f"step {step_idx} missing keys: {expected_keys - set(logged.keys())}"
+        )
+        for key in expected_keys:
+            value = logged[key]
+            assert torch.isfinite(torch.tensor(value)), f"step {step_idx} key {key!r} is not finite: {value}"
+
+    # Params on both sides must change across the 3 steps.
+    g_changed = any(not torch.equal(g_before[n], p.detach()) for n, p in model.generator.named_parameters())
+    d_changed = any(not torch.equal(d_before[n], p.detach()) for n, p in model.discriminator.named_parameters())
+    assert g_changed, "no generator parameter changed across 3 training steps"
+    assert d_changed, "no discriminator parameter changed across 3 training steps"
+
+    # After the final G step, D grads must be empty / zero. This is the
+    # ``requires_grad`` toggle correctness check.
+    for name, p in model.discriminator.named_parameters():
+        if p.grad is not None:
+            assert p.grad.abs().sum().item() == 0.0, f"discriminator param {name!r} has non-zero grad after G step"
+
+
+def test_dynacell_gan_predict_step():
+    """``predict_step`` runs G only and returns an input-shape tensor."""
+    model = DynacellGAN(
+        architecture="UNetViT3D",
+        generator_config=GAN_GEN_TEST_CONFIG,
+        discriminator_config=GAN_DISC_TEST_CONFIG,
+    )
+    model.eval()
+    model.on_predict_start()
+    batch = _make_gan_batch(batch_size=1)
+    batch_meta = {"source": MetaTensor(batch["source"])}
+    with torch.no_grad():
+        prediction = model.predict_step(batch_meta, batch_idx=0)
+    assert prediction.shape == batch["source"].shape
+
+
+def test_dynacell_gan_validate_logs_alias():
+    """``on_validation_epoch_end`` logs the ``loss/validate`` weighted mean."""
+    model = DynacellGAN(
+        architecture="UNetViT3D",
+        generator_config=GAN_GEN_TEST_CONFIG,
+        discriminator_config=GAN_DISC_TEST_CONFIG,
+    )
+    model.eval()
+
+    logged: dict[str, torch.Tensor] = {}
+
+    def _capture(name, value, *args, **kwargs):
+        logged[name] = value if isinstance(value, torch.Tensor) else torch.tensor(value)
+
+    model.log = _capture  # type: ignore[method-assign]
+    # Skip the real Trainer-bound _log_samples — no logger attached here.
+    model._log_samples = lambda *args, **kwargs: None  # type: ignore[method-assign]
+
+    batch = _make_gan_batch()
+    with torch.no_grad():
+        model.validation_step(batch, batch_idx=0)
+        model.validation_step(batch, batch_idx=1)
+    # Stash the snapshot of losses for the weighted-mean reference.
+    losses_snapshot = copy.deepcopy(model.validation_losses)
+    model.on_validation_epoch_end()
+
+    assert "loss/validate" in logged, "loss/validate must be logged at validation_epoch_end"
+    # Verify the value matches a hand-computed weighted mean to confirm it's
+    # the aggregated alias and not just a passthrough of the last batch.
+    total_loss = sum(loss.item() * n for dl in losses_snapshot for loss, n in dl)
+    total_n = sum(n for dl in losses_snapshot for _, n in dl)
+    expected = total_loss / total_n
+    assert pytest.approx(expected, rel=1e-5) == logged["loss/validate"].item()

--- a/applications/dynacell/tests/test_engine.py
+++ b/applications/dynacell/tests/test_engine.py
@@ -547,7 +547,7 @@ def test_dynacell_gan_predict_step():
     assert prediction.shape == batch["source"].shape
 
 
-def test_dynacell_gan_validate_logs_alias():
+def test_dynacell_gan_validate_logs_alias(monkeypatch):
     """``on_validation_epoch_end`` logs the ``loss/validate`` weighted mean."""
     model = DynacellGAN(
         architecture="UNetViT3D",
@@ -563,7 +563,7 @@ def test_dynacell_gan_validate_logs_alias():
 
     model.log = _capture  # type: ignore[method-assign]
     # Skip the real Trainer-bound _log_samples — no logger attached here.
-    model._log_samples = lambda *args, **kwargs: None  # type: ignore[method-assign]
+    monkeypatch.setattr("dynacell.engine._log_samples", lambda *args, **kwargs: None)
 
     batch = _make_gan_batch()
     with torch.no_grad():

--- a/packages/viscy-models/src/viscy_models/gan/__init__.py
+++ b/packages/viscy-models/src/viscy_models/gan/__init__.py
@@ -1,0 +1,6 @@
+"""3D PatchGAN discriminators and LSGAN losses for adversarial virtual staining."""
+
+from viscy_models.gan.losses import lsgan_d_loss, lsgan_g_loss
+from viscy_models.gan.patchgan3d import MultiScalePatchGAN3D, PatchGAN3D
+
+__all__ = ["MultiScalePatchGAN3D", "PatchGAN3D", "lsgan_d_loss", "lsgan_g_loss"]

--- a/packages/viscy-models/src/viscy_models/gan/losses.py
+++ b/packages/viscy-models/src/viscy_models/gan/losses.py
@@ -1,0 +1,71 @@
+"""LSGAN losses for multi-scale 3D PatchGAN discriminators.
+
+Both losses always operate on lists of per-scale logit tensors and average
+the per-scale loss across scales (Mao et al. 2017 "Least Squares GANs",
+adapted to the multi-scale pix2pixHD convention).
+"""
+
+import torch
+from torch import Tensor
+
+__all__ = ["lsgan_d_loss", "lsgan_g_loss"]
+
+
+def lsgan_d_loss(d_real: list[Tensor], d_fake: list[Tensor]) -> Tensor:
+    """Multi-scale LSGAN discriminator loss.
+
+    For each scale, computes ``0.5 * (mean((d_real - 1) ** 2) + mean(d_fake ** 2))``,
+    then averages across scales.
+
+    Parameters
+    ----------
+    d_real : list of Tensor
+        Per-scale discriminator logits on real (source + target) pairs.
+    d_fake : list of Tensor
+        Per-scale discriminator logits on fake (source + generator-output)
+        pairs. These should come from a detached generator output so the loss
+        does not backprop into the generator.
+
+    Returns
+    -------
+    Tensor
+        Scalar loss, mean across scales.
+    """
+    if len(d_real) != len(d_fake):
+        raise ValueError(f"Number of scales must match: len(d_real)={len(d_real)} vs len(d_fake)={len(d_fake)}.")
+    if len(d_real) == 0:
+        raise ValueError("Discriminator outputs must contain at least one scale.")
+
+    per_scale: list[Tensor] = []
+    for real_logits, fake_logits in zip(d_real, d_fake, strict=True):
+        real_loss = torch.mean((real_logits - 1.0) ** 2)
+        fake_loss = torch.mean(fake_logits**2)
+        per_scale.append(0.5 * (real_loss + fake_loss))
+    return torch.stack(per_scale).mean()
+
+
+def lsgan_g_loss(d_fake: list[Tensor]) -> Tensor:
+    """Multi-scale LSGAN generator loss.
+
+    For each scale, computes ``mean((d_fake - 1) ** 2)``, then averages
+    across scales. ``d_fake`` here is the discriminator's response to the
+    *current* (non-detached) generator output, so the loss backpropagates
+    through both the discriminator and the generator parameters along the
+    chain; the discriminator side is typically frozen via ``requires_grad``
+    in the training step.
+
+    Parameters
+    ----------
+    d_fake : list of Tensor
+        Per-scale discriminator logits on fake pairs built from the live
+        generator output.
+
+    Returns
+    -------
+    Tensor
+        Scalar loss, mean across scales.
+    """
+    if len(d_fake) == 0:
+        raise ValueError("Discriminator outputs must contain at least one scale.")
+    per_scale = [torch.mean((logits - 1.0) ** 2) for logits in d_fake]
+    return torch.stack(per_scale).mean()

--- a/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
+++ b/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
@@ -43,10 +43,6 @@ class PatchGAN3D(nn.Module):
         Channel count of the first conv. Subsequent convs double the channels
         up to ``base_channels * 8`` before projecting to a single logit
         channel. Default is 64.
-    num_layers : int, optional
-        Number of conv layers. Only ``num_layers=5`` is supported in v1; the
-        argument exists so future ablations can extend the network without an
-        API break.
     use_spectral_norm : bool, optional
         If True, apply ``spectral_norm`` to every conv. Default is True.
 
@@ -62,13 +58,9 @@ class PatchGAN3D(nn.Module):
         self,
         in_channels: int = 2,
         base_channels: int = 64,
-        num_layers: int = 5,
         use_spectral_norm: bool = True,
     ) -> None:
         super().__init__()
-        if num_layers != 5:
-            raise ValueError(f"PatchGAN3D only supports num_layers=5 in v1, got {num_layers}.")
-
         c1 = base_channels
         c2 = base_channels * 2
         c3 = base_channels * 4
@@ -154,8 +146,6 @@ class MultiScalePatchGAN3D(nn.Module):
         target / pred).
     base_channels : int, optional
         First-conv channel count for each ``PatchGAN3D``. Default is 64.
-    num_layers : int, optional
-        Number of conv layers per ``PatchGAN3D``. Default is 5.
     num_scales : int, optional
         Number of independent discriminators. ``num_scales=2`` is the v1
         default; ``num_scales=1`` is supported as a single-scale ablation.
@@ -174,7 +164,6 @@ class MultiScalePatchGAN3D(nn.Module):
         self,
         in_channels: int = 2,
         base_channels: int = 64,
-        num_layers: int = 5,
         num_scales: int = 2,
         use_spectral_norm: bool = True,
     ) -> None:
@@ -187,7 +176,6 @@ class MultiScalePatchGAN3D(nn.Module):
                 PatchGAN3D(
                     in_channels=in_channels,
                     base_channels=base_channels,
-                    num_layers=num_layers,
                     use_spectral_norm=use_spectral_norm,
                 )
                 for _ in range(num_scales)

--- a/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
+++ b/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
@@ -74,7 +74,6 @@ class PatchGAN3D(nn.Module):
         c3 = base_channels * 4
         c4 = base_channels * 8
 
-        # Layer 1: stride (1, 2, 2), no norm, LeakyReLU
         self.layer1 = nn.Sequential(
             _maybe_spectral_norm(
                 nn.Conv3d(in_channels, c1, kernel_size=4, stride=(1, 2, 2), padding=1),
@@ -83,7 +82,6 @@ class PatchGAN3D(nn.Module):
             nn.LeakyReLU(0.2, inplace=True),
         )
 
-        # Layer 2: stride (1, 2, 2), InstanceNorm + LeakyReLU
         self.layer2 = nn.Sequential(
             _maybe_spectral_norm(
                 nn.Conv3d(c1, c2, kernel_size=4, stride=(1, 2, 2), padding=1),
@@ -93,7 +91,6 @@ class PatchGAN3D(nn.Module):
             nn.LeakyReLU(0.2, inplace=True),
         )
 
-        # Layer 3: stride (2, 2, 2), InstanceNorm + LeakyReLU
         self.layer3 = nn.Sequential(
             _maybe_spectral_norm(
                 nn.Conv3d(c2, c3, kernel_size=4, stride=(2, 2, 2), padding=1),
@@ -103,7 +100,6 @@ class PatchGAN3D(nn.Module):
             nn.LeakyReLU(0.2, inplace=True),
         )
 
-        # Layer 4: stride (2, 2, 2), InstanceNorm + LeakyReLU
         self.layer4 = nn.Sequential(
             _maybe_spectral_norm(
                 nn.Conv3d(c3, c4, kernel_size=4, stride=(2, 2, 2), padding=1),
@@ -113,8 +109,7 @@ class PatchGAN3D(nn.Module):
             nn.LeakyReLU(0.2, inplace=True),
         )
 
-        # Layer 5: stride 1, kernel (1, 4, 4) so it stays valid when Z=1.
-        # Raw logits — no norm, no activation.
+        # Final kernel is (1, 4, 4) so it stays valid when Z=1; emits raw logits.
         self.layer5 = _maybe_spectral_norm(
             nn.Conv3d(c4, 1, kernel_size=(1, 4, 4), stride=1, padding=(0, 1, 1)),
             use_spectral_norm,

--- a/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
+++ b/packages/viscy-models/src/viscy_models/gan/patchgan3d.py
@@ -1,0 +1,223 @@
+"""3D PatchGAN discriminators for paired virtual-staining adversarial training.
+
+Single-scale ``PatchGAN3D`` is a 5-layer convolutional 3D discriminator with
+anisotropic strides (preserving Z early, downsampling YX aggressively), inspired
+by vox2vox / pix2pix 3D medical-imaging conventions. ``MultiScalePatchGAN3D``
+stacks several ``PatchGAN3D`` instances operating on progressively
+YX-downsampled inputs (pix2pixHD-style; Wang et al. 2018).
+"""
+
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.utils.parametrizations import spectral_norm
+
+__all__ = ["MultiScalePatchGAN3D", "PatchGAN3D"]
+
+
+def _maybe_spectral_norm(module: nn.Module, use_spectral_norm: bool) -> nn.Module:
+    """Wrap ``module`` in spectral normalization if requested."""
+    return spectral_norm(module) if use_spectral_norm else module
+
+
+class PatchGAN3D(nn.Module):
+    """Single-scale 5-layer 3D PatchGAN discriminator.
+
+    Five strided 3D convolutions with anisotropic strides
+    ``(1, 2, 2) -> (1, 2, 2) -> (2, 2, 2) -> (2, 2, 2) -> (1, 1, 1)``. The
+    first four convs use ``kernel_size=4`` and ``padding=1``; the final conv
+    uses ``kernel_size=(1, 4, 4)`` and ``padding=(0, 1, 1)`` so it remains
+    valid when the Z dimension has already collapsed to 1. Inner layers 2-4
+    receive ``InstanceNorm3d`` followed by ``LeakyReLU(0.2)``; the first conv
+    has only ``LeakyReLU(0.2)`` and the final conv emits raw logits.
+
+    Spectral normalization (Miyato et al. 2018) is applied to every conv when
+    ``use_spectral_norm`` is True (default and recommended).
+
+    Parameters
+    ----------
+    in_channels : int, optional
+        Number of input channels for the discriminator. For a paired
+        conditional PatchGAN this is the channel count of
+        ``concat([source, target], dim=1)``. Default is 2.
+    base_channels : int, optional
+        Channel count of the first conv. Subsequent convs double the channels
+        up to ``base_channels * 8`` before projecting to a single logit
+        channel. Default is 64.
+    num_layers : int, optional
+        Number of conv layers. Only ``num_layers=5`` is supported in v1; the
+        argument exists so future ablations can extend the network without an
+        API break.
+    use_spectral_norm : bool, optional
+        If True, apply ``spectral_norm`` to every conv. Default is True.
+
+    Returns
+    -------
+    Tensor
+        Raw logits of shape ``(B, 1, Z', H', W')``; spatial size depends on
+        the input. ``MultiScalePatchGAN3D.forward`` wraps this as
+        ``list[Tensor]``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 2,
+        base_channels: int = 64,
+        num_layers: int = 5,
+        use_spectral_norm: bool = True,
+    ) -> None:
+        super().__init__()
+        if num_layers != 5:
+            raise ValueError(f"PatchGAN3D only supports num_layers=5 in v1, got {num_layers}.")
+
+        c1 = base_channels
+        c2 = base_channels * 2
+        c3 = base_channels * 4
+        c4 = base_channels * 8
+
+        # Layer 1: stride (1, 2, 2), no norm, LeakyReLU
+        self.layer1 = nn.Sequential(
+            _maybe_spectral_norm(
+                nn.Conv3d(in_channels, c1, kernel_size=4, stride=(1, 2, 2), padding=1),
+                use_spectral_norm,
+            ),
+            nn.LeakyReLU(0.2, inplace=True),
+        )
+
+        # Layer 2: stride (1, 2, 2), InstanceNorm + LeakyReLU
+        self.layer2 = nn.Sequential(
+            _maybe_spectral_norm(
+                nn.Conv3d(c1, c2, kernel_size=4, stride=(1, 2, 2), padding=1),
+                use_spectral_norm,
+            ),
+            nn.InstanceNorm3d(c2, affine=True),
+            nn.LeakyReLU(0.2, inplace=True),
+        )
+
+        # Layer 3: stride (2, 2, 2), InstanceNorm + LeakyReLU
+        self.layer3 = nn.Sequential(
+            _maybe_spectral_norm(
+                nn.Conv3d(c2, c3, kernel_size=4, stride=(2, 2, 2), padding=1),
+                use_spectral_norm,
+            ),
+            nn.InstanceNorm3d(c3, affine=True),
+            nn.LeakyReLU(0.2, inplace=True),
+        )
+
+        # Layer 4: stride (2, 2, 2), InstanceNorm + LeakyReLU
+        self.layer4 = nn.Sequential(
+            _maybe_spectral_norm(
+                nn.Conv3d(c3, c4, kernel_size=4, stride=(2, 2, 2), padding=1),
+                use_spectral_norm,
+            ),
+            nn.InstanceNorm3d(c4, affine=True),
+            nn.LeakyReLU(0.2, inplace=True),
+        )
+
+        # Layer 5: stride 1, kernel (1, 4, 4) so it stays valid when Z=1.
+        # Raw logits — no norm, no activation.
+        self.layer5 = _maybe_spectral_norm(
+            nn.Conv3d(c4, 1, kernel_size=(1, 4, 4), stride=1, padding=(0, 1, 1)),
+            use_spectral_norm,
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Compute raw discriminator logits.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input of shape ``(B, in_channels, Z, H, W)``. For paired
+            conditional PatchGAN this is ``concat([source, target], dim=1)``.
+
+        Returns
+        -------
+        Tensor
+            Raw logits of shape ``(B, 1, Z', H', W')``.
+        """
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.layer5(x)
+        return x
+
+
+class MultiScalePatchGAN3D(nn.Module):
+    """Multi-scale 3D PatchGAN discriminator (pix2pixHD-style).
+
+    Wraps ``num_scales`` independent ``PatchGAN3D`` instances. Scale 0 sees
+    the input at its native resolution; each subsequent scale operates on a
+    YX-downsampled (``F.avg_pool3d(kernel=(1, 2, 2), stride=(1, 2, 2))``)
+    version of the previous scale's input. The forward returns one logit
+    tensor per scale, with no aggregation — losses (LSGAN) average across
+    scales separately.
+
+    Parameters
+    ----------
+    in_channels : int, optional
+        Channel count of the input to scale 0. Default is 2 (paired source +
+        target / pred).
+    base_channels : int, optional
+        First-conv channel count for each ``PatchGAN3D``. Default is 64.
+    num_layers : int, optional
+        Number of conv layers per ``PatchGAN3D``. Default is 5.
+    num_scales : int, optional
+        Number of independent discriminators. ``num_scales=2`` is the v1
+        default; ``num_scales=1`` is supported as a single-scale ablation.
+        Default is 2.
+    use_spectral_norm : bool, optional
+        If True, apply spectral normalization to every conv in each scale.
+        Default is True.
+
+    Returns
+    -------
+    list of Tensor
+        One logit tensor per scale, ordered from highest to lowest resolution.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 2,
+        base_channels: int = 64,
+        num_layers: int = 5,
+        num_scales: int = 2,
+        use_spectral_norm: bool = True,
+    ) -> None:
+        super().__init__()
+        if num_scales < 1:
+            raise ValueError(f"num_scales must be >= 1, got {num_scales}.")
+        self.num_scales = num_scales
+        self.discriminators = nn.ModuleList(
+            [
+                PatchGAN3D(
+                    in_channels=in_channels,
+                    base_channels=base_channels,
+                    num_layers=num_layers,
+                    use_spectral_norm=use_spectral_norm,
+                )
+                for _ in range(num_scales)
+            ]
+        )
+
+    def forward(self, x: Tensor) -> list[Tensor]:
+        """Compute discriminator logits at every scale.
+
+        Parameters
+        ----------
+        x : Tensor
+            Input of shape ``(B, in_channels, Z, H, W)``.
+
+        Returns
+        -------
+        list of Tensor
+            ``num_scales`` logit tensors, ordered from highest to lowest
+            resolution. Each entry has shape ``(B, 1, Z', H', W')``; spatial
+            size shrinks by roughly 2x in YX between consecutive scales.
+        """
+        outputs: list[Tensor] = []
+        current = x
+        for scale_idx, disc in enumerate(self.discriminators):
+            outputs.append(disc(current))
+            if scale_idx + 1 < self.num_scales:
+                current = F.avg_pool3d(current, kernel_size=(1, 2, 2), stride=(1, 2, 2))
+        return outputs

--- a/packages/viscy-models/tests/test_gan/test_losses.py
+++ b/packages/viscy-models/tests/test_gan/test_losses.py
@@ -1,0 +1,69 @@
+"""Tests for LSGAN losses."""
+
+import math
+
+import torch
+
+from viscy_models.gan import lsgan_d_loss, lsgan_g_loss
+
+
+def test_lsgan_d_loss_single_scale():
+    """Single-scale D loss returns a finite scalar."""
+    d_real = [torch.ones(2, 1, 2, 8, 8)]
+    d_fake = [torch.zeros(2, 1, 2, 8, 8)]
+    loss = lsgan_d_loss(d_real, d_fake)
+    assert loss.ndim == 0
+    assert math.isfinite(loss.item())
+    # D_real perfectly classifies (1 -> target 1) and D_fake perfectly
+    # classifies (0 -> target 0), so the loss is 0.
+    assert loss.item() == 0.0
+
+
+def test_lsgan_d_loss_multi_scale():
+    """Multi-scale D loss with different YX per scale returns a finite scalar."""
+    d_real = [
+        torch.randn(2, 1, 2, 8, 8),
+        torch.randn(2, 1, 2, 4, 4),
+    ]
+    d_fake = [
+        torch.randn(2, 1, 2, 8, 8),
+        torch.randn(2, 1, 2, 4, 4),
+    ]
+    loss = lsgan_d_loss(d_real, d_fake)
+    assert loss.ndim == 0
+    assert math.isfinite(loss.item())
+    assert loss.item() > 0.0
+
+
+def test_lsgan_g_loss_single_and_multi():
+    """G loss works for both single- and multi-scale inputs."""
+    d_fake_single = [torch.ones(2, 1, 2, 8, 8)]
+    loss_single = lsgan_g_loss(d_fake_single)
+    assert loss_single.ndim == 0
+    assert math.isfinite(loss_single.item())
+    # All ones means D classifies fake as real -> G loss is 0.
+    assert loss_single.item() == 0.0
+
+    d_fake_multi = [
+        torch.randn(2, 1, 2, 8, 8),
+        torch.randn(2, 1, 2, 4, 4),
+    ]
+    loss_multi = lsgan_g_loss(d_fake_multi)
+    assert loss_multi.ndim == 0
+    assert math.isfinite(loss_multi.item())
+    assert loss_multi.item() > 0.0
+
+
+def test_losses_gradient_flow():
+    """Both losses propagate non-zero gradients back into the input logits."""
+    real = torch.randn(2, 1, 2, 8, 8, requires_grad=True)
+    fake = torch.randn(2, 1, 2, 8, 8, requires_grad=True)
+    d_loss = lsgan_d_loss([real], [fake])
+    d_loss.backward()
+    assert real.grad is not None and real.grad.abs().sum().item() > 0.0
+    assert fake.grad is not None and fake.grad.abs().sum().item() > 0.0
+
+    fake_g = torch.randn(2, 1, 2, 8, 8, requires_grad=True)
+    g_loss = lsgan_g_loss([fake_g])
+    g_loss.backward()
+    assert fake_g.grad is not None and fake_g.grad.abs().sum().item() > 0.0

--- a/packages/viscy-models/tests/test_gan/test_patchgan3d.py
+++ b/packages/viscy-models/tests/test_gan/test_patchgan3d.py
@@ -1,0 +1,65 @@
+"""Tests for 3D PatchGAN discriminators."""
+
+import torch
+
+from viscy_models.gan import MultiScalePatchGAN3D, PatchGAN3D
+
+
+def test_patchgan3d_shape_small():
+    """Small (2, 2, 8, 64, 64) input produces a single 5-D tensor with square YX."""
+    model = PatchGAN3D(in_channels=2)
+    x = torch.randn(2, 2, 8, 64, 64)
+    y = model(x)
+    assert y.ndim == 5
+    assert y.shape[0] == 2
+    assert y.shape[1] == 1
+    assert y.shape[-1] == y.shape[-2], f"Expected square YX, got {y.shape}"
+
+
+def test_patchgan3d_full_resolution_shape():
+    """Full-resolution (1, 2, 8, 512, 512) input maps to a (1, 1, ?, ?, ?) tensor with square YX."""
+    model = PatchGAN3D(in_channels=2)
+    x = torch.randn(1, 2, 8, 512, 512)
+    with torch.no_grad():
+        y = model(x)
+    assert y.ndim == 5
+    assert y.shape[0] == 1
+    assert y.shape[1] == 1
+    assert y.shape[-1] == y.shape[-2], f"Expected square YX, got {y.shape}"
+
+
+def test_patchgan3d_gradient_flow():
+    """Gradients reach all conv weights after a forward + backward."""
+    model = PatchGAN3D(in_channels=2)
+    x = torch.randn(2, 2, 8, 64, 64, requires_grad=True)
+    y = model(x)
+    loss = y.sum()
+    loss.backward()
+    has_nonzero_grad = False
+    for name, param in model.named_parameters():
+        if "weight" in name and param.grad is not None and param.grad.abs().sum().item() > 0.0:
+            has_nonzero_grad = True
+            break
+    assert has_nonzero_grad, "No conv weight received a non-zero gradient."
+
+
+def test_multi_scale_patchgan3d_shapes():
+    """num_scales=2 returns two tensors; the second has smaller YX than the first."""
+    model = MultiScalePatchGAN3D(in_channels=2, num_scales=2)
+    x = torch.randn(2, 2, 8, 64, 64)
+    out = model(x)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    # Scale 0 sees the full input; scale 1 sees YX-halved input, so its YX
+    # output must be strictly smaller than scale 0's.
+    assert out[1].shape[-1] < out[0].shape[-1]
+    assert out[1].shape[-2] < out[0].shape[-2]
+
+
+def test_multi_scale_patchgan3d_single_scale_ablation():
+    """num_scales=1 returns a single-element list."""
+    model = MultiScalePatchGAN3D(in_channels=2, num_scales=1)
+    x = torch.randn(2, 2, 8, 64, 64)
+    out = model(x)
+    assert isinstance(out, list)
+    assert len(out) == 1


### PR DESCRIPTION
## Summary

Adds a **pix2pix-style 3D GAN baseline** to the DynaCell paper benchmark — UNetViT3D generator (reused unchanged from the existing regression baseline) + a new MultiScalePatchGAN3D discriminator + LSGAN + L1 (λ=100) adversarial objective. Pairs with the existing CellDiff flow-matching baseline so the paper now has both a flow-matching and a GAN generative method to compare against the regression baselines.

The "one-knob ablation" framing for the paper:

| Baseline | Backbone | Objective |
|---|---|---|
| UNetViT3D | UNet3DBase + ViT bottleneck | L2 regression |
| CellDiff  | UNet3DBase + ViT bottleneck + flow head | Flow matching |
| **pix2pix3d_unetvit** (new) | UNet3DBase + ViT bottleneck | **L1 + LSGAN adversarial** |

All three share `UNet3DBase`; pix2pix3d_unetvit differs from UNetViT3D *only* by adding a discriminator + adversarial term.

### What's in this PR

- **`viscy-models/gan/`** — new `PatchGAN3D` (5-layer spectral-normalized) + `MultiScalePatchGAN3D` (pix2pixHD-style 2-scale) + `lsgan_d_loss` / `lsgan_g_loss` helpers + tests
- **`DynacellGAN` Lightning module** — manual two-optimizer training_step with `requires_grad` toggle, validation pipeline mirroring `DynacellUNet`'s aggregation, predict_step that uses generator only at inference
- **8 of 12 cells of training config coverage** — recipe + fit/predict overlays + train leaves for er/{ipsc, a549}, membrane/{ipsc, a549}, mito/{ipsc, a549}, nucleus/{ipsc, a549}. Joint leaves deferred (still gated on the open BatchedConcatDataModule DDP deadlock from handoff 2026-04-26)
- **Predict + eval starter** for `er/pix2pix3d_unetvit/ipsc_confocal` — iPSC + 3 a549_mantis splits (mock, denv, zikv)
- **/simplify cleanup pass** — `configure_optimizers` now reuses `configure_adamw_scheduler`; `_log_samples` deduplicated as a module-level helper across all three Lightning classes

### Architectural decisions (locked from prior planning)

- **LSGAN** over hinge (3D medical convention per Lan 2021/2024, vox2vox-modernized literature)
- **Multi-scale D** (pix2pixHD-style 2-scale) — improves sharpness without the cost of VGG perceptual
- **`requires_grad` toggle** for compute efficiency; Phase 2 will need `find_unused_parameters: true` for DDP
- **bf16-mixed precision**, AdamW + WarmupCosine, `λ_l1 = 100`

### Out of scope (deferred for follow-ups)

- **Phase 2** — DDP topology + production multi-GPU training (write the topology + smoke leaf, blocked on the open DDP deadlock for joint datamodules)
- **Phase 3 joint** — 4 `joint_ipsc_confocal_a549_mantis` train leaves (also DDP-deadlock-blocked)
- **Phase 4 expansion** — predict/eval leaves for the remaining 11 cells (~88 more YAMLs)
- **Signature cleanup** — `predict_method` / `predict_overlap` / `num_layers` dead params, single-value Literals; deferred because production training is currently running with Slurm auto-requeue and a signature change would break a requeue's hparam reconstruction

## Test plan

- [x] `uv run pytest packages/viscy-models/tests/test_gan/` — 9/9 pass (shape contracts, gradient flow, multi-scale variants, LSGAN losses)
- [x] `uv run pytest applications/dynacell/tests/test_engine.py` — 39/39 pass including 5 new `test_dynacell_gan_*` tests (init, forward, training_step, predict_step, validate_logs_alias)
- [x] `uvx prek run --files <touched files>` — ruff check + format clean
- [x] Hydra dry-compose for every new train / predict / eval leaf — all resolve cleanly
- [x] Single-GPU smoke training (20 steps on SEC61B_test48.zarr, H200) — `Trainer.fit stopped: max_steps=20 reached`, both checkpoints written, no NaN, all 4 GAN losses finite
- [x] Production training (job 33132605) launched — W&B run https://czi.wandb.io/computational_imaging/dynacell/runs/20260519-163628; epoch-0 metrics confirm losses finite and L1 descending
- [ ] **Production training complete + reviewer-presentable W&B grids at epoch 5+** — in flight (~10 hr expected total)
- [ ] **Predict + eval against the trained ER iPSC checkpoint** — gated on training completion + a manual `ckpt_path` override (predict leaves use the `REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH` placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)