### PR TITLE
feat(dynacell): controlled FOV-parallel eval + thread budgeting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,16 +138,21 @@ jobs:
         working-directory: applications/dynacell
 
       - name: Run benchmark-schema + submit-tool + eval-runtime tests
-        # tests/test_runtime.py and tests/test_evaluation_pipeline_parallel.py
+        # tests/test_runtime.py + tests/test_evaluation_pipeline_parallel.py
         # cover the dynacell.evaluation.runtime module + FovResult pickle
-        # contract that gate the FOV-level parallelism wiring. They don't
-        # need the eval extras (no iohub fixture or model loads).
+        # contract. tests/test_evaluation_pipeline_parallel_cpu.py drives
+        # evaluate_predictions end-to-end (serial vs spawn-process) on a
+        # tiny iohub fixture + prebuilt mask cache — no eval extras (no
+        # cellpose, transformers, cubic) needed since target_name=er +
+        # require_complete_cache=true short-circuit segmenter and feature
+        # extractor loads.
         run: |
           uv run --frozen pytest \
             tests/test_benchmark_config_composition.py \
             tests/test_submit_benchmark_job.py \
             tests/test_runtime.py \
             tests/test_evaluation_pipeline_parallel.py \
+            tests/test_evaluation_pipeline_parallel_cpu.py \
             -v
         working-directory: applications/dynacell
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,8 +137,18 @@ jobs:
         run: uv sync --frozen --group test
         working-directory: applications/dynacell
 
-      - name: Run benchmark-schema + submit-tool tests
-        run: uv run --frozen pytest tests/test_benchmark_config_composition.py tests/test_submit_benchmark_job.py -v
+      - name: Run benchmark-schema + submit-tool + eval-runtime tests
+        # tests/test_runtime.py and tests/test_evaluation_pipeline_parallel.py
+        # cover the dynacell.evaluation.runtime module + FovResult pickle
+        # contract that gate the FOV-level parallelism wiring. They don't
+        # need the eval extras (no iohub fixture or model loads).
+        run: |
+          uv run --frozen pytest \
+            tests/test_benchmark_config_composition.py \
+            tests/test_submit_benchmark_job.py \
+            tests/test_runtime.py \
+            tests/test_evaluation_pipeline_parallel.py \
+            -v
         working-directory: applications/dynacell
 
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,8 @@ jobs:
         # tiny iohub fixture + prebuilt mask cache — no eval extras (no
         # cellpose, transformers, cubic) needed since target_name=er +
         # require_complete_cache=true short-circuit segmenter and feature
-        # extractor loads.
+        # extractor loads. tests/test_evaluation_grouped.py drives the
+        # multi-condition driver against the same cache-only fixture.
         run: |
           uv run --frozen pytest \
             tests/test_benchmark_config_composition.py \
@@ -153,6 +154,7 @@ jobs:
             tests/test_runtime.py \
             tests/test_evaluation_pipeline_parallel.py \
             tests/test_evaluation_pipeline_parallel_cpu.py \
+            tests/test_evaluation_grouped.py \
             -v
         working-directory: applications/dynacell
 

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -67,8 +67,56 @@ Under `executor=process`, workers return their slice of the timing log inside `F
 
 ### Reality check for process mode
 
-- The parent still loads the seg model once at `pipeline.py:171` (used for checkpoint pre-warm side-effect under `process` mode + the seg model itself under `serial` mode).
+- The parent still loads the seg model once via `load_eval_models(config)` at the start of `evaluate_predictions` in `pipeline.py` (used for checkpoint pre-warm side-effect under `process` mode + the seg model itself under `serial` mode).
 - `precompute_deep_features` (the upfront batched feature pre-fill) stays in the parent — single-pass over positions with the `DeepFeatureBatcher` cross-FOV amortization. Parallelizing precompute is a separate plan.
 - Workers cannot share open iohub plate handles or torch modules across the pickle boundary; each worker re-opens plates on first FOV.
 - `ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)` cancels queued futures only — in-flight workers continue to completion (~minutes if mid-cellpose). Ctrl-C may need `scancel` to fully release GPU memory.
 - Tests for the runtime module + FovResult pickle contract live in `applications/dynacell/tests/test_runtime.py` and `tests/test_evaluation_pipeline_parallel.py`. An end-to-end serial-vs-process parity test on a real iohub fixture is a follow-up (see plan `.claude/plans/eval-parallelism.md` §C5).
+
+### Grouped multi-condition eval
+
+When evaluating the same `(model, organelle)` across multiple I/O variants — typically the three A549 treatment plates (`mock`, `denv`, `zikv`), but also any case where the same trained model is scored on multiple datasets — use `dynacell evaluate-grouped`. The driver loads `SuperModel` + `DinoV3` + `DynaCLR` + `CELL-DINO` once, then loops over the conditions calling `evaluate_predictions(merged_cfg, models=...)` so the per-condition cold-start (~30–90 s of weight load + checkpoint warmup) is paid once total instead of N times.
+
+```yaml
+# applications/dynacell/configs/.../eval_grouped_a549_mantis_er.yml
+defaults:
+  - eval_grouped
+  - _self_
+
+target_name: er           # MUST be set at the base; conditions cannot override it
+compute_feature_metrics: true
+feature_extractor:
+  dinov3: { ... }         # shared across all conditions
+  dynaclr: { checkpoint: /path/to/dynaclr.ckpt, ... }
+  celldino: { weights_path: /path/to/celldino.ckpt, ... }
+
+conditions:
+  - name: a549_mock
+    io: { pred_path: ..., gt_path: ..., gt_cache_dir: ..., pred_cache_dir: ..., cell_segmentation_path: ... }
+    save: { save_dir: /path/to/out/a549_mock }
+  - name: a549_denv
+    io: { ... }
+    save: { save_dir: /path/to/out/a549_denv }
+  - name: a549_zikv
+    io: { ... }
+    save: { save_dir: /path/to/out/a549_zikv }
+```
+
+Invoke:
+```sh
+uv run dynacell evaluate-grouped -c eval_grouped_a549_mantis_er
+```
+
+Constraints (enforced at runtime by `_check_grouped_field_invariants`):
+- Per-condition overlays may freely override `io.*`, `save.*`, `runtime.*`, `limit_positions`, `force_recompute.*`, and carry a `name` label.
+- Overlays MUST NOT change `target_name`, `feature_extractor.*`, `compute_feature_metrics`, or `use_gpu` — those gate model loading and must be identical across conditions. Run such variants separately.
+- Each condition independently honors `_final_metrics_cache_valid` — if a condition's CSV/NPY already exist AND both `force_recompute.all=false` and `force_recompute.final_metrics=false`, the driver skips it and loads the cached outputs. Either flag set to `true` bypasses the cache.
+
+Process-mode caveat: under `runtime.executor=process`, the parent's shared `EvalModels` is passed to `evaluate_predictions(..., models=...)` so the parent-side pre-warm is amortized, but each condition still spawns a fresh `ProcessPoolExecutor` whose workers re-load their own model copies. Use `executor=serial` to maximize the amortization benefit. The driver tiers its message based on the cache mode:
+
+- `executor=process` + `require_complete_cache=true` + `n_conditions > 1` → mild **note**: workers re-init per condition but skip `prepare_segmentation_model` (returns None) and don't instantiate extractors, so the cost is just N pool spawns.
+- `executor=process` + `require_complete_cache=false` + `n_conditions > 1` → loud **WARNING**: each condition's worker pool independently loads SuperModel + DINOv3 + DynaCLR + CELL-DINO. Total waste is ~30-90 s × `runtime.fov_workers` × `n_conditions`. Fix: switch to `executor=serial` so the parent's pre-loaded models are reused across conditions; reserve `process` for per-FOV parallelism within a *single* condition.
+
+For an A40 / single-GPU interactive node where you'd run serial anyway, this is the default win.
+
+Tests: `applications/dynacell/tests/test_evaluation_grouped.py` validates byte-equal parity against sequential per-condition runs on the same cache-only fixture used by `test_evaluation_pipeline_parallel_cpu.py`, plus rejection cases for empty `conditions` and forbidden model-loading-field overrides.

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -32,3 +32,43 @@ Set by `trainer.callbacks[…HCSPredictionWriter].init_args.output_store` in eac
 Where `<org>` is `nucl` / `memb` / `sec61b` / `tomm20`, `<model>` is the **code name** from the table above (e.g. `fcmae_vscyto3d_scratch`, `fnet3d_paper`), and `<cond>` is `mock` / `denv` / `zikv`. The (no-infix) iPSC-trained naming is historical baggage from before joint/A549 training existed; don't add a `_ipsctrained` infix retroactively. Output dirs: iPSC test predictions land under `ipsc/predictions/`, A549 plate predictions under `a549/predictions/`, regardless of training set.
 
 Caveat: Dihan's earlier ER + Mito iPSC-trained zarrs use a legacy `<gene>_<model>__<gene>_<cond>.zarr` shape (e.g. `sec61b_fcmae_vscyto3d_scratch__sec61b_mock.zarr`, double-underscore + redundant gene prefix). New leaves should follow the table above; do not propagate the legacy form.
+
+## Eval runtime / parallelism
+
+`dynacell.evaluation.runtime` (added 2026-05) provides three layered thread-cap entry points + optional FOV-level parallelism via spawn-context `ProcessPoolExecutor`. Defaults preserve sequential behavior; opt in via the `runtime:` block in `eval.yaml`.
+
+### Config block (in `_configs/eval.yaml`)
+
+```yaml
+runtime:
+  fov_workers: 1                          # int | "auto"
+  threads_per_worker: "auto"              # int | "auto" -> cpu_count // fov_workers
+  executor: "serial"                      # "serial" | "process"
+  cuda_empty_cache_every_n_timepoints: 0  # 0 = off
+  gc_collect_every_n_fovs: 0              # 0 = off
+```
+
+- `executor=serial` (default): inline FOV loop, identical to pre-runtime-module behavior.
+- `executor=process`: spawn-context `ProcessPoolExecutor` over FOVs. Each worker independently lazy-loads `seg_model` + extractors under an fcntl GPU lock at `/tmp/dynacell_gpu_<SLURM_JOB_ID>.lock`, so models stay GPU-resident per worker (N × model weights on the GPU) but only one worker runs GPU work at a time. Suitable when GPU memory has headroom for N model copies.
+- `fov_workers: "auto"` resolves to 1 under `executor=serial`; under `executor=process` it clamps to `min(cpu_count // threads_per_worker, n_positions)`.
+- Literal `fov_workers > 1` with `executor=serial` raises. Literal `fov_workers=1` with `executor=process` auto-demotes to `serial` to avoid the ~5 s spawn cold-start cost for a single-worker pool.
+- Two-phase resolve: parent applies BLAS cap at function entry (provisional), then re-resolves after the position list is built with `freeze_threads_per_worker=` so worker initializers see the same value the parent capped to.
+
+### Env-var entry points
+
+- `DYNACELL_THREADS_PER_WORKER=N` — set in SLURM scripts BEFORE invoking `dynacell evaluate`. Exports `OMP_NUM_THREADS` / `MKL_NUM_THREADS` / `OPENBLAS_NUM_THREADS` at C-extension load time (in-process `apply_thread_budget` is a runtime safety net but can come after BLAS load). The `__main__:main_cli` first statement reads this var.
+- `DYNACELL_FORCE_PER_T_HYGIENE=1` — operator escape hatch: flips both `cuda_empty_cache_every_n_timepoints` and `gc_collect_every_n_fovs` to ≥1 at runtime regardless of YAML defaults. Useful for post-ship mitigation of per-T memory degradation without a code change.
+
+### Timing instrumentation
+
+Region timers are always on (overhead is ~120 ms on a 9-h eval, ~4e-6 of wall time). Output goes to `<save_dir>/eval_timing.csv` at end of run with columns `pos_name, t, region, seconds`. Regions tag the FOV-level work (`mask_gt`, `mask_pred`, `cp_gt`, `deep_gt_{dinov3,dynaclr,celldino}`, `features_pred_per_t`, `microssim`, `seg_write`) and the per-T work (`pixel_metrics`, `mask_metrics`, `feature_pairwise`).
+
+Under `executor=process`, workers return their slice of the timing log inside `FovResult.timings`; the parent aggregator concatenates.
+
+### Reality check for process mode
+
+- The parent still loads the seg model once at `pipeline.py:171` (used for checkpoint pre-warm side-effect under `process` mode + the seg model itself under `serial` mode).
+- `precompute_deep_features` (the upfront batched feature pre-fill) stays in the parent — single-pass over positions with the `DeepFeatureBatcher` cross-FOV amortization. Parallelizing precompute is a separate plan.
+- Workers cannot share open iohub plate handles or torch modules across the pickle boundary; each worker re-opens plates on first FOV.
+- `ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)` cancels queued futures only — in-flight workers continue to completion (~minutes if mid-cellpose). Ctrl-C may need `scancel` to fully release GPU memory.
+- Tests for the runtime module + FovResult pickle contract live in `applications/dynacell/tests/test_runtime.py` and `tests/test_evaluation_pipeline_parallel.py`. An end-to-end serial-vs-process parity test on a real iohub fixture is a follow-up (see plan `.claude/plans/eval-parallelism.md` §C5).

--- a/applications/dynacell/src/dynacell/__main__.py
+++ b/applications/dynacell/src/dynacell/__main__.py
@@ -106,6 +106,14 @@ def _inject_external_configs(argv: list[str]) -> list[str]:
 
 def main_cli():
     """Console script entry point for ``dynacell`` command."""
+    # Apply BLAS/OMP env caps BEFORE any torch/numpy import. The import below
+    # is stdlib + threadpoolctl only — no torch — so the env vars set here
+    # bite at first BLAS C-extension load, which happens transitively when
+    # we import the Hydra command module or viscy_utils.cli below.
+    from dynacell.evaluation.runtime import early_apply_env_caps
+
+    early_apply_env_caps()
+
     if len(sys.argv) >= 2 and sys.argv[1] in _HYDRA_COMMANDS:
         command = sys.argv[1]
         module_path, func_name, extra = _HYDRA_COMMANDS[command]

--- a/applications/dynacell/src/dynacell/__main__.py
+++ b/applications/dynacell/src/dynacell/__main__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 _HYDRA_COMMANDS: dict[str, tuple[str, str, str]] = {
     "evaluate": ("dynacell.evaluation.pipeline", "evaluate_model", "eval"),
+    "evaluate-grouped": ("dynacell.evaluation.pipeline", "evaluate_model_grouped", "eval"),
     "precompute-gt": ("dynacell.evaluation.precompute_cli", "precompute_gt", "eval"),
     "report": ("dynacell.reporting.cli", "generate_report", "report"),
 }

--- a/applications/dynacell/src/dynacell/evaluation/README.md
+++ b/applications/dynacell/src/dynacell/evaluation/README.md
@@ -6,183 +6,71 @@ End-to-end evaluation pipeline for virtual staining predictions against fluoresc
 
 | Module | Purpose |
 |---|---|
-| `pipeline.py` | Hydra-driven orchestrator. Loads prediction/GT OME-Zarr plates, computes per-FOV per-timepoint metrics, saves CSVs + NPYs + plots. CLI entrypoint: `dynacell evaluate`. |
-| `metrics.py` | Pixel metrics (PCC, SSIM, NRMSE, PSNR, FSC resolution, spectral PCC, MicroMS3IM), mask metrics (Dice, IoU, precision, recall, accuracy, TP/FP/FN/TN), feature metrics split into `*_target_*` / `*_pred_*` / `*_pairwise` so GT-side work can be cached separately from predictions. |
-| `segmentation.py` | Organelle-specific classical-CV segmentation via `aicssegmentation` workflows (`nucleus`, `membrane`, `nucleoli`, `lysosomes`, `er`, `mitochondria`). Used for mask metrics. |
-| `cache.py` | Artifact cache: on-disk layout, manifest I/O, read/write helpers, staleness check. Keyed by source plate/channel plus `cell_segmentation_path` where relevant. |
-| `pipeline_cache.py` | Per-FOV load-or-compute wrappers for GT and prediction masks/features. Honor `force_recompute.*` flags and the `io.require_complete_cache` contract. |
-| `precompute_cli.py` | Hydra entrypoint for `dynacell precompute-gt`. Iterates GT positions and fills the cache; no eval loop. |
-| `utils.py` | `DinoV3FeatureExtractor`, `DynaCLRFeatureExtractor`, pairwise feature-similarity helpers, `plot_metrics()` bar/violin plots. |
-| `io.py` | OME-Zarr / tiff readers and writers, prediction preprocessing transforms. |
-| `torch_ssim.py` | GPU-friendly PyTorch SSIM. |
-| `formatting.py` | Metric table formatting helpers. |
-| `spectral_pcc/` | Bandlimited spectral PCC diagnostics and bead simulations. |
-| `_configs/eval.yaml` | Hydra config for `dynacell evaluate`, with `???` MISSING markers for dataset-specific fields. |
-| `_configs/precompute.yaml` | Hydra config for `dynacell precompute-gt`; inherits eval, requires `io.gt_cache_dir`. |
+| `pipeline.py` | Hydra orchestrator. CLIs: `dynacell evaluate` (single-condition) and `dynacell evaluate-grouped` (one model load, N I/O conditions). |
+| `metrics.py` | Pixel, mask, and feature metrics (CP regionprops + DINOv3 + DynaCLR + CELL-DINO), computed symmetrically for GT/predictions and combined pairwise. |
+| `segmentation.py` | `aicssegmentation` workflows + SuperModel for `nucleus`/`membrane`. |
+| `cache.py`, `pipeline_cache.py` | Artifact cache: on-disk layout, manifest, identity check, per-FOV load-or-compute wrappers, batched `precompute_deep_features`. |
+| `model_loader.py` | Shared `load_eval_models(config, flags=...)` returning an `EvalModels` bundle. Used by both `evaluate` and `precompute-gt`. |
+| `runtime.py` | BLAS/OMP thread caps, `ProcessPoolExecutor` worker initializer, `gpu_serialization_lock`, region timers. |
+| `precompute_cli.py` | `dynacell precompute-gt` — fills the GT cache without running the eval loop. |
+| `utils.py` | `DinoV3FeatureExtractor`, `DynaCLRFeatureExtractor`, `CellDinoFeatureExtractor`, plot helpers. |
+| `_configs/*.yaml` | Hydra schemas: `eval.yaml`, `precompute.yaml`, `eval_grouped.yaml`. |
+
+Other files (`io.py`, `torch_ssim.py`, `formatting.py`, `spectral_pcc/`) house readers, GPU SSIM, and bead/PSF diagnostics.
 
 ## Inputs
 
 - `io.pred_path` — model predictions, HCS OME-Zarr (channel: `io.pred_channel_name`)
-- `io.gt_path` — fluorescence ground truth, HCS OME-Zarr (channel: `io.gt_channel_name`)
-- `io.cell_segmentation_path` — *optional* precomputed cell segmentation, HCS OME-Zarr. Required only when `compute_feature_metrics=true` or when building CP/DINOv3/DynaCLR cache entries. Position layout must match GT/pred 1:1.
-- `io.gt_cache_dir` — *optional* directory for the GT artifact cache. `null` (default) disables caching; set to a writable path to opt in. Required for `dynacell precompute-gt` and for `io.require_complete_cache=true`.
-- `io.pred_cache_dir` — *optional* directory for the prediction artifact cache. `null` (default) preserves the old behavior. Must be distinct from `io.gt_cache_dir`.
+- `io.gt_path` — fluorescence ground truth (channel: `io.gt_channel_name`)
+- `io.cell_segmentation_path` — *optional* precomputed cell segmentation HCS OME-Zarr. Required when `compute_feature_metrics=true` or when building CP/DINOv3/DynaCLR/CELL-DINO cache entries. Position layout must match GT/pred 1:1.
+- `io.gt_cache_dir`, `io.pred_cache_dir` — *optional* artifact cache directories; must be distinct. See [Caches](#caches).
 
-## Running an evaluation
-
-`dynacell evaluate` is a Hydra entrypoint. Override any field on the CLI with `key=value`.
-
-Paths and settings that belong to a (target, marker, dataset) combination
-live in named Hydra config groups, so most invocations only need to select
-the right group and point at the prediction / output paths. Groups come from
-two sources: the packaged schema under `src/dynacell/evaluation/_configs/`
-and — on a repo checkout — HPC-bound groups under
-`configs/benchmarks/virtual_staining/_internal/` that `dynacell.__main__`
-exposes through two injected `hydra.searchpath` roots. See the table below.
-
-### Config groups
-
-| Group | Options | What it sets | Source |
-|---|---|---|---|
-| `target` | `er_sec61b`, `mito_tomm20`, `membrane`, `nucleus` | `target_name`, `benchmark.dataset_ref.target`. | `configs/benchmarks/virtual_staining/_internal/shared/eval/target/` |
-| `predict_set` | `ipsc_confocal` | `benchmark.dataset_ref.dataset`. | in-package (`_configs/predict_set/`) |
-| `feature_extractor/dinov3` | `lvd1689m` | `feature_extractor.dinov3.pretrained_model_name`. | in-package (`_configs/feature_extractor/dinov3/`) |
-| `feature_extractor/dynaclr` | `default` | `feature_extractor.dynaclr.checkpoint` and 8-field `encoder` dict. | `configs/benchmarks/virtual_staining/_internal/shared/eval/feature_extractor/dynaclr/` |
-| `leaf` | `<org>/<model>/<train_set>/eval__<predict_set>` (8 canonical leaves) | Composes all of the above for a canonical benchmark run; see "Benchmark eval leaves" below. | `configs/benchmarks/virtual_staining/_internal/leaf/` (symlink tree) |
-
-`io.*` fields (`gt_path`, `cell_segmentation_path`, `gt_channel_name`,
-`pred_channel_name`, `gt_cache_dir`) and `pixel_metrics.spacing` are now
-owned by the dataset manifest (`dynacell/data/manifests.py`) and
-spliced into the composed config by a post-compose hook in
-`_ref_hook.py`. `pred_channel_name` is derived as
-`{target_channel}_prediction`.
-
-- **In-package** groups (`predict_set`, `feature_extractor/dinov3`,
-  `spectral_pcc/*`) ship in the wheel: schema and path-free reference
-  values only.
-- **Repo-checkout** groups (`target`, `feature_extractor/dynaclr`, `leaf`)
-  all live under `configs/benchmarks/virtual_staining/_internal/` — the
-  hidden support tree that keeps the top level of `virtual_staining/`
-  biology-only. They contain HPC paths, our DynaCLR checkpoint, and
-  benchmark-instance values — useless to external users.
-  `dynacell.__main__` injects two `hydra.searchpath` roots
-  (`_internal/` for the `leaf/` tree and `_internal/shared/eval/` for
-  `target/` and `feature_extractor/dynaclr/`) when running from a repo
-  checkout. Wheel installs without the repo silently omit these, and
-  external users supply their own via `--config-dir`.
-- **Hydra only discovers `.yaml` files for group resolution**, so eval
-  group files under `_internal/shared/eval/`, the canonical eval leaves
-  at `<org>/<model>/<train_set>/eval__<predict_set>.yaml`, and the
-  `_internal/leaf/` symlinks all use `.yaml`.
-  Lightning-side train and predict leaves stay `.yml` (they compose
-  through `viscy_utils.compose`, which is extension-agnostic).
-
-Selecting a group on the CLI: `<group>=<option>` (no `+` prefix needed — groups are
-declared as `optional` in `eval.yaml`).
-
-`target_name` ∈ {`nucleus`, `membrane`, `nucleoli`, `lysosomes`, `er`, `mitochondria`} — selects the `aicssegmentation` workflow. The first four map 1:1 with the `target` group's
-`target_name` field; `nucleoli` and `lysosomes` have no ready-made target group yet
-and must be set directly (`target_name=…`).
-
-### Minimal example — pixel + mask metrics only
+## Quick start
 
 ```bash
 uv run dynacell evaluate \
   target=er_sec61b \
   predict_set=ipsc_confocal \
-  io.pred_path=/hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/fnet3d_sec61b.zarr \
-  save.save_dir=/hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/eval_fnet3d_sec61b
-```
-
-The older field-by-field form still works and composes cleanly with groups; any
-field set directly on the CLI overrides the group:
-
-```bash
-uv run dynacell evaluate \
-  target=er_sec61b \
-  io.gt_path=/some/other/SEC61B.zarr \   # leaf wins over group
-  io.pred_path=… save.save_dir=… pixel_metrics.spacing=[0.29,0.108,0.108]
-```
-
-### Smoke test on a subset
-
-```bash
-uv run dynacell evaluate ... limit_positions=10
-```
-
-### Shared Hugging Face hub cache (DINOv3 weights)
-
-`dynacell evaluate` and `dynacell precompute-gt` default `HF_HUB_CACHE`
-to
-`/hpc/projects/comp.micro/virtual_staining/models/dynacell/evaluation/hf_cache/`
-when they detect a repo checkout, so gated HF models (DINOv3) are
-downloaded once per team instead of once per user to per-home
-`~/.cache/huggingface/hub/`. If you already export `HF_HUB_CACHE`
-yourself the auto-setter backs off. Wheel-install users fall through to
-the normal per-user HF default.
-
-**HF_HUB_CACHE, not HF_HOME.** `HF_HOME` relocates the whole HF
-directory including the auth token file, which would break per-user
-gated-repo ACLs (HF returns 401 because the token at
-`~/.cache/huggingface/token` is no longer where HF looks for it).
-`HF_HUB_CACHE` only relocates weights/datasets; tokens stay per-user
-and each user's gate access is enforced separately.
-
-First-time setup is one-time per team: one member with gated-repo
-access (see `https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m`)
-runs any eval command that triggers the DINOv3 download; everyone else
-thereafter reuses the shared weights on disk — those reads don't hit HF
-and don't need a token.
-
-### Enable feature metrics (DINOv3 + DynaCLR)
-
-The `feature_extractor/dinov3=lvd1689m` and
-`feature_extractor/dynaclr=default` groups are auto-selected in
-`eval.yaml`'s defaults list on a repo checkout, so you don't need to
-pass them unless you're swapping variants. Turn
-`compute_feature_metrics=true` to enable the feature-metrics branch:
-
-```bash
-uv run dynacell evaluate \
-  target=er_sec61b \
-  predict_set=ipsc_confocal \
-  compute_feature_metrics=true \
   io.pred_path=/hpc/.../fnet3d_sec61b.zarr \
   save.save_dir=/hpc/.../eval_fnet3d_sec61b
 ```
 
-`io.cell_segmentation_path` comes from the `target` group; the pipeline requires
-it to be non-null when feature metrics are on.
+Add `compute_feature_metrics=true` to enable feature metrics. Smoke test on a subset of FOVs with `limit_positions=N`.
 
-To use a non-canonical DynaCLR checkpoint, override the field directly:
-```bash
-uv run dynacell evaluate … \
-  feature_extractor.dynaclr.checkpoint=/hpc/.../other.ckpt
-```
+## Configuration
 
-To disable DINOv3 or DynaCLR on a repo checkout (e.g. to isolate one
-feature family), pin the group back to `null`:
-```bash
-uv run dynacell evaluate … feature_extractor/dinov3=null
-```
+`dynacell evaluate` is a Hydra entrypoint — override any field with `key=value` (CLI overrides win over groups). Settings that travel with a (target, marker, dataset) combination live in named Hydra **config groups**:
 
-### External users: authoring your own groups
+| Group | Options | What it sets | Source |
+|---|---|---|---|
+| `target` | `er_sec61b`, `mito_tomm20`, `membrane`, `nucleus` | `target_name`, `benchmark.dataset_ref.target` | repo-checkout `_internal/shared/eval/target/` |
+| `predict_set` | `ipsc_confocal` | `benchmark.dataset_ref.dataset` | in-package |
+| `feature_extractor/dinov3` | `lvd1689m` | `feature_extractor.dinov3.pretrained_model_name` | in-package |
+| `feature_extractor/dynaclr` | `default` | `feature_extractor.dynaclr.checkpoint` + 8-field encoder dict | repo-checkout `_internal/shared/eval/feature_extractor/dynaclr/` |
+| `leaf` | `<org>/<model>/<train_set>/eval__<predict_set>` | Composes all of the above for one canonical run | repo-checkout `_internal/leaf/` (symlink tree) |
 
-`pip install dynacell` ships only the schema and path-free reference groups
-(eval.yaml, precompute.yaml, feature_extractor/dinov3/lvd1689m, predict_set/ipsc_confocal,
-spectral_pcc/*). Our HPC-bound groups (the `target/*` files,
-`feature_extractor/dynaclr/default`, and the `leaf/` eval-leaf symlinks)
-live under `configs/benchmarks/virtual_staining/_internal/` in the repo
-checkout and won't be present in a wheel-only install — they point at
-paths and checkpoints external users don't have.
+Select a group: `<group>=<option>` (no `+` — groups are declared `optional` in `eval.yaml`).
 
-To evaluate your own predictions, write your own group files and point Hydra at
-them with `--config-dir`. A minimal target file:
+`io.*` and `pixel_metrics.spacing` resolve from the dataset manifest (`dynacell/data/manifests.py`) via a post-compose hook in `_ref_hook.py`. `pred_channel_name` is derived as `{target_channel}_prediction`.
+
+`target_name` ∈ {`nucleus`, `membrane`, `nucleoli`, `lysosomes`, `er`, `mitochondria`} selects the segmentation workflow. The first four map 1:1 with a `target` group; `nucleoli`/`lysosomes` have no ready-made group — set `target_name=…` directly.
+
+**Group sources**: in-package groups ship in the wheel (schema + path-free reference values). Repo-checkout groups under `configs/benchmarks/virtual_staining/_internal/` are discovered via two `hydra.searchpath` roots that `dynacell.__main__` injects on a repo checkout. Hydra only resolves `.yaml` for group lookup, so eval groups + leaves use `.yaml` (Lightning train/predict leaves stay `.yml`).
+
+### Feature metrics
+
+`feature_extractor/dinov3=lvd1689m` and `feature_extractor/dynaclr=default` auto-select on a repo checkout. CELL-DINO is opt-in: set `feature_extractor.celldino.weights_path=/path/to/celldino.ckpt`, or leave `null` to soft-skip.
+
+Override a checkpoint: `feature_extractor.dynaclr.checkpoint=/hpc/.../other.ckpt`. Disable a backbone: `feature_extractor/dinov3=null`. Enable feature metrics: `compute_feature_metrics=true` (also needs `io.cell_segmentation_path` non-null).
+
+### External users (`--config-dir`)
+
+Wheel installs see only in-package groups. To evaluate your own predictions, point Hydra at your group files:
 
 ```yaml
-# File: my_configs/target/mine.yaml
-# @package _global_         # REQUIRED: writes into root, not under 'target.*'
-target_name: er             # one of: nucleus, membrane, nucleoli, lysosomes, er, mitochondria
+# my_configs/target/mine.yaml
+# @package _global_         # REQUIRED — writes into root, not under 'target.*'
+target_name: er
 io:
   gt_path: /data/mine/gt.zarr
   cell_segmentation_path: /data/mine/seg.zarr
@@ -190,93 +78,31 @@ io:
   pred_channel_name: MyPredictionChannel
 ```
 
-Wheel-only users: either author a dynacell manifest YAML and set
-`DYNACELL_MANIFEST_ROOTS` (so `benchmark.dataset_ref` resolves through
-the hook in `_ref_hook.py`), or set `io.*` fields directly on the CLI
-as in the minimal example above.
-
-Run with:
 ```bash
-dynacell evaluate --config-dir /absolute/path/to/my_configs \
+dynacell evaluate --config-dir /abs/path/my_configs \
   target=mine predict_set=ipsc_confocal \
-  io.pred_path=/path/to/predictions.zarr \
-  save.save_dir=/path/to/out
+  io.pred_path=/path/to/preds.zarr save.save_dir=/path/to/out
 ```
 
-**Common footguns:**
+Or skip groups and set `io.*` directly on the CLI. For manifest-based path resolution from a wheel-only install, author a dynacell manifest and set `DYNACELL_MANIFEST_ROOTS`.
 
-- Omitting the `# @package _global_` directive on line 1 makes the file's
-  contents land at `cfg.target.target_name` instead of `cfg.target_name`;
-  the schema fields (`target_name`, `io.*`) stay `???` and the pipeline
-  fails with `MissingMandatoryValue` — not an obviously-linked error.
-- Saving your group file as `.yml` instead of `.yaml`. Hydra's group
-  resolver looks for `.yaml` specifically, so the group is silently
-  undiscoverable and the `target=mine` selector raises
-  `MissingConfigException`.
+**Footguns**: (1) missing `# @package _global_` makes contents land under `cfg.target.*` instead of root → `MissingMandatoryValue`. (2) Saving group as `.yml` instead of `.yaml` makes it undiscoverable → `MissingConfigException`.
 
 ### Benchmark eval leaves
 
-Canonical evaluations for the virtual-staining benchmarks are checked in
-under
-`applications/dynacell/configs/benchmarks/virtual_staining/<organelle>/<model>/<train_set>/eval__<predict_set>.yaml`,
-next to the matching train and predict leaves for the same training run.
-Each leaf pins every group selection, paths, and the save directory — run
-one by selecting it as the `leaf` group:
+Canonical leaves at `configs/benchmarks/virtual_staining/<org>/<model>/<train_set>/eval__<predict_set>.yaml` pin every group + path + save dir:
 
 ```bash
 uv run dynacell evaluate leaf=er/celldiff/ipsc_confocal/eval__ipsc_confocal
 ```
 
-The current set mirrors the predict benchmark tree one-to-one:
-`(er, membrane, mito, nucleus) × (celldiff, unetvit3d)`. CLI overrides still
-apply on top (e.g. `limit_positions=1`, `compute_feature_metrics=false`,
-`save.save_dir=/tmp/…` for smoke tests).
+Coverage: `(er, membrane, mito, nucleus) × (celldiff, unetvit3d)`. CLI overrides apply on top (e.g. `limit_positions=1` for smoke).
 
-Hydra resolves `leaf=<path>` through a symlink tree at
-`configs/benchmarks/virtual_staining/_internal/leaf/<path>.yaml` that
-aliases the canonical eval leaves. Two `hydra.searchpath` roots are
-injected by `dynacell.__main__`: `_internal/` (for the `leaf/` tree)
-and `_internal/shared/eval/` (for `target/` and
-`feature_extractor/dynaclr/`). Wheel-only installs without the repo
-checkout won't see any of these — see "External users" above for
-authoring your own.
+## Caches
 
-### Force recompute
+Set `io.gt_cache_dir` to write/read GT-side artifacts. Set `io.pred_cache_dir` for prediction-side organelle masks + per-cell features. Sharing one root is rejected.
 
-The `force_recompute` block has one flag per cacheable artifact plus a shortcut:
-
-| Flag | What it invalidates |
-|---|---|
-| `force_recompute.final_metrics` | Saved CSV/NPY under `save.save_dir` — forces a full re-run of the eval loop. |
-| `force_recompute.gt_masks` | Cached target-side organelle masks for `target_name`. |
-| `force_recompute.gt_cp` | Cached target-side CP regionprops features. |
-| `force_recompute.gt_dinov3` | Cached target-side DINOv3 features for the current model name. |
-| `force_recompute.gt_dynaclr` | Cached target-side DynaCLR features for the current `(ckpt_sha256, encoder_config_sha256)`. |
-| `force_recompute.gt_celldino` | Cached target-side CELL-DINO features for the current weights. |
-| `force_recompute.pred_masks` | Cached prediction-side organelle masks for `target_name`. |
-| `force_recompute.pred_cp` | Cached prediction-side CP regionprops features. |
-| `force_recompute.pred_dinov3` | Cached prediction-side DINOv3 features for the current model name. |
-| `force_recompute.pred_dynaclr` | Cached prediction-side DynaCLR features for the current `(ckpt_sha256, encoder_config_sha256)`. |
-| `force_recompute.pred_celldino` | Cached prediction-side CELL-DINO features for the current weights. |
-| `force_recompute.all` | All of the above. |
-
-Examples:
-
-```bash
-# Regenerate only DINOv3 features, keep everything else cached:
-uv run dynacell evaluate ... io.gt_cache_dir=/path/to/cache force_recompute.gt_dinov3=true
-
-# Nuke everything and rebuild:
-uv run dynacell evaluate ... io.gt_cache_dir=/path/to/cache force_recompute.all=true
-```
-
-Without `io.gt_cache_dir` / `io.pred_cache_dir`, that side's cache layer is a no-op. Only `force_recompute.final_metrics` / `.all` affect uncached runs.
-
-## Artifact caches
-
-Set `io.gt_cache_dir` to write and read back GT-side artifacts. Set `io.pred_cache_dir` to do the same for prediction-side organelle masks and per-cell features. Keep them as separate directories; sharing one root is rejected to avoid artifact collisions.
-
-GT caches are reusable across model checkpoints for the same dataset/target. Prediction caches are reusable for repeated evaluations of the same prediction store/channel, for example when changing dataset-level feature comparisons or re-running reports.
+GT caches are reusable across model checkpoints for the same `(gt_path, gt_channel_name, cell_segmentation_path)`. Prediction caches are reusable for repeated evals of the same `(pred_path, pred_channel_name, cell_segmentation_path)`.
 
 ### Layout
 
@@ -284,37 +110,21 @@ GT caches are reusable across model checkpoints for the same dataset/target. Pre
 {cache_dir}/
   manifest.yaml                          # built_at, params, positions per artifact
   organelle_masks/{target_name}.zarr     # HCS plate; channel target_seg or prediction_seg
-  features/cp.zarr                       # zarr group, arrays at {row}/{col}/{fov}/t{t}
-  features/dinov3/{model_slug}.zarr      # one plate per model name
+  features/cp.zarr                       # arrays at {row}/{col}/{fov}/t{t}
+  features/dinov3/{model_slug}.zarr      # one plate per DINOv3 model name
   features/dynaclr/{ckpt_sha12}.zarr     # one plate per (checkpoint, encoder_config)
-  features/celldino/{weights_sha12}.zarr # one plate per CELL-DINO weights file
+  features/celldino/{weights_sha12}.zarr # one plate per CELL-DINO weights
 ```
 
-GT cache identity is `(cache_schema_version, gt_path, gt_channel_name, cell_segmentation_path)`. Prediction cache identity is `(cache_schema_version, pred_path, pred_channel_name, cell_segmentation_path)`. A mismatch raises `StaleCacheError` — no silent mis-serving when you change channels, swap segmentations, or bump the computation-logic version.
+Identity: `(cache_schema_version, plate_path, channel_name, cell_segmentation_path)`. Mismatch raises `StaleCacheError`. The DynaCLR `ckpt_sha256_12` is memoized to a `<ckpt>.sha256` sidecar; touch or replace the checkpoint and the hash recomputes.
 
-The DynaCLR checkpoint hash (`ckpt_sha256_12`) is memoized to a
-`<ckpt>.sha256` sidecar next to the checkpoint and reused across eval
-runs as long as the sidecar's mtime is ≥ the checkpoint's. Touch or
-replace the checkpoint and the hash recomputes automatically.
-
-### Priming the cache
-
-All four cache families (`masks`, `cp`, `dinov3`, `dynaclr`) build by
-default, and `feature_extractor/dinov3=lvd1689m` and
-`feature_extractor/dynaclr=default` are auto-selected via
-`eval.yaml`'s defaults list on a repo checkout. `io.gt_cache_dir` now
-comes from the manifest via `benchmark.dataset_ref` — both the
-`target` group (contributing `dataset_ref.target`) and the
-`predict_set` group (contributing `dataset_ref.dataset`) are needed
-for the hook to resolve the manifest entry. So a full prime still
-needs only the target and predict-set selectors:
+### Priming with `precompute-gt`
 
 ```bash
 uv run dynacell precompute-gt target=er_sec61b predict_set=ipsc_confocal
 ```
 
-For an ad-hoc prime without the HPC groups, set the equivalent fields
-directly:
+Ad-hoc without HPC groups:
 
 ```bash
 uv run dynacell precompute-gt \
@@ -323,31 +133,24 @@ uv run dynacell precompute-gt \
   io.cell_segmentation_path=/hpc/.../SEC61B_segmented_cleaned.zarr \
   io.gt_cache_dir=/hpc/.../cache/SEC61B \
   pixel_metrics.spacing=[0.29,0.108,0.108] \
-  feature_extractor.dinov3.pretrained_model_name=facebook/dinov3-vitl16-pretrain-lvd1689m \
-  feature_extractor.dynaclr.checkpoint=/path/to/dynaclr.ckpt \
-  'feature_extractor.dynaclr.encoder={backbone: resnet50, in_channels: 1, ...}'
+  feature_extractor.dynaclr.checkpoint=/path/to/dynaclr.ckpt
 ```
 
-`build.*` toggles let you skip families you don't need — for example,
-mask-only:
-
-```bash
-uv run dynacell precompute-gt ... build.cp=false build.dinov3=false build.dynaclr=false
-```
+Skip families: `build.cp=false build.dinov3=false build.dynaclr=false build.celldino=false build.masks=false`.
 
 ### Prediction cache
 
-There is no separate `precompute-pred` command yet. The first `dynacell evaluate` run with `io.pred_cache_dir` set fills prediction masks/features; later runs hit that cache.
+No `precompute-pred` CLI. The first `dynacell evaluate` run with `io.pred_cache_dir` set fills prediction masks/features; later runs hit it.
 
-```bash
-uv run dynacell evaluate ... \
-  io.pred_cache_dir=/hpc/.../pred_cache/sec61b_fcmae_v1 \
-  force_recompute.final_metrics=true
-```
+### Cache-only fast path: `io.require_complete_cache=true`
 
-### Parallel sweeps
+With both caches warm, this flag puts `dynacell evaluate` in cache-only mode:
 
-After a full GT precompute and one prediction-cache fill, launch many `dynacell evaluate` jobs in parallel against the same caches with `io.require_complete_cache=true`. Missing entries raise `StaleCacheError` instead of being built opportunistically.
+- No model loads (~30-90 s cold-start skipped). The upfront `precompute_deep_features` pass is also skipped.
+- Cache misses raise `StaleCacheError` immediately — fail-loud instead of opportunistic rebuild.
+- Pixel + mask metrics still run on the original image volumes; deep features served from disk.
+
+Use case: parallel sweeps, downstream metric iteration, crash recovery.
 
 ```bash
 uv run dynacell evaluate ... \
@@ -356,9 +159,79 @@ uv run dynacell evaluate ... \
   io.require_complete_cache=true
 ```
 
-### Cache invalidation
+**Edge case**: when `target_name ∈ {nucleus, membrane}` AND `io.pred_cache_dir=null`, SuperModel still loads — the per-T loop falls back to `segment(predict[t], seg_model=...)` for predictions. The skip-load fast path applies cleanly for organelle targets or when `io.pred_cache_dir` is also configured.
 
-We deliberately do **not** fingerprint the GT, prediction, or cell_segmentation zarr *contents*. If you modify them in place, either bump `cache_schema_version` in `cache.py`, set the appropriate `force_recompute.*` flag, or delete the affected cache directory.
+### Force recompute
+
+```yaml
+force_recompute:
+  all: false              # invalidate everything below
+  final_metrics: false    # CSV/NPY under save.save_dir → full re-run of the eval loop
+  gt_masks / gt_cp / gt_dinov3 / gt_dynaclr / gt_celldino: false
+  pred_masks / pred_cp / pred_dinov3 / pred_dynaclr / pred_celldino: false
+```
+
+Each per-artifact flag invalidates that family for its side only:
+- `*_masks` — organelle masks for `target_name`
+- `*_cp` — CP regionprops
+- `*_dinov3` — features keyed on the active DINOv3 model name
+- `*_dynaclr` — features keyed on `(ckpt_sha12, encoder_cfg_sha12)`
+- `*_celldino` — features keyed on the CELL-DINO weights hash
+
+Without `io.gt_cache_dir` / `io.pred_cache_dir`, only `force_recompute.{final_metrics, all}` matter.
+
+### Invalidation
+
+We deliberately do **not** fingerprint zarr contents. If you modify them in place, either bump `cache_schema_version` in `cache.py`, set the right `force_recompute.*`, or delete the affected cache dir.
+
+## Scaling
+
+### FOV-level parallelism: `runtime.*`
+
+Default is sequential per FOV. Knobs (and their YAML defaults):
+
+```yaml
+runtime:
+  fov_workers: 1                           # int | "auto"
+  threads_per_worker: "auto"               # int | "auto" → cpu_count // fov_workers
+  executor: "serial"                       # "serial" | "process"
+  cuda_empty_cache_every_n_timepoints: 0   # 0 = off
+  gc_collect_every_n_fovs: 0               # 0 = off
+```
+
+- `executor=serial` is bit-for-bit identical to pre-runtime behavior.
+- `executor=process` uses a spawn-context `ProcessPoolExecutor` over FOVs. Each worker independently lazy-loads models under an `fcntl` GPU lock, so only one worker runs GPU work at a time. Best when (a) the per-FOV CPU phase (cache I/O, regionprops, crop construction) is your bottleneck, or (b) you're under `require_complete_cache=true` so workers do no GPU work.
+- `fov_workers="auto"` resolves to 1 under `serial`; under `process` it clamps to `min(cpu_count // threads_per_worker, n_positions)`. A literal `fov_workers > 1` with `executor=serial` raises; a resolved `fov_workers=1` with `executor=process` auto-demotes to `serial` (skips ~5 s spawn cost).
+
+**Env-var hooks**:
+- `DYNACELL_THREADS_PER_WORKER=N` — set in SLURM script *before* `dynacell evaluate`; the only thread-cap layer that bites at C-extension load time.
+- `DYNACELL_FORCE_PER_T_HYGIENE=1` — operator escape hatch; flips both per-T memory hygiene knobs ≥1 regardless of YAML.
+
+Region timers are always on (~120 ms overhead on a 9 h eval). Output: `<save_dir>/eval_timing.csv` with rows `(pos_name, t, region, seconds)`.
+
+### Grouped multi-condition eval: `dynacell evaluate-grouped`
+
+Score one `(model, organelle)` across multiple I/O variants — typically the three A549 plates (`mock`/`denv`/`zikv`) — paying the model cold-start **once** total.
+
+```yaml
+# eval_grouped_a549_mantis_er.yaml
+defaults: [eval_grouped, _self_]
+target_name: er
+compute_feature_metrics: true
+feature_extractor: { ... }   # shared across all conditions
+conditions:
+  - { name: a549_mock, io: { ... }, save: { save_dir: /out/a549_mock } }
+  - { name: a549_denv, io: { ... }, save: { save_dir: /out/a549_denv } }
+  - { name: a549_zikv, io: { ... }, save: { save_dir: /out/a549_zikv } }
+```
+
+```bash
+uv run dynacell evaluate-grouped -c eval_grouped_a549_mantis_er
+```
+
+Per-condition overlays may override `io.*`, `save.*`, `runtime.*`, `limit_positions`, `force_recompute.*`, and carry a `name` label. They MUST NOT touch `target_name`, `feature_extractor.*`, `compute_feature_metrics`, or `use_gpu` — those gate model loading. Each condition honors `force_recompute.{all, final_metrics}` independently — if CSV/NPY already exist and neither flag is set, the condition is skipped and cached outputs are loaded.
+
+**Process-mode caveat**: under `runtime.executor=process` each condition spawns its own worker pool that re-loads models. Combined with `require_complete_cache=false` this multiplies cold-start across conditions; the driver emits a loud warning. For maximum amortization use `executor=serial`, or precompute caches and run with `require_complete_cache=true`.
 
 ## Outputs
 
@@ -366,18 +239,27 @@ Under `save.save_dir`:
 
 ```
 pixel_metrics.csv / .npy        # per-FOV per-timepoint pixel metrics
-mask_metrics.csv / .npy         # per-FOV per-timepoint mask metrics
-feature_metrics.csv / .npy      # per-FOV per-timepoint feature metrics (if enabled)
-segmentation_results.zarr       # HCS plate, channels: [prediction_seg, target_seg]
+mask_metrics.csv / .npy
+feature_metrics.csv / .npy      # if compute_feature_metrics=true
+segmentation_results.zarr       # HCS plate; channels [prediction_seg, target_seg]
 pixel_metrics/*.png             # bar/violin plots per metric
 mask_metrics/*.png
 feature_metrics/*.png
+eval_timing.csv                 # region timer log (always on)
 ```
 
 ## Installation
 
-Evaluation pulls heavy optional deps (`aicssegmentation`, `segmenter-model-zoo`, `cubic`, `microssim`, `transformers`, `dynaclr`). Install them with the `eval` extra:
+Heavy optional deps (`aicssegmentation`, `segmenter-model-zoo`, `cubic`, `microssim`, `transformers`, `dynaclr`):
 
 ```bash
 uv pip install -e "applications/dynacell[eval]"
 ```
+
+## HPC notes
+
+### Shared Hugging Face hub cache
+
+`dynacell evaluate` and `dynacell precompute-gt` default `HF_HUB_CACHE` to a team-shared directory on project storage when they detect a repo checkout, so gated HF models (DINOv3) download once per team. The default path is set in `dynacell/__main__.py` (`_DEFAULT_SHARED_HF_CACHE`); other sites override it via the `DYNACELL_SHARED_HF_CACHE` env var. Pre-set `HF_HUB_CACHE` and the auto-setter backs off.
+
+We use `HF_HUB_CACHE` (not `HF_HOME`) because `HF_HOME` relocates the auth token file too, breaking per-user gated-repo ACLs. `HF_HUB_CACHE` only relocates weights/datasets; tokens stay per-user. First-time setup: one team member with gated-repo access (see [DINOv3 on HF](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m)) runs any eval command to trigger the download; everyone else reuses the shared weights afterward — those reads don't hit HF and don't need a token.

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -77,6 +77,27 @@ compute_microssim: true
 compute_feature_metrics: false
 limit_positions: null  # process first N positions; null means all
 
+# Eval runtime / parallelism. Default is bit-for-bit-current sequential behavior.
+# See applications/dynacell/CLAUDE.md "Eval runtime / parallelism" section.
+runtime:
+  # Outer FOV-level parallelism. 1 = current sequential behavior.
+  # "auto" + executor=process clamps to min(cpu_count//4, n_positions).
+  # "auto" + executor=serial resolves to 1.
+  fov_workers: 1  # int | "auto"
+
+  # BLAS/OMP/torch intra-op threads per worker process.
+  # "auto" → max(1, cpu_count // resolved_fov_workers).
+  threads_per_worker: "auto"  # int | "auto"
+
+  # FOV-loop executor. "serial" runs inline; "process" uses spawn-context
+  # ProcessPoolExecutor. Auto-demoted to "serial" if fov_workers resolves to 1.
+  executor: "serial"  # "serial" | "process"
+
+  # Per-T memory hygiene. Defaults set by C2 measurement (see commit log).
+  # Override at runtime with DYNACELL_FORCE_PER_T_HYGIENE=1 (operator escape hatch).
+  cuda_empty_cache_every_n_timepoints: 0   # 0 = off
+  gc_collect_every_n_fovs: 0               # 0 = off
+
 force_recompute:
   all: false
   gt_masks: false

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval_grouped.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval_grouped.yaml
@@ -1,0 +1,34 @@
+defaults:
+  - eval
+  - _self_
+
+# Per-condition overlays for grouped multi-condition eval. Each entry is a
+# deep merge applied to the base config above. Use this to run e.g. all three
+# A549 treatment conditions (mock / denv / zikv) in one process, amortizing
+# the segmenter + DINOv3 + DynaCLR + CELL-DINO load.
+#
+# Each overlay may freely change ``io.*``, ``save.*``, ``runtime.*``,
+# ``limit_positions``, ``force_recompute.*``, and optionally carry a ``name``
+# label used in logs + the returned result tuple. Overlays MUST NOT touch
+# ``target_name``, ``feature_extractor.*``, ``compute_feature_metrics``, or
+# ``use_gpu`` — those gate model loading, which is shared. See
+# applications/dynacell/CLAUDE.md "Grouped multi-condition eval".
+#
+# Example:
+# conditions:
+#   - name: a549_mock
+#     io:
+#       pred_path: /path/to/mock_pred.zarr
+#       gt_path:   /path/to/mock_gt.zarr
+#       cell_segmentation_path: /path/to/mock_seg.zarr
+#       gt_cache_dir:   /path/to/mock_gt_cache
+#       pred_cache_dir: /path/to/mock_pred_cache
+#     save:
+#       save_dir: /path/to/eval_out/a549_mock
+#   - name: a549_denv
+#     io: { ... }
+#     save: { save_dir: /path/to/eval_out/a549_denv }
+#   - name: a549_zikv
+#     io: { ... }
+#     save: { save_dir: /path/to/eval_out/a549_zikv }
+conditions: []

--- a/applications/dynacell/src/dynacell/evaluation/model_loader.py
+++ b/applications/dynacell/src/dynacell/evaluation/model_loader.py
@@ -1,0 +1,193 @@
+"""Shared model-loading entry point for the dynacell eval pipeline.
+
+A single source of truth for instantiating the segmenter + deep-feature
+extractors used by ``evaluate_predictions`` and the precompute-gt CLI.
+Lifting the load out of the pipeline lets the grouped multi-condition
+driver build models once and reuse them across conditions that differ
+only in I/O paths; the precompute-gt CLI shares the same code path with
+its own per-extractor gates (``build.masks`` / ``build.dinov3`` / ...).
+
+The dataclass carries the **identity tags** (model name, checkpoint sha
+sources) that ``init_cache_context`` needs, so callers don't have to
+recompute them per condition.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from omegaconf import DictConfig
+
+
+@dataclass
+class EvalModels:
+    """Bundle of pre-loaded segmenter + feature extractors with their identity tags.
+
+    Attributes
+    ----------
+    seg_model : Any | None
+        SuperModel returned by ``prepare_segmentation_model``. May be None
+        when ``io.require_complete_cache=true`` short-circuits the load
+        or when ``LoadFlags.masks=False``.
+    dinov3, dynaclr, celldino : Any | None
+        Deep feature extractor instances. Each is None when its
+        ``LoadFlags`` gate is False, or (for celldino) when its
+        ``weights_path`` is unset.
+    dinov3_model_name, dynaclr_ckpt_path, dynaclr_encoder_cfg,
+    celldino_weights_path : str | dict | None
+        Identity tags consumed by ``init_cache_context``. Stay None when
+        the corresponding extractor was not loaded.
+    """
+
+    seg_model: Any | None
+    dinov3: Any | None
+    dynaclr: Any | None
+    celldino: Any | None
+    dinov3_model_name: str | None
+    dynaclr_ckpt_path: str | None
+    dynaclr_encoder_cfg: dict[str, Any] | None
+    celldino_weights_path: str | None
+
+
+@dataclass(frozen=True)
+class LoadFlags:
+    """Per-model gate for :func:`load_eval_models`.
+
+    Lets ``precompute-gt`` (per-extractor flags ``build.masks`` /
+    ``build.dinov3`` / ``build.dynaclr`` / ``build.celldino``) and
+    ``evaluate-predictions`` (all extractors gated together by
+    ``compute_feature_metrics``) share one loader.
+    """
+
+    masks: bool = True
+    dinov3: bool = False
+    dynaclr: bool = False
+    celldino: bool = False
+
+    @classmethod
+    def for_evaluate(cls, config: DictConfig) -> LoadFlags:
+        """Flags matching the ``evaluate_predictions`` call path.
+
+        Masks always on (``prepare_segmentation_model`` handles its own
+        ``require_complete_cache`` short-circuit). Extractors gated as a
+        group by ``config.compute_feature_metrics``; celldino additionally
+        soft-skips inside the loader when its ``weights_path`` is null.
+        """
+        ext_on = bool(config.compute_feature_metrics)
+        return cls(masks=True, dinov3=ext_on, dynaclr=ext_on, celldino=ext_on)
+
+
+def load_eval_models(config: DictConfig, *, flags: LoadFlags | None = None) -> EvalModels:
+    """Instantiate the segmenter + deep feature extractors from ``config``.
+
+    No GPU serialization wrapping — callers (worker setup) wrap with
+    ``gpu_serialization_lock`` as needed. The parent of
+    ``evaluate_predictions`` calls this unwrapped today, so this entry
+    preserves that exact pattern.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Resolved eval config. Reads ``target_name``,
+        ``feature_extractor.{dinov3,dynaclr,celldino}``,
+        and (transitively) ``io.require_complete_cache``.
+    flags : LoadFlags, optional
+        Per-model gates. Defaults to :meth:`LoadFlags.for_evaluate`,
+        which preserves the historical ``evaluate_predictions``
+        behavior. Pass a custom :class:`LoadFlags` to load a subset
+        (e.g. for precompute-gt where ``build.dinov3`` / etc. are
+        toggled independently).
+
+    Returns
+    -------
+    EvalModels
+        All model handles + identity tags. Each slot is None when its
+        flag is off; celldino additionally soft-skips when its
+        ``weights_path`` is null even with the flag on.
+    """
+    from dynacell.evaluation.pipeline_cache import resolve_dynaclr_encoder_cfg
+    from dynacell.evaluation.segmentation import prepare_segmentation_model
+    from dynacell.evaluation.utils import (
+        CellDinoFeatureExtractor,
+        DinoV3FeatureExtractor,
+        DynaCLRFeatureExtractor,
+    )
+
+    if flags is None:
+        flags = LoadFlags.for_evaluate(config)
+
+    seg_model = prepare_segmentation_model(config) if flags.masks else None
+
+    dinov3_model_name: str | None = None
+    dynaclr_ckpt_path: str | None = None
+    dynaclr_encoder_cfg: dict[str, Any] | None = None
+    celldino_weights_path: str | None = None
+    dinov3 = None
+    dynaclr = None
+    celldino = None
+
+    if flags.dinov3:
+        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
+        dinov3 = DinoV3FeatureExtractor(dinov3_model_name)
+    if flags.dynaclr:
+        dynaclr_config = config.feature_extractor.dynaclr
+        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
+        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
+        dynaclr = DynaCLRFeatureExtractor(
+            checkpoint=dynaclr_config.checkpoint,
+            encoder_config=dynaclr_encoder_cfg,
+        )
+    if flags.celldino:
+        celldino_cfg = config.feature_extractor.celldino
+        if celldino_cfg.weights_path is not None:
+            celldino_weights_path = str(celldino_cfg.weights_path)
+            celldino = CellDinoFeatureExtractor(
+                weights_path=celldino_weights_path,
+                img_size=int(celldino_cfg.img_size),
+                patch_size=int(celldino_cfg.patch_size),
+            )
+
+    return EvalModels(
+        seg_model=seg_model,
+        dinov3=dinov3,
+        dynaclr=dynaclr,
+        celldino=celldino,
+        dinov3_model_name=dinov3_model_name,
+        dynaclr_ckpt_path=dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
+        celldino_weights_path=celldino_weights_path,
+    )
+
+
+def _identity_kwargs(models: EvalModels) -> dict[str, Any]:
+    """Identity tags forwarded into ``init_cache_context``."""
+    return {
+        "dinov3_model_name": models.dinov3_model_name,
+        "dynaclr_ckpt_path": models.dynaclr_ckpt_path,
+        "dynaclr_encoder_cfg": models.dynaclr_encoder_cfg,
+        "celldino_weights_path": models.celldino_weights_path,
+    }
+
+
+def init_cache_contexts(config: DictConfig, models: EvalModels) -> tuple[Any, Any]:
+    """Build ``(gt_ctx, pred_ctx)`` cache contexts using ``models``'s identity tags.
+
+    Replaces the four-call-site duplication in ``evaluate_predictions``
+    and ``_worker_setup`` where the same six kwargs flowed into
+    ``init_cache_context(..., side="gt")`` then again into
+    ``init_cache_context(..., side="pred")``.
+    """
+    from dynacell.evaluation.pipeline_cache import init_cache_context
+
+    kwargs = _identity_kwargs(models)
+    gt_ctx = init_cache_context(config, side="gt", **kwargs)
+    pred_ctx = init_cache_context(config, side="pred", **kwargs)
+    return gt_ctx, pred_ctx
+
+
+def init_gt_cache_context(config: DictConfig, models: EvalModels) -> Any:
+    """Build only the GT cache context — used by ``precompute-gt`` which is GT-only."""
+    from dynacell.evaluation.pipeline_cache import init_cache_context
+
+    return init_cache_context(config, side="gt", **_identity_kwargs(models))

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -226,12 +226,16 @@ def _process_one_fov(
     from dynacell.evaluation.runtime import (
         get_timings,
         gpu_serialization_lock,
+        is_worker,
         maybe_empty_cuda_cache,
         region_timer,
     )
     from dynacell.evaluation.segmentation import segment
 
     timings_start = len(get_timings())
+    # Inner per-T tqdm is noise when N workers each emit it to the shared
+    # parent stderr — outer per-FOV tqdm in the parent stays visible either way.
+    suppress_inner_tqdm = is_worker()
 
     pred_channel_index = pos_pred.get_channel_index(io_config.pred_channel_name)
     gt_channel_index = pos_gt.get_channel_index(io_config.gt_channel_name)
@@ -299,7 +303,7 @@ def _process_one_fov(
     dynaclr = _BackboneLists()
     celldino = _BackboneLists()
 
-    for t in tqdm(range(T), desc="Processing timepoints", leave=False):
+    for t in tqdm(range(T), desc="Processing timepoints", leave=False, disable=suppress_inner_tqdm):
         data_info = {"FOV": pos_name_pred, "Timepoint": t}
 
         with region_timer("pixel_metrics", pos_name_pred, t), gpu_serialization_lock():

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -964,11 +964,21 @@ def evaluate_predictions(config: DictConfig):
             else:
                 # executor == "process": spawn-context ProcessPoolExecutor.
                 # Workers lazy-load their own seg_model + extractors under the
-                # GPU lock; parent's copy stays loaded (used only here for
-                # checkpoint pre-warm side effect — discarded after this block).
+                # GPU lock; parent's copy was discarded after Phase-2 resolve.
+                #
+                # Streaming aggregation: futures arrive in completion order
+                # but we want deterministic per-FOV CSV / embedding NPZ row
+                # order, so the next-expected pos_name index advances
+                # opportunistically as results land. Only out-of-order
+                # FovResults stay buffered — once the expected position
+                # completes, we drain the buffer in order. Bounds peak
+                # parent-side memory to the number of out-of-order FOVs
+                # rather than the full N×seg_array (~N × 440 MB).
                 from concurrent.futures import as_completed
 
                 pos_names_in_order = [p[0] for p, _, _ in zip(pred_positions, gt_positions, seg_positions)]
+                next_idx = 0
+                buffer: dict[str, FovResult] = {}
                 with make_fov_executor(runtime) as pool:
                     if pool is None:
                         raise RuntimeError("make_fov_executor returned None for executor='process'")
@@ -978,15 +988,19 @@ def evaluate_predictions(config: DictConfig):
                         ): pos_name
                         for pos_name in pos_names_in_order
                     }
-                    results_by_pos: dict[str, FovResult] = {}
-                    for fut in tqdm(as_completed(futures), total=len(futures), desc="Processing positions"):
-                        pos_name = futures[fut]
-                        results_by_pos[pos_name] = fut.result()
-                # Aggregate in position order (independent of completion order)
-                # so per-FOV CSV / embedding NPZ row order is deterministic.
-                for fov_idx, pos_name in enumerate(pos_names_in_order):
-                    _aggregate(results_by_pos[pos_name])
-                    maybe_gc_collect(fov_idx, runtime.gc_collect_every_n_fovs)
+                    with tqdm(total=len(futures), desc="Processing positions") as pbar:
+                        for fut in as_completed(futures):
+                            pos_name = futures[fut]
+                            buffer[pos_name] = fut.result()
+                            # Drain in order while the next-expected position
+                            # is available, releasing seg_array refs as soon
+                            # as the aggregator's plate write completes.
+                            while next_idx < len(pos_names_in_order) and (pos_names_in_order[next_idx] in buffer):
+                                expected = pos_names_in_order[next_idx]
+                                _aggregate(buffer.pop(expected))
+                                maybe_gc_collect(next_idx, runtime.gc_collect_every_n_fovs)
+                                next_idx += 1
+                                pbar.update(1)
         finally:
             if seg_plate is not None:
                 seg_plate.close()

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -155,8 +155,16 @@ def _save_embeddings(save_dir: Path, groups: dict[str, tuple[list, list, list]])
 
 def evaluate_predictions(config: DictConfig):
     """Evaluate predictions on all test images."""
+    from dynacell.evaluation.runtime import apply_thread_budget, resolve_runtime
     from dynacell.evaluation.segmentation import prepare_segmentation_model, segment
     from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
+
+    # Phase 1 runtime resolution: lock in executor + thread caps before any
+    # heavy work. fov_workers may be provisional when "auto"; re-resolved in
+    # Phase 2 once the position list is known (C4). threads_per_worker stays
+    # frozen across phases for parent/worker BLAS-cap consistency.
+    runtime = resolve_runtime(config)
+    apply_thread_budget(runtime.threads_per_worker)
 
     all_pixel_metrics = []
     all_mask_metrics = []

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -641,6 +641,11 @@ def evaluate_predictions(config: DictConfig):
     # frozen across phases for parent/worker BLAS-cap consistency.
     runtime = resolve_runtime(config)
     apply_thread_budget(runtime.threads_per_worker)
+    # Resolve ${...} interpolations in-place so spawn workers don't lazy-resolve
+    # refs in their child interpreters. ??? MISSING fields stay unresolved
+    # (OmegaConf 2.3 _resolve walks only interpolation nodes, not value nodes),
+    # so this is safe under feature-metrics-disabled runs.
+    OmegaConf.resolve(config)
     reset_timings()
 
     all_pixel_metrics = []

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -35,14 +35,13 @@ from dynacell.evaluation.metrics import (
     evaluate_segmentations,
     features_from_crops,
 )
+from dynacell.evaluation.model_loader import EvalModels, init_cache_contexts, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
     flush_manifest,
     fov_cp_features,
     fov_deep_features,
     fov_masks,
-    init_cache_context,
     precompute_deep_features,
-    resolve_dynaclr_encoder_cfg,
 )
 from dynacell.evaluation.utils import plot_metrics
 
@@ -528,68 +527,21 @@ def _worker_setup(config: DictConfig) -> None:
     """
     if _WORKER_STATE.get("initialized"):
         return
-    from dynacell.evaluation.pipeline_cache import init_cache_context, resolve_dynaclr_encoder_cfg
     from dynacell.evaluation.runtime import gpu_serialization_lock
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import (
-        CellDinoFeatureExtractor,
-        DinoV3FeatureExtractor,
-        DynaCLRFeatureExtractor,
-    )
 
     use_gpu = bool(getattr(config, "use_gpu", True))
     with gpu_serialization_lock(gate=use_gpu):
-        seg_model = prepare_segmentation_model(config)
-        dinov3_feature_extractor = None
-        dynaclr_feature_extractor = None
-        celldino_feature_extractor = None
-        dinov3_model_name = None
-        dynaclr_ckpt_path = None
-        dynaclr_encoder_cfg = None
-        celldino_weights_path = None
-        if config.compute_feature_metrics:
-            dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-            dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-            dynaclr_config = config.feature_extractor.dynaclr
-            dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-            dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-            dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-                checkpoint=dynaclr_config.checkpoint,
-                encoder_config=dynaclr_encoder_cfg,
-            )
-            celldino_cfg = config.feature_extractor.celldino
-            if celldino_cfg.weights_path is not None:
-                celldino_weights_path = str(celldino_cfg.weights_path)
-                celldino_feature_extractor = CellDinoFeatureExtractor(
-                    weights_path=celldino_weights_path,
-                    img_size=int(celldino_cfg.img_size),
-                    patch_size=int(celldino_cfg.patch_size),
-                )
+        models = load_eval_models(config)
 
-    cache_ctx = init_cache_context(
-        config,
-        side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
-    )
-    pred_cache_ctx = init_cache_context(
-        config,
-        side="pred",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
-    )
+    cache_ctx, pred_cache_ctx = init_cache_contexts(config, models)
 
     _WORKER_STATE.update(
         {
             "initialized": True,
-            "seg_model": seg_model,
-            "dinov3": dinov3_feature_extractor,
-            "dynaclr": dynaclr_feature_extractor,
-            "celldino": celldino_feature_extractor,
+            "seg_model": models.seg_model,
+            "dinov3": models.dinov3,
+            "dynaclr": models.dynaclr,
+            "celldino": models.celldino,
             "cache_ctx": cache_ctx,
             "pred_cache_ctx": pred_cache_ctx,
         }
@@ -673,8 +625,22 @@ def _worker_run_fov(config: DictConfig, pos_name: str, cuda_empty_every_n: int) 
     return result
 
 
-def evaluate_predictions(config: DictConfig):
-    """Evaluate predictions on all test images."""
+def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None):
+    """Evaluate predictions on all test images.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Resolved eval config.
+    models : EvalModels | None, optional
+        Pre-loaded segmenter + feature extractors. When provided, the
+        inline ``load_eval_models(config)`` call is skipped — used by the
+        grouped multi-condition driver to amortize model loads across
+        conditions sharing the same target/extractors. Default ``None``
+        preserves the historical single-condition behavior. Note: under
+        ``runtime.executor=process``, workers still load their own model
+        copies; this kwarg saves only the parent-side load.
+    """
     from dynacell.evaluation.runtime import (
         apply_thread_budget,
         dump_timings_csv,
@@ -683,8 +649,6 @@ def evaluate_predictions(config: DictConfig):
         reset_timings,
         resolve_runtime,
     )
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     # Phase 1 runtime resolution: lock in executor + thread caps before any
     # heavy work. fov_workers may be provisional when "auto"; re-resolved in
@@ -709,53 +673,17 @@ def evaluate_predictions(config: DictConfig):
     save_dir = Path(config.save.save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)
 
-    seg_model = prepare_segmentation_model(config)
+    if config.compute_feature_metrics and io_config.cell_segmentation_path is None:
+        raise ValueError("io.cell_segmentation_path is required when compute_feature_metrics=true")
 
-    dinov3_model_name = None
-    dynaclr_ckpt_path = None
-    dynaclr_encoder_cfg = None
-    celldino_weights_path = None
-    dinov3_feature_extractor = None
-    dynaclr_feature_extractor = None
-    celldino_feature_extractor = None
+    if models is None:
+        models = load_eval_models(config)
+    seg_model = models.seg_model
+    dinov3_feature_extractor = models.dinov3
+    dynaclr_feature_extractor = models.dynaclr
+    celldino_feature_extractor = models.celldino
 
-    if config.compute_feature_metrics:
-        if io_config.cell_segmentation_path is None:
-            raise ValueError("io.cell_segmentation_path is required when compute_feature_metrics=true")
-        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-        dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-        dynaclr_config = config.feature_extractor.dynaclr
-        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-        dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-            checkpoint=dynaclr_config.checkpoint,
-            encoder_config=dynaclr_encoder_cfg,
-        )
-        celldino_cfg = config.feature_extractor.celldino
-        if celldino_cfg.weights_path is not None:
-            celldino_weights_path = str(celldino_cfg.weights_path)
-            celldino_feature_extractor = CellDinoFeatureExtractor(
-                weights_path=celldino_weights_path,
-                img_size=int(celldino_cfg.img_size),
-                patch_size=int(celldino_cfg.patch_size),
-            )
-
-    cache_ctx = init_cache_context(
-        config,
-        side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
-    )
-    pred_cache_ctx = init_cache_context(
-        config,
-        side="pred",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
-    )
+    cache_ctx, pred_cache_ctx = init_cache_contexts(config, models)
 
     seg_path = Path(io_config.cell_segmentation_path) if io_config.cell_segmentation_path is not None else None
 
@@ -1156,22 +1084,200 @@ def _final_metrics_cache_valid(config: DictConfig) -> bool:
     return pixel_ok and mask_ok and feature_ok
 
 
+def _load_cached_final_metrics(config: DictConfig) -> tuple[list, list, list]:
+    """Reload the (pixel, mask, feature) NPY caches saved by ``save_metrics``."""
+    save_dir = Path(config.save.save_dir)
+    pixel = np.load(save_dir / config.save.pixel_metrics_filename, allow_pickle=True).tolist()
+    mask = np.load(save_dir / config.save.mask_metrics_filename, allow_pickle=True).tolist()
+    if config.compute_feature_metrics:
+        feature = np.load(save_dir / config.save.feature_metrics_filename, allow_pickle=True).tolist()
+    else:
+        feature = []
+    return pixel, mask, feature
+
+
+_MODEL_LOADING_FIELDS: tuple[str, ...] = (
+    "target_name",
+    "feature_extractor",
+    "compute_feature_metrics",
+    "use_gpu",
+    # require_complete_cache flips ``prepare_segmentation_model`` between
+    # "load real SuperModel" and "return None" — letting a condition
+    # override it would mean the shared seg_model bundle is wrong for that
+    # condition (None when cache-miss expects a real model, or loaded but
+    # never used). Treat as a grouped invariant.
+    "io.require_complete_cache",
+)
+
+
+def _snapshot_field(cfg: DictConfig, cfg_field: str):
+    """Resolve a model-loading field to a comparable plain Python value."""
+    node = OmegaConf.select(cfg, cfg_field, default=None)
+    if OmegaConf.is_config(node):
+        return OmegaConf.to_container(node, resolve=False)
+    return node
+
+
+def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
+    """Return a fresh DictConfig with ``overrides`` deep-merged into ``base``.
+
+    Hydra composition always returns struct-mode configs. ``OmegaConf.merge``
+    propagates struct mode from its first argument, so merging an overlay
+    that carries fields outside the base's schema (notably the per-condition
+    ``name`` label) raises ``ConfigKeyError``, and deleting the
+    ``conditions`` / ``name`` keys raises ``ConfigTypeError`` even when the
+    merge succeeds. The to_container round-trip below escapes struct mode
+    while still producing a config that's independent of ``base``.
+    """
+    base_copy = OmegaConf.create(OmegaConf.to_container(base, resolve=False))
+    merged = OmegaConf.merge(base_copy, OmegaConf.create(overrides))
+    for key in ("conditions", "name"):
+        if key in merged:
+            del merged[key]
+    return merged  # type: ignore[return-value]
+
+
+def _check_grouped_field_invariants(base_snapshot: dict[str, object], merged: DictConfig, condition_name: str) -> None:
+    """Raise if a per-condition merged config disagrees with the baseline on model-loading fields.
+
+    ``base_snapshot`` is computed once per grouped run from the
+    conditions-stripped base, so condition 0 is validated symmetrically
+    with all later conditions (a condition 0 overlay that sneaks in e.g.
+    ``target_name`` would be rejected, not silently adopted as the new
+    "base").
+    """
+    for cfg_field in _MODEL_LOADING_FIELDS:
+        merged_val = _snapshot_field(merged, cfg_field)
+        if base_snapshot[cfg_field] != merged_val:
+            raise ValueError(
+                f"Condition {condition_name!r}: overrides changed model-loading field "
+                f"{cfg_field!r}. Move it to the base config or run this condition separately."
+            )
+
+
+def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
+    """Run ``evaluate_predictions`` over a list of conditions sharing one model load.
+
+    Reads ``config.conditions`` (list of per-condition overrides). For each
+    condition, merges its overrides into a copy of the base config and
+    calls :func:`evaluate_predictions` with the shared ``EvalModels``.
+    Models are loaded lazily on the first condition that misses its
+    ``_final_metrics_cache_valid`` short-circuit, so restarts where every
+    condition is cache-hit pay no cold-start.
+
+    Conditions may freely override ``io.*``, ``save.*``, ``runtime.*``,
+    ``limit_positions``, and ``force_recompute.*``. They must NOT change
+    ``target_name``, ``feature_extractor.*``, ``compute_feature_metrics``,
+    or ``use_gpu`` — those gate which models get loaded.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Eval config with an extra top-level ``conditions: [...]`` list.
+        Each entry is a dict-like overlay applied to the base.
+
+    Returns
+    -------
+    list[tuple[str, tuple]]
+        ``[(condition_name, (pixel_rows, mask_rows, feature_rows)), ...]``
+        in input order. ``condition_name`` is taken from the entry's
+        ``name`` field, falling back to its index as a string.
+
+    Notes
+    -----
+    Under ``runtime.executor=process``, workers still load their own
+    model copies per condition (the pool is rebuilt inside each
+    ``evaluate_predictions`` call). Only the parent-side load is shared.
+    Use ``executor=serial`` to maximize the amortization benefit.
+    """
+    conditions = OmegaConf.select(config, "conditions", default=None)
+    if not conditions:
+        raise ValueError("evaluate_predictions_grouped requires a non-empty top-level 'conditions' list")
+
+    executor = OmegaConf.select(config, "runtime.executor", default="serial")
+    require_complete = bool(OmegaConf.select(config, "io.require_complete_cache", default=False))
+    n_conditions = len(conditions)
+    if executor == "process" and n_conditions > 1:
+        if require_complete:
+            # Cache-only path: workers skip prepare_segmentation_model (returns
+            # None) and don't instantiate extractors. Pool re-spawn is the only
+            # overhead — mild informational note, not a warning.
+            print(
+                "[grouped] note: runtime.executor=process with require_complete_cache=true — "
+                f"workers re-init per condition but no models actually load. "
+                f"{n_conditions} pool spawns total; consider executor=serial to skip "
+                "spawn overhead entirely."
+            )
+        else:
+            # Worst-case: each condition's worker pool independently loads
+            # SuperModel + DINOv3 + DynaCLR + CELL-DINO. Total wasted
+            # cold-start ≈ load_time × N_workers × N_conditions.
+            print(
+                "\n"
+                "[grouped] !!! WARNING: runtime.executor=process + "
+                f"{n_conditions} conditions + require_complete_cache=false !!!\n"
+                "  Each condition's worker pool independently loads SuperModel + "
+                "DINOv3 + DynaCLR + CELL-DINO.\n"
+                "  Expected waste: ~30-90 s × N_workers × "
+                f"{n_conditions} conditions of redundant cold-start.\n"
+                "  Fix: set runtime.executor=serial to share the parent's pre-loaded "
+                "models across conditions.\n"
+                "  Use process mode only when you need per-FOV parallelism within a "
+                "single condition.\n"
+            )
+
+    # Canonical baseline for invariant checks: the input config with the
+    # ``conditions`` list dropped. Snapshot once; conditions are validated
+    # against this, including condition 0. Round-trip through to_container
+    # to escape Hydra's struct-mode flag — ``del`` on a struct DictConfig
+    # raises ``ConfigTypeError``.
+    models_base = OmegaConf.create(OmegaConf.to_container(config, resolve=False))
+    if "conditions" in models_base:
+        del models_base["conditions"]
+    base_snapshot = {field: _snapshot_field(models_base, field) for field in _MODEL_LOADING_FIELDS}
+
+    models: EvalModels | None = None
+
+    def get_models() -> EvalModels:
+        nonlocal models
+        if models is None:
+            print(f"[grouped] loading shared models for {len(conditions)} conditions ...")
+            models = load_eval_models(models_base)
+        return models
+
+    results: list[tuple[str, tuple]] = []
+    for idx, cond in enumerate(conditions):
+        name = (
+            cond.get("name", str(idx)) if isinstance(cond, dict) else OmegaConf.select(cond, "name", default=str(idx))
+        )
+        merged = _merge_condition(config, cond)
+        apply_dataset_ref(merged)
+        _check_grouped_field_invariants(base_snapshot, merged, name)
+        print(f"[grouped] ({idx + 1}/{len(conditions)}) evaluating {name!r} → {merged.save.save_dir}")
+
+        if _final_metrics_cache_valid(merged):
+            print(f"[grouped] ({idx + 1}/{len(conditions)}) {name!r}: reusing cached final metrics")
+            pixel_metrics, mask_metrics, feature_metrics = _load_cached_final_metrics(merged)
+        else:
+            pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(merged, models=get_models())
+            save_metrics(
+                merged,
+                pixel_metrics=pixel_metrics,
+                mask_metrics=mask_metrics,
+                feature_metrics=feature_metrics,
+            )
+        results.append((name, (pixel_metrics, mask_metrics, feature_metrics)))
+
+    return results
+
+
 @hydra.main(version_base="1.2", config_path="_configs", config_name="eval")
 def evaluate_model(config: DictConfig):
     """Evaluate model on test images."""
     apply_dataset_ref(config)
-    save_dir = Path(config.save.save_dir)
-    pixel_metrics_path = save_dir / config.save.pixel_metrics_filename
-    mask_metrics_path = save_dir / config.save.mask_metrics_filename
-    feature_metrics_path = save_dir / config.save.feature_metrics_filename
     if _final_metrics_cache_valid(config):
         print("Found existing metrics.")
-        pixel_metrics = np.load(pixel_metrics_path, allow_pickle=True).tolist()
-        mask_metrics = np.load(mask_metrics_path, allow_pickle=True).tolist()
-        if config.compute_feature_metrics:
-            feature_metrics = np.load(feature_metrics_path, allow_pickle=True).tolist()
-        else:
-            feature_metrics = []
+        pixel_metrics, mask_metrics, feature_metrics = _load_cached_final_metrics(config)
     else:
         pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(config)
         save_metrics(
@@ -1181,6 +1287,12 @@ def evaluate_model(config: DictConfig):
             feature_metrics=feature_metrics,
         )
     return pixel_metrics, mask_metrics, feature_metrics
+
+
+@hydra.main(version_base="1.2", config_path="_configs", config_name="eval_grouped")
+def evaluate_model_grouped(config: DictConfig):
+    """Run grouped multi-condition eval, amortizing model loads across conditions."""
+    return evaluate_predictions_grouped(config)
 
 
 if __name__ == "__main__":

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -501,19 +501,25 @@ def _aggregate_fov_result(
 
 
 # Worker-side state for ``executor=process``. A spawn-context child Python
-# interpreter calls ``_worker_run_fov`` once per submitted FOV; the first call
-# triggers ``_worker_setup`` which lazy-loads seg model + extractors + plate
-# handles under the GPU serialization lock and caches them here. Subsequent
-# FOVs in the same worker reuse the cached state.
+# interpreter calls ``_worker_run_fov`` once per submitted FOV; the first
+# call triggers ``_worker_setup`` which lazy-loads seg model + extractors +
+# cache contexts under the GPU serialization lock and caches them here.
+# Subsequent FOVs in the same worker reuse the cached state.
+#
+# Plate handles are intentionally *not* cached here — they're context-managed
+# per-FOV inside ``_worker_run_fov`` so iohub file descriptors close when the
+# worker is between FOVs, and so the worker has nothing to clean up on
+# ProcessPoolExecutor shutdown.
 _WORKER_STATE: dict[str, Any] = {}
 
 
 def _worker_setup(config: DictConfig) -> None:
-    """First-FOV-per-worker initialization: load models, open plates, init caches.
+    """First-FOV-per-worker initialization: load models + init cache contexts.
 
-    Wraps all GPU touch sites in ``gpu_serialization_lock()`` so N workers
-    don't initialize CUDA contexts + load weights concurrently. Cache contexts
-    and iohub plates are opened outside the lock (no GPU touch).
+    GPU touch sites (model + extractor loads) run under
+    ``gpu_serialization_lock()`` so N workers don't initialize CUDA + load
+    weights concurrently. Cache contexts (no GPU touch) are built outside
+    the lock. Plate handles are opened lazily per-FOV in ``_worker_run_fov``.
     """
     if _WORKER_STATE.get("initialized"):
         return
@@ -571,12 +577,6 @@ def _worker_setup(config: DictConfig) -> None:
         celldino_weights_path=celldino_weights_path,
     )
 
-    pred_plate = open_ome_zarr(Path(config.io.pred_path), mode="r")
-    gt_plate = open_ome_zarr(Path(config.io.gt_path), mode="r")
-    seg_plate = None
-    if config.io.cell_segmentation_path is not None:
-        seg_plate = open_ome_zarr(Path(config.io.cell_segmentation_path), mode="r")
-
     _WORKER_STATE.update(
         {
             "initialized": True,
@@ -586,46 +586,78 @@ def _worker_setup(config: DictConfig) -> None:
             "celldino": celldino_feature_extractor,
             "cache_ctx": cache_ctx,
             "pred_cache_ctx": pred_cache_ctx,
-            "pred_plate": pred_plate,
-            "gt_plate": gt_plate,
-            "seg_plate": seg_plate,
-            "pred_positions": dict(pred_plate.positions()),
-            "gt_positions": dict(gt_plate.positions()),
-            "seg_positions": dict(seg_plate.positions()) if seg_plate is not None else None,
         }
     )
+
+
+def _find_position(plate, pos_name: str):
+    """Return the iohub Position with name ``pos_name`` from ``plate``.
+
+    Scans ``plate.positions()`` since iohub doesn't index by name. Cheap
+    for the ≤ tens of positions per eval.
+    """
+    for name, pos in plate.positions():
+        if name == pos_name:
+            return pos
+    raise KeyError(f"position {pos_name!r} not found in plate")
 
 
 def _worker_run_fov(config: DictConfig, pos_name: str, cuda_empty_every_n: int) -> FovResult:
     """Worker entry point: process one FOV by name and return FovResult.
 
-    Submitted via ``pool.submit`` in ``executor=process`` mode. Returns a
-    pickle-friendly ``FovResult`` (no plate handles or torch modules
-    cross the process boundary).
+    Submitted via ``pool.submit`` in ``executor=process`` mode. Plates
+    are opened with a context manager scoped to this single call — iohub
+    file descriptors close before the worker accepts its next FOV. Models
+    + cache contexts stay cached in ``_WORKER_STATE`` across FOVs.
     """
     from dynacell.evaluation.pipeline_cache import flush_manifest
 
     _worker_setup(config)
     state = _WORKER_STATE
-    pos_pred = state["pred_positions"][pos_name]
-    pos_gt = state["gt_positions"][pos_name]
-    pos_seg = state["seg_positions"][pos_name] if state["seg_positions"] is not None else None
 
-    result = _process_one_fov(
-        config,
-        cuda_empty_every_n,
-        pos_name,
-        pos_pred,
-        pos_gt,
-        pos_seg,
-        config.io,
-        state["cache_ctx"],
-        state["pred_cache_ctx"],
-        state["seg_model"],
-        state["dinov3"],
-        state["dynaclr"],
-        state["celldino"],
-    )
+    seg_path = config.io.cell_segmentation_path
+    with (
+        open_ome_zarr(Path(config.io.pred_path), mode="r") as pred_plate,
+        open_ome_zarr(Path(config.io.gt_path), mode="r") as gt_plate,
+    ):
+        pos_pred = _find_position(pred_plate, pos_name)
+        pos_gt = _find_position(gt_plate, pos_name)
+
+        if seg_path is not None:
+            with open_ome_zarr(Path(seg_path), mode="r") as seg_plate:
+                pos_seg = _find_position(seg_plate, pos_name)
+                result = _process_one_fov(
+                    config,
+                    cuda_empty_every_n,
+                    pos_name,
+                    pos_pred,
+                    pos_gt,
+                    pos_seg,
+                    config.io,
+                    state["cache_ctx"],
+                    state["pred_cache_ctx"],
+                    state["seg_model"],
+                    state["dinov3"],
+                    state["dynaclr"],
+                    state["celldino"],
+                )
+        else:
+            result = _process_one_fov(
+                config,
+                cuda_empty_every_n,
+                pos_name,
+                pos_pred,
+                pos_gt,
+                None,
+                config.io,
+                state["cache_ctx"],
+                state["pred_cache_ctx"],
+                state["seg_model"],
+                state["dinov3"],
+                state["dynaclr"],
+                state["celldino"],
+            )
+
     # Worker-side manifest flush so interrupted runs preserve progress even
     # when the parent dies. The global manifest lock at
     # _pos_write_lock(ctx, "manifest", "global") serializes flushes across

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -43,6 +43,20 @@ from dynacell.evaluation.pipeline_cache import (
     fov_masks,
     precompute_deep_features,
 )
+from dynacell.evaluation.runtime import (
+    apply_thread_budget,
+    dump_timings_csv,
+    extend_timings,
+    get_timings,
+    gpu_serialization_lock,
+    is_worker,
+    make_fov_executor,
+    maybe_empty_cuda_cache,
+    maybe_gc_collect,
+    region_timer,
+    reset_timings,
+    resolve_runtime,
+)
 from dynacell.evaluation.utils import plot_metrics
 
 
@@ -222,13 +236,6 @@ def _process_one_fov(
     ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
     paths in ``evaluate_predictions``.
     """
-    from dynacell.evaluation.runtime import (
-        get_timings,
-        gpu_serialization_lock,
-        is_worker,
-        maybe_empty_cuda_cache,
-        region_timer,
-    )
     from dynacell.evaluation.segmentation import segment
 
     timings_start = len(get_timings())
@@ -465,8 +472,6 @@ def _aggregate_fov_result(
     already there); set ``True`` in process mode (workers have separate
     per-process collectors, so the parent must aggregate).
     """
-    from dynacell.evaluation.runtime import extend_timings, region_timer
-
     if extend_worker_timings:
         extend_timings(result.timings)
 
@@ -527,7 +532,6 @@ def _worker_setup(config: DictConfig) -> None:
     """
     if _WORKER_STATE.get("initialized"):
         return
-    from dynacell.evaluation.runtime import gpu_serialization_lock
 
     use_gpu = bool(getattr(config, "use_gpu", True))
     with gpu_serialization_lock(gate=use_gpu):
@@ -568,8 +572,6 @@ def _worker_run_fov(config: DictConfig, pos_name: str, cuda_empty_every_n: int) 
     file descriptors close before the worker accepts its next FOV. Models
     + cache contexts stay cached in ``_WORKER_STATE`` across FOVs.
     """
-    from dynacell.evaluation.pipeline_cache import flush_manifest
-
     _worker_setup(config)
     state = _WORKER_STATE
 
@@ -641,15 +643,6 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
         ``runtime.executor=process``, workers still load their own model
         copies; this kwarg saves only the parent-side load.
     """
-    from dynacell.evaluation.runtime import (
-        apply_thread_budget,
-        dump_timings_csv,
-        make_fov_executor,
-        maybe_gc_collect,
-        reset_timings,
-        resolve_runtime,
-    )
-
     # Phase 1 runtime resolution: lock in executor + thread caps before any
     # heavy work. fov_workers may be provisional when "auto"; re-resolved in
     # Phase 2 once the position list is known (C4). threads_per_worker stays
@@ -920,15 +913,18 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
                         for fut in as_completed(futures):
                             pos_name = futures[fut]
                             buffer[pos_name] = fut.result()
-                            # Drain in order while the next-expected position
-                            # is available, releasing seg_array refs as soon
-                            # as the aggregator's plate write completes.
+                            # Advance the bar on every worker completion so the
+                            # operator sees real progress even when FOVs arrive
+                            # out of order. The in-order drain below releases
+                            # seg_array refs as soon as the aggregator's plate
+                            # write completes; that's an internal step, not a
+                            # user-visible unit of work.
+                            pbar.update(1)
                             while next_idx < len(pos_names_in_order) and (pos_names_in_order[next_idx] in buffer):
                                 expected = pos_names_in_order[next_idx]
                                 _aggregate(buffer.pop(expected))
                                 maybe_gc_collect(next_idx, runtime.gc_collect_every_n_fovs)
                                 next_idx += 1
-                                pbar.update(1)
         finally:
             if seg_plate is not None:
                 seg_plate.close()
@@ -1118,6 +1114,38 @@ def _snapshot_field(cfg: DictConfig, cfg_field: str):
     return node
 
 
+def _seg_model_required(cfg: DictConfig) -> bool:
+    """Mirror ``prepare_segmentation_model``'s load decision without instantiating.
+
+    Returns ``True`` iff a real ``SuperModel`` would be loaded for *cfg*.
+    Used as a derived grouped-eval invariant so a per-condition override of
+    ``io.pred_cache_dir`` cannot silently flip whether the shared seg_model
+    is needed (per-condition pred caches are otherwise free to differ).
+
+    Mirrors ``segmentation.prepare_segmentation_model``:
+
+    - Organelle targets (``er``, ``mitochondria``, ``nucleoli``,
+      ``lysosomes``) use ``aicssegmentation`` workflows that don't take a
+      ``seg_model`` arg → ``False``.
+    - Nucleus/membrane with ``require_complete_cache=false`` → ``True``
+      (cellpose loads to compute fresh masks on cache miss).
+    - Nucleus/membrane with ``require_complete_cache=true`` AND
+      ``io.pred_cache_dir`` set → ``False`` (pred masks served from cache;
+      per-T loop never falls back to ``segment(predict[t], seg_model=...)``).
+    - Nucleus/membrane with ``require_complete_cache=true`` AND
+      ``io.pred_cache_dir is None`` → ``True`` (per-T loop falls back to
+      ``segment(predict[t], seg_model=...)``; the seg_model is required).
+    """
+    target_name = OmegaConf.select(cfg, "target_name", default=None)
+    if target_name not in ("nucleus", "membrane"):
+        return False
+    require_complete = bool(OmegaConf.select(cfg, "io.require_complete_cache", default=False))
+    if not require_complete:
+        return True
+    pred_cache_dir = OmegaConf.select(cfg, "io.pred_cache_dir", default=None)
+    return pred_cache_dir is None
+
+
 def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
     """Return a fresh DictConfig with ``overrides`` deep-merged into ``base``.
 
@@ -1137,7 +1165,12 @@ def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConf
     return merged  # type: ignore[return-value]
 
 
-def _check_grouped_field_invariants(base_snapshot: dict[str, object], merged: DictConfig, condition_name: str) -> None:
+def _check_grouped_field_invariants(
+    base_snapshot: dict[str, object],
+    base_seg_required: bool,
+    merged: DictConfig,
+    condition_name: str,
+) -> None:
     """Raise if a per-condition merged config disagrees with the baseline on model-loading fields.
 
     ``base_snapshot`` is computed once per grouped run from the
@@ -1145,6 +1178,13 @@ def _check_grouped_field_invariants(base_snapshot: dict[str, object], merged: Di
     with all later conditions (a condition 0 overlay that sneaks in e.g.
     ``target_name`` would be rejected, not silently adopted as the new
     "base").
+
+    ``base_seg_required`` is the baseline value of :func:`_seg_model_required`.
+    ``io.pred_cache_dir`` is intentionally NOT in :data:`_MODEL_LOADING_FIELDS`
+    (per-condition pred caches are the canonical grouped-run use case), but a
+    pred_cache_dir flip *can* indirectly change whether SuperModel is needed
+    for nucleus/membrane targets under ``require_complete_cache=true``. Catch
+    that specific case here so the shared seg_model bundle is never wrong.
     """
     for cfg_field in _MODEL_LOADING_FIELDS:
         merged_val = _snapshot_field(merged, cfg_field)
@@ -1153,6 +1193,18 @@ def _check_grouped_field_invariants(base_snapshot: dict[str, object], merged: Di
                 f"Condition {condition_name!r}: overrides changed model-loading field "
                 f"{cfg_field!r}. Move it to the base config or run this condition separately."
             )
+    if _seg_model_required(merged) and not base_seg_required:
+        raise ValueError(
+            f"Condition {condition_name!r}: io.pred_cache_dir override flips "
+            f"prepare_segmentation_model's load decision in the dangerous direction. "
+            f"The base config does NOT load SuperModel "
+            f"(target_name={base_snapshot['target_name']!r}, "
+            f"require_complete_cache={base_snapshot['io.require_complete_cache']!r}, "
+            f"base io.pred_cache_dir is set), but this condition sets "
+            f"io.pred_cache_dir=None which makes the per-T loop fall back to "
+            f"segment(predict[t], seg_model=...) — that call would receive None "
+            f"and raise. Set io.pred_cache_dir on this condition, or run it separately."
+        )
 
 
 def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
@@ -1199,14 +1251,16 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
     n_conditions = len(conditions)
     if executor == "process" and n_conditions > 1:
         if require_complete:
-            # Cache-only path: workers skip prepare_segmentation_model (returns
-            # None) and don't instantiate extractors. Pool re-spawn is the only
-            # overhead — mild informational note, not a warning.
+            # Cache-only path: workers still re-init per condition (pool spawn +
+            # thread budget + ``load_eval_models`` call). Under
+            # ``require_complete_cache=true`` the segmenter usually short-circuits
+            # to ``None``, but deep extractors still load when
+            # ``compute_feature_metrics=true``. Mild informational note.
             print(
                 "[grouped] note: runtime.executor=process with require_complete_cache=true — "
-                f"workers re-init per condition but no models actually load. "
-                f"{n_conditions} pool spawns total; consider executor=serial to skip "
-                "spawn overhead entirely."
+                f"workers re-init per condition (segmenter usually skipped; deep extractors "
+                f"still load when compute_feature_metrics=true). {n_conditions} pool spawns "
+                f"total; use executor=serial to amortize the per-condition load."
             )
         else:
             # Worst-case: each condition's worker pool independently loads
@@ -1235,6 +1289,7 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
     if "conditions" in models_base:
         del models_base["conditions"]
     base_snapshot = {field: _snapshot_field(models_base, field) for field in _MODEL_LOADING_FIELDS}
+    base_seg_required = _seg_model_required(models_base)
 
     models: EvalModels | None = None
 
@@ -1252,7 +1307,7 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
         )
         merged = _merge_condition(config, cond)
         apply_dataset_ref(merged)
-        _check_grouped_field_invariants(base_snapshot, merged, name)
+        _check_grouped_field_invariants(base_snapshot, base_seg_required, merged, name)
         print(f"[grouped] ({idx + 1}/{len(conditions)}) evaluating {name!r} → {merged.save.save_dir}")
 
         if _final_metrics_cache_valid(merged):

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -2,6 +2,7 @@
 
 import json
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import hydra
@@ -153,18 +154,345 @@ def _save_embeddings(save_dir: Path, groups: dict[str, tuple[list, list, list]])
         print(f"Saved embeddings → {out_path}")
 
 
+@dataclass
+class _BackboneLists:
+    """Per-FOV per-backbone single-cell feature lists.
+
+    Each list holds one entry per timepoint with non-empty cell features.
+    ``pred_*`` and ``gt_*`` indices align: ``pred_feats[i]`` and
+    ``gt_feats[i]`` come from the same (pos_name, t) pair, with
+    ``pred_fovs[i] == gt_fovs[i]`` and ``pred_ts[i] == gt_ts[i]``.
+    """
+
+    pred_feats: list[np.ndarray] = field(default_factory=list)
+    gt_feats: list[np.ndarray] = field(default_factory=list)
+    pred_fovs: list[np.ndarray] = field(default_factory=list)
+    gt_fovs: list[np.ndarray] = field(default_factory=list)
+    pred_ts: list[np.ndarray] = field(default_factory=list)
+    gt_ts: list[np.ndarray] = field(default_factory=list)
+
+
+@dataclass
+class FovResult:
+    """Output of ``_process_one_fov``: everything one FOV contributes to the run.
+
+    Designed for cross-process transport via pickle: all fields are picklable
+    types (str, list[dict], list[np.ndarray], np.ndarray) — no iohub handles,
+    no torch modules.
+
+    Microssim scores are merged into ``per_t_pixel_rows`` before return
+    (matching the existing serial path at ``pipeline.py:478-481``); no
+    separate microssim field.
+    """
+
+    pos_name: str
+    row: str
+    col: str
+    fov: str
+    per_t_pixel_rows: list[dict]
+    per_t_mask_rows: list[dict]
+    per_t_feature_rows: list[dict]
+    seg_array: np.ndarray  # (T, 2, D, H, W) bool: channel 0 = pred, channel 1 = GT
+    cp: _BackboneLists = field(default_factory=_BackboneLists)
+    dinov3: _BackboneLists = field(default_factory=_BackboneLists)
+    dynaclr: _BackboneLists = field(default_factory=_BackboneLists)
+    celldino: _BackboneLists = field(default_factory=_BackboneLists)
+    timings: list[tuple[str, int | None, str, float]] = field(default_factory=list)
+
+
+def _process_one_fov(
+    config: DictConfig,
+    cuda_empty_cache_every_n_timepoints: int,
+    pos_name_pred: str,
+    pos_pred,
+    pos_gt,
+    pos_seg,
+    io_config,
+    cache_ctx,
+    pred_cache_ctx,
+    seg_model,
+    dinov3_feature_extractor,
+    dynaclr_feature_extractor,
+    celldino_feature_extractor,
+) -> FovResult:
+    """Compute everything one FOV contributes to the eval and return a FovResult.
+
+    No side effects on shared parent state (no segmentation_results plate
+    writes, no manifest flush). The parent aggregator handles those — see
+    ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
+    paths in ``evaluate_predictions``.
+    """
+    from dynacell.evaluation.runtime import (
+        get_timings,
+        maybe_empty_cuda_cache,
+        region_timer,
+    )
+    from dynacell.evaluation.segmentation import segment
+
+    timings_start = len(get_timings())
+
+    pred_channel_index = pos_pred.get_channel_index(io_config.pred_channel_name)
+    gt_channel_index = pos_gt.get_channel_index(io_config.gt_channel_name)
+
+    predict = np.asarray(pos_pred.data[:, pred_channel_index])  # shape: (T, D, H, W)
+    target = np.asarray(pos_gt.data[:, gt_channel_index])
+    cell_segmentation = np.asarray(pos_seg.data[:, 0]) if pos_seg is not None else None
+
+    T = predict.shape[0]
+
+    with region_timer("mask_gt", pos_name_pred):
+        gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
+    if pred_cache_ctx.enabled:
+        with region_timer("mask_pred", pos_name_pred):
+            pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
+    else:
+        pred_mask_stack = None
+
+    gt_cp_per_t = None
+    gt_dinov3_per_t = None
+    gt_dynaclr_per_t = None
+    gt_celldino_per_t = None
+    pred_per_t = None
+    if config.compute_feature_metrics:
+        with region_timer("cp_gt", pos_name_pred):
+            gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
+        with region_timer("deep_gt_dinov3", pos_name_pred):
+            gt_dinov3_per_t = fov_deep_features(
+                cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
+            )
+        with region_timer("deep_gt_dynaclr", pos_name_pred):
+            gt_dynaclr_per_t = fov_deep_features(
+                cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
+            )
+        if celldino_feature_extractor is not None:
+            with region_timer("deep_gt_celldino", pos_name_pred):
+                gt_celldino_per_t = fov_deep_features(
+                    cache_ctx,
+                    pos_name_pred,
+                    target,
+                    cell_segmentation,
+                    celldino_feature_extractor,
+                    "celldino",
+                )
+        with region_timer("features_pred_per_t", pos_name_pred):
+            pred_per_t = _fov_pred_features_per_t(
+                pred_cache_ctx,
+                pos_name_pred,
+                predict,
+                cell_segmentation,
+                dinov3_feature_extractor,
+                dynaclr_feature_extractor,
+                celldino_feature_extractor,
+                config.feature_metrics.patch_size,
+                config.pixel_metrics.spacing,
+            )
+
+    microssim_data: list[dict] = []
+    fov_pixel_metrics: list[dict] = []
+    fov_mask_metrics: list[dict] = []
+    fov_feature_metrics: list[dict] = []
+    segmentations: list[np.ndarray] = []
+    cp = _BackboneLists()
+    dinov3 = _BackboneLists()
+    dynaclr = _BackboneLists()
+    celldino = _BackboneLists()
+
+    for t in tqdm(range(T), desc="Processing timepoints", leave=False):
+        data_info = {"FOV": pos_name_pred, "Timepoint": t}
+
+        with region_timer("pixel_metrics", pos_name_pred, t):
+            pixel_metrics = compute_pixel_metrics(
+                predict[t],
+                target[t],
+                spacing=config.pixel_metrics.spacing,
+                fsc_kwargs=config.pixel_metrics.fsc,
+                spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
+                use_gpu=config.use_gpu,
+            )
+        if config.compute_microssim:
+            microssim_data.append({"target": target[t], "predict": predict[t]})
+        fov_pixel_metrics.append({**data_info, **pixel_metrics})
+
+        with region_timer("mask_metrics", pos_name_pred, t):
+            segmented_target = gt_mask_stack[t]
+            segmented_predict = (
+                pred_mask_stack[t]
+                if pred_mask_stack is not None
+                else np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(bool)
+            )
+            fov_mask_metrics.append({**data_info, **evaluate_segmentations(segmented_predict, segmented_target)})
+            segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
+
+        if config.compute_feature_metrics:
+            with region_timer("feature_pairwise", pos_name_pred, t):
+                pred_cp = pred_per_t["cp"][t]
+                pred_dinov3 = pred_per_t["dinov3"][t]
+                pred_dynaclr = pred_per_t["dynaclr"][t]
+                pred_celldino = pred_per_t["celldino"][t] if pred_per_t["celldino"] is not None else None
+                pred_cp, gt_cp_t = drop_paired_nonfinite_rows(pred_cp, gt_cp_per_t[t])
+                if pred_cp.size and gt_cp_t.size:
+                    pred_cp_z, gt_cp_z = _cp_dropzero_zscore(pred_cp, gt_cp_t)
+                else:
+                    pred_cp_z, gt_cp_z = pred_cp, gt_cp_t
+                pairwise_metrics = {
+                    **compute_feature_similarity_pairwise(pred_cp_z, gt_cp_z, "CP"),
+                    **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
+                    **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
+                }
+                if pred_celldino is not None:
+                    pairwise_metrics.update(
+                        compute_feature_similarity_pairwise(pred_celldino, gt_celldino_per_t[t], "CellDINO")
+                    )
+                fov_feature_metrics.append({**data_info, **pairwise_metrics})
+                if pred_cp.size > 0:
+                    cp.pred_feats.append(pred_cp)
+                    cp.gt_feats.append(gt_cp_t)
+                    fov_arr = np.full(len(pred_cp), pos_name_pred)
+                    t_arr = np.full(len(pred_cp), t, dtype=np.int32)
+                    cp.pred_fovs.append(fov_arr)
+                    cp.gt_fovs.append(fov_arr)
+                    cp.pred_ts.append(t_arr)
+                    cp.gt_ts.append(t_arr)
+                if pred_dinov3.size > 0:
+                    dinov3.pred_feats.append(pred_dinov3)
+                    dinov3.gt_feats.append(gt_dinov3_per_t[t])
+                    fov_arr = np.full(len(pred_dinov3), pos_name_pred)
+                    t_arr = np.full(len(pred_dinov3), t, dtype=np.int32)
+                    dinov3.pred_fovs.append(fov_arr)
+                    dinov3.gt_fovs.append(fov_arr)
+                    dinov3.pred_ts.append(t_arr)
+                    dinov3.gt_ts.append(t_arr)
+                if pred_dynaclr.size > 0:
+                    dynaclr.pred_feats.append(pred_dynaclr)
+                    dynaclr.gt_feats.append(gt_dynaclr_per_t[t])
+                    fov_arr = np.full(len(pred_dynaclr), pos_name_pred)
+                    t_arr = np.full(len(pred_dynaclr), t, dtype=np.int32)
+                    dynaclr.pred_fovs.append(fov_arr)
+                    dynaclr.gt_fovs.append(fov_arr)
+                    dynaclr.pred_ts.append(t_arr)
+                    dynaclr.gt_ts.append(t_arr)
+                if pred_celldino is not None and pred_celldino.size > 0:
+                    celldino.pred_feats.append(pred_celldino)
+                    celldino.gt_feats.append(gt_celldino_per_t[t])
+                    fov_arr = np.full(len(pred_celldino), pos_name_pred)
+                    t_arr = np.full(len(pred_celldino), t, dtype=np.int32)
+                    celldino.pred_fovs.append(fov_arr)
+                    celldino.gt_fovs.append(fov_arr)
+                    celldino.pred_ts.append(t_arr)
+                    celldino.gt_ts.append(t_arr)
+
+        maybe_empty_cuda_cache(t, cuda_empty_cache_every_n_timepoints)
+
+    seg_array = np.stack(segmentations, axis=0)  # shape: (T, 2, D, H, W)
+
+    if config.compute_microssim:
+        with region_timer("microssim", pos_name_pred):
+            microssim_scores = calculate_microssim(microssim_data)
+            for i in range(T):
+                fov_pixel_metrics[i]["MicroMS3IM"] = float(microssim_scores[i]["MicroMS3IM"])
+
+    row, col, fov = pos_name_pred.split("/")
+    return FovResult(
+        pos_name=pos_name_pred,
+        row=row,
+        col=col,
+        fov=fov,
+        per_t_pixel_rows=fov_pixel_metrics,
+        per_t_mask_rows=fov_mask_metrics,
+        per_t_feature_rows=fov_feature_metrics,
+        seg_array=seg_array.astype(bool),
+        cp=cp,
+        dinov3=dinov3,
+        dynaclr=dynaclr,
+        celldino=celldino,
+        timings=get_timings()[timings_start:],
+    )
+
+
+def _aggregate_fov_result(
+    result: FovResult,
+    segmentation_results,
+    all_pixel_metrics: list[dict],
+    all_mask_metrics: list[dict],
+    all_feature_metrics: list[dict],
+    pred_cp_feats: list[np.ndarray],
+    pred_cp_fovs: list[np.ndarray],
+    pred_cp_ts: list[np.ndarray],
+    gt_cp_feats: list[np.ndarray],
+    gt_cp_fovs: list[np.ndarray],
+    gt_cp_ts: list[np.ndarray],
+    pred_dinov3_feats: list[np.ndarray],
+    pred_dinov3_fovs: list[np.ndarray],
+    pred_dinov3_ts: list[np.ndarray],
+    gt_dinov3_feats: list[np.ndarray],
+    gt_dinov3_fovs: list[np.ndarray],
+    gt_dinov3_ts: list[np.ndarray],
+    pred_dynaclr_feats: list[np.ndarray],
+    pred_dynaclr_fovs: list[np.ndarray],
+    pred_dynaclr_ts: list[np.ndarray],
+    gt_dynaclr_feats: list[np.ndarray],
+    gt_dynaclr_fovs: list[np.ndarray],
+    gt_dynaclr_ts: list[np.ndarray],
+    pred_celldino_feats: list[np.ndarray],
+    pred_celldino_fovs: list[np.ndarray],
+    pred_celldino_ts: list[np.ndarray],
+    gt_celldino_feats: list[np.ndarray],
+    gt_celldino_fovs: list[np.ndarray],
+    gt_celldino_ts: list[np.ndarray],
+) -> None:
+    """Apply one FOV's contributions to the parent-side run state.
+
+    Writes the segmentation array to the HCS plate, extends the per-T row
+    lists, and extends the 24 dataset-level accumulator lists.
+    """
+    from dynacell.evaluation.runtime import extend_timings, region_timer
+
+    extend_timings(result.timings)
+
+    with region_timer("seg_write", result.pos_name):
+        seg_pos = segmentation_results.create_position(result.row, result.col, result.fov)
+        seg_pos.create_image("0", result.seg_array)
+
+    all_pixel_metrics.extend(result.per_t_pixel_rows)
+    all_mask_metrics.extend(result.per_t_mask_rows)
+    all_feature_metrics.extend(result.per_t_feature_rows)
+
+    pred_cp_feats.extend(result.cp.pred_feats)
+    pred_cp_fovs.extend(result.cp.pred_fovs)
+    pred_cp_ts.extend(result.cp.pred_ts)
+    gt_cp_feats.extend(result.cp.gt_feats)
+    gt_cp_fovs.extend(result.cp.gt_fovs)
+    gt_cp_ts.extend(result.cp.gt_ts)
+    pred_dinov3_feats.extend(result.dinov3.pred_feats)
+    pred_dinov3_fovs.extend(result.dinov3.pred_fovs)
+    pred_dinov3_ts.extend(result.dinov3.pred_ts)
+    gt_dinov3_feats.extend(result.dinov3.gt_feats)
+    gt_dinov3_fovs.extend(result.dinov3.gt_fovs)
+    gt_dinov3_ts.extend(result.dinov3.gt_ts)
+    pred_dynaclr_feats.extend(result.dynaclr.pred_feats)
+    pred_dynaclr_fovs.extend(result.dynaclr.pred_fovs)
+    pred_dynaclr_ts.extend(result.dynaclr.pred_ts)
+    gt_dynaclr_feats.extend(result.dynaclr.gt_feats)
+    gt_dynaclr_fovs.extend(result.dynaclr.gt_fovs)
+    gt_dynaclr_ts.extend(result.dynaclr.gt_ts)
+    pred_celldino_feats.extend(result.celldino.pred_feats)
+    pred_celldino_fovs.extend(result.celldino.pred_fovs)
+    pred_celldino_ts.extend(result.celldino.pred_ts)
+    gt_celldino_feats.extend(result.celldino.gt_feats)
+    gt_celldino_fovs.extend(result.celldino.gt_fovs)
+    gt_celldino_ts.extend(result.celldino.gt_ts)
+
+
 def evaluate_predictions(config: DictConfig):
     """Evaluate predictions on all test images."""
     from dynacell.evaluation.runtime import (
         apply_thread_budget,
         dump_timings_csv,
-        maybe_empty_cuda_cache,
         maybe_gc_collect,
-        region_timer,
         reset_timings,
         resolve_runtime,
     )
-    from dynacell.evaluation.segmentation import prepare_segmentation_model, segment
+    from dynacell.evaluation.segmentation import prepare_segmentation_model
     from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     # Phase 1 runtime resolution: lock in executor + thread caps before any
@@ -348,169 +676,52 @@ def evaluate_predictions(config: DictConfig):
                 _, pos_gt = p2
                 _, pos_seg = p3
 
-                pred_channel_index = pos_pred.get_channel_index(io_config.pred_channel_name)
-                gt_channel_index = pos_gt.get_channel_index(io_config.gt_channel_name)
-
-                predict = np.asarray(pos_pred.data[:, pred_channel_index])  # shape: (T, D, H, W)
-                target = np.asarray(pos_gt.data[:, gt_channel_index])  # shape: (T, D, H, W)
-                cell_segmentation = np.asarray(pos_seg.data[:, 0]) if pos_seg is not None else None
-
-                T = predict.shape[0]
-
-                with region_timer("mask_gt", pos_name_pred):
-                    gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
-                if pred_cache_ctx.enabled:
-                    with region_timer("mask_pred", pos_name_pred):
-                        pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
-                else:
-                    pred_mask_stack = None
-
-                if config.compute_feature_metrics:
-                    with region_timer("cp_gt", pos_name_pred):
-                        gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
-                    with region_timer("deep_gt_dinov3", pos_name_pred):
-                        gt_dinov3_per_t = fov_deep_features(
-                            cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
-                        )
-                    with region_timer("deep_gt_dynaclr", pos_name_pred):
-                        gt_dynaclr_per_t = fov_deep_features(
-                            cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
-                        )
-                    if celldino_feature_extractor is not None:
-                        with region_timer("deep_gt_celldino", pos_name_pred):
-                            gt_celldino_per_t = fov_deep_features(
-                                cache_ctx,
-                                pos_name_pred,
-                                target,
-                                cell_segmentation,
-                                celldino_feature_extractor,
-                                "celldino",
-                            )
-                    else:
-                        gt_celldino_per_t = None
-                    with region_timer("features_pred_per_t", pos_name_pred):
-                        pred_per_t = _fov_pred_features_per_t(
-                            pred_cache_ctx,
-                            pos_name_pred,
-                            predict,
-                            cell_segmentation,
-                            dinov3_feature_extractor,
-                            dynaclr_feature_extractor,
-                            celldino_feature_extractor,
-                            config.feature_metrics.patch_size,
-                            config.pixel_metrics.spacing,
-                        )
-
-                microssim_data = []
-                fov_pixel_metrics = []
-                segmentations = []
-
-                for t in tqdm(range(T), desc="Processing timepoints"):
-                    data_info = {"FOV": pos_name_pred, "Timepoint": t}
-
-                    with region_timer("pixel_metrics", pos_name_pred, t):
-                        pixel_metrics = compute_pixel_metrics(
-                            predict[t],
-                            target[t],
-                            spacing=config.pixel_metrics.spacing,
-                            fsc_kwargs=config.pixel_metrics.fsc,
-                            spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
-                            use_gpu=config.use_gpu,
-                        )
-                    if config.compute_microssim:
-                        microssim_data.append({"target": target[t], "predict": predict[t]})
-                    fov_pixel_metrics.append({**data_info, **pixel_metrics})
-
-                    with region_timer("mask_metrics", pos_name_pred, t):
-                        segmented_target = gt_mask_stack[t]
-                        segmented_predict = (
-                            pred_mask_stack[t]
-                            if pred_mask_stack is not None
-                            else np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(bool)
-                        )
-                        all_mask_metrics.append(
-                            {**data_info, **evaluate_segmentations(segmented_predict, segmented_target)}
-                        )
-                        segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
-
-                    if config.compute_feature_metrics:
-                        with region_timer("feature_pairwise", pos_name_pred, t):
-                            pred_cp = pred_per_t["cp"][t]
-                            pred_dinov3 = pred_per_t["dinov3"][t]
-                            pred_dynaclr = pred_per_t["dynaclr"][t]
-                            pred_celldino = pred_per_t["celldino"][t] if pred_per_t["celldino"] is not None else None
-                            pred_cp, gt_cp_t = drop_paired_nonfinite_rows(pred_cp, gt_cp_per_t[t])
-                            # Per-timepoint CP: drop target-zero columns + per-side z-score.
-                            # Deep features stay untouched.
-                            if pred_cp.size and gt_cp_t.size:
-                                pred_cp_z, gt_cp_z = _cp_dropzero_zscore(pred_cp, gt_cp_t)
-                            else:
-                                pred_cp_z, gt_cp_z = pred_cp, gt_cp_t
-                            pairwise_metrics = {
-                                **compute_feature_similarity_pairwise(pred_cp_z, gt_cp_z, "CP"),
-                                **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
-                                **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
-                            }
-                            if pred_celldino is not None:
-                                pairwise_metrics.update(
-                                    compute_feature_similarity_pairwise(pred_celldino, gt_celldino_per_t[t], "CellDINO")
-                                )
-                            all_feature_metrics.append({**data_info, **pairwise_metrics})
-                        # pred/gt fov+timepoint arrays are byte-identical per
-                        # backbone; share one reference each (consumers only
-                        # concatenate, never mutate in place).
-                        if pred_cp.size > 0:
-                            pred_cp_feats.append(pred_cp)
-                            gt_cp_feats.append(gt_cp_t)
-                            fov_arr = np.full(len(pred_cp), pos_name_pred)
-                            t_arr = np.full(len(pred_cp), t, dtype=np.int32)
-                            pred_cp_fovs.append(fov_arr)
-                            gt_cp_fovs.append(fov_arr)
-                            pred_cp_ts.append(t_arr)
-                            gt_cp_ts.append(t_arr)
-                        if pred_dinov3.size > 0:
-                            pred_dinov3_feats.append(pred_dinov3)
-                            gt_dinov3_feats.append(gt_dinov3_per_t[t])
-                            fov_arr = np.full(len(pred_dinov3), pos_name_pred)
-                            t_arr = np.full(len(pred_dinov3), t, dtype=np.int32)
-                            pred_dinov3_fovs.append(fov_arr)
-                            gt_dinov3_fovs.append(fov_arr)
-                            pred_dinov3_ts.append(t_arr)
-                            gt_dinov3_ts.append(t_arr)
-                        if pred_dynaclr.size > 0:
-                            pred_dynaclr_feats.append(pred_dynaclr)
-                            gt_dynaclr_feats.append(gt_dynaclr_per_t[t])
-                            fov_arr = np.full(len(pred_dynaclr), pos_name_pred)
-                            t_arr = np.full(len(pred_dynaclr), t, dtype=np.int32)
-                            pred_dynaclr_fovs.append(fov_arr)
-                            gt_dynaclr_fovs.append(fov_arr)
-                            pred_dynaclr_ts.append(t_arr)
-                            gt_dynaclr_ts.append(t_arr)
-                        if pred_celldino is not None and pred_celldino.size > 0:
-                            pred_celldino_feats.append(pred_celldino)
-                            gt_celldino_feats.append(gt_celldino_per_t[t])
-                            fov_arr = np.full(len(pred_celldino), pos_name_pred)
-                            t_arr = np.full(len(pred_celldino), t, dtype=np.int32)
-                            pred_celldino_fovs.append(fov_arr)
-                            gt_celldino_fovs.append(fov_arr)
-                            pred_celldino_ts.append(t_arr)
-                            gt_celldino_ts.append(t_arr)
-
-                    maybe_empty_cuda_cache(t, runtime.cuda_empty_cache_every_n_timepoints)
-
-                with region_timer("seg_write", pos_name_pred):
-                    seg = np.stack(segmentations, axis=0)  # shape: (T, 2, D, H, W)
-                    row, col, fov = pos_name_pred.split("/")
-                    seg_pos = segmentation_results.create_position(row, col, fov)
-                    seg_pos.create_image("0", seg.astype(bool))
-
-                if config.compute_microssim:
-                    with region_timer("microssim", pos_name_pred):
-                        microssim_scores = calculate_microssim(microssim_data)
-                        for i in range(T):
-                            fov_pixel_metrics[i]["MicroMS3IM"] = float(microssim_scores[i]["MicroMS3IM"])
-
-                all_pixel_metrics.extend(fov_pixel_metrics)
+                result = _process_one_fov(
+                    config,
+                    runtime.cuda_empty_cache_every_n_timepoints,
+                    pos_name_pred,
+                    pos_pred,
+                    pos_gt,
+                    pos_seg,
+                    io_config,
+                    cache_ctx,
+                    pred_cache_ctx,
+                    seg_model,
+                    dinov3_feature_extractor,
+                    dynaclr_feature_extractor,
+                    celldino_feature_extractor,
+                )
+                _aggregate_fov_result(
+                    result,
+                    segmentation_results,
+                    all_pixel_metrics,
+                    all_mask_metrics,
+                    all_feature_metrics,
+                    pred_cp_feats,
+                    pred_cp_fovs,
+                    pred_cp_ts,
+                    gt_cp_feats,
+                    gt_cp_fovs,
+                    gt_cp_ts,
+                    pred_dinov3_feats,
+                    pred_dinov3_fovs,
+                    pred_dinov3_ts,
+                    gt_dinov3_feats,
+                    gt_dinov3_fovs,
+                    gt_dinov3_ts,
+                    pred_dynaclr_feats,
+                    pred_dynaclr_fovs,
+                    pred_dynaclr_ts,
+                    gt_dynaclr_feats,
+                    gt_dynaclr_fovs,
+                    gt_dynaclr_ts,
+                    pred_celldino_feats,
+                    pred_celldino_fovs,
+                    pred_celldino_ts,
+                    gt_celldino_feats,
+                    gt_celldino_fovs,
+                    gt_celldino_ts,
+                )
 
                 # Flush manifest after each position so interrupted runs preserve progress.
                 flush_manifest(cache_ctx)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -236,6 +236,11 @@ def _process_one_fov(
     # Inner per-T tqdm is noise when N workers each emit it to the shared
     # parent stderr — outer per-FOV tqdm in the parent stays visible either way.
     suppress_inner_tqdm = is_worker()
+    # GPU serialization lock is a no-op when use_gpu=false: under that
+    # setting compute_pixel_metrics, cellpose, and feature extractors all
+    # run CPU-only, so cross-worker fcntl serialization would just add
+    # latency for nothing.
+    use_gpu = bool(getattr(config, "use_gpu", True))
 
     pred_channel_index = pos_pred.get_channel_index(io_config.pred_channel_name)
     gt_channel_index = pos_gt.get_channel_index(io_config.gt_channel_name)
@@ -246,10 +251,10 @@ def _process_one_fov(
 
     T = predict.shape[0]
 
-    with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock():
+    with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
         gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
     if pred_cache_ctx.enabled:
-        with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock():
+        with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
     else:
         pred_mask_stack = None
@@ -260,18 +265,18 @@ def _process_one_fov(
     gt_celldino_per_t = None
     pred_per_t = None
     if config.compute_feature_metrics:
-        with region_timer("cp_gt", pos_name_pred), gpu_serialization_lock():
+        with region_timer("cp_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
-        with region_timer("deep_gt_dinov3", pos_name_pred), gpu_serialization_lock():
+        with region_timer("deep_gt_dinov3", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             gt_dinov3_per_t = fov_deep_features(
                 cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
             )
-        with region_timer("deep_gt_dynaclr", pos_name_pred), gpu_serialization_lock():
+        with region_timer("deep_gt_dynaclr", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             gt_dynaclr_per_t = fov_deep_features(
                 cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
             )
         if celldino_feature_extractor is not None:
-            with region_timer("deep_gt_celldino", pos_name_pred), gpu_serialization_lock():
+            with region_timer("deep_gt_celldino", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
                 gt_celldino_per_t = fov_deep_features(
                     cache_ctx,
                     pos_name_pred,
@@ -280,7 +285,7 @@ def _process_one_fov(
                     celldino_feature_extractor,
                     "celldino",
                 )
-        with region_timer("features_pred_per_t", pos_name_pred), gpu_serialization_lock():
+        with region_timer("features_pred_per_t", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             pred_per_t = _fov_pred_features_per_t(
                 pred_cache_ctx,
                 pos_name_pred,
@@ -306,7 +311,7 @@ def _process_one_fov(
     for t in tqdm(range(T), desc="Processing timepoints", leave=False, disable=suppress_inner_tqdm):
         data_info = {"FOV": pos_name_pred, "Timepoint": t}
 
-        with region_timer("pixel_metrics", pos_name_pred, t), gpu_serialization_lock():
+        with region_timer("pixel_metrics", pos_name_pred, t), gpu_serialization_lock(gate=use_gpu):
             pixel_metrics = compute_pixel_metrics(
                 predict[t],
                 target[t],
@@ -324,7 +329,7 @@ def _process_one_fov(
             if pred_mask_stack is not None:
                 segmented_predict = pred_mask_stack[t]
             else:
-                with gpu_serialization_lock():
+                with gpu_serialization_lock(gate=use_gpu):
                     segmented_predict = np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(
                         bool
                     )
@@ -517,7 +522,7 @@ def _worker_setup(config: DictConfig) -> None:
     """First-FOV-per-worker initialization: load models + init cache contexts.
 
     GPU touch sites (model + extractor loads) run under
-    ``gpu_serialization_lock()`` so N workers don't initialize CUDA + load
+    ``gpu_serialization_lock(gate=use_gpu)`` so under ``use_gpu=true`` N workers don't initialize CUDA + load
     weights concurrently. Cache contexts (no GPU touch) are built outside
     the lock. Plate handles are opened lazily per-FOV in ``_worker_run_fov``.
     """
@@ -532,7 +537,8 @@ def _worker_setup(config: DictConfig) -> None:
         DynaCLRFeatureExtractor,
     )
 
-    with gpu_serialization_lock():
+    use_gpu = bool(getattr(config, "use_gpu", True))
+    with gpu_serialization_lock(gate=use_gpu):
         seg_model = prepare_segmentation_model(config)
         dinov3_feature_extractor = None
         dynaclr_feature_extractor = None

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -814,6 +814,22 @@ def evaluate_predictions(config: DictConfig):
                 freeze_threads_per_worker=runtime.threads_per_worker,
             )
 
+            # Under executor=process, workers lazy-load their own seg_model
+            # copies (under the GPU lock). The parent's copy is held only for
+            # the checkpoint-cache-warm side effect (segmenter_model_zoo's
+            # validate_model has no file lock around its quilt download, so
+            # pre-warming in the parent prevents N workers from racing on a
+            # cold cache). After Phase 2 we know the final executor — if it's
+            # process, drop the parent copy so we don't keep two seg model
+            # copies resident on the GPU.
+            if runtime.executor == "process" and seg_model is not None:
+                del seg_model
+                seg_model = None
+                import torch
+
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
             def _aggregate(result: FovResult) -> None:
                 _aggregate_fov_result(
                     result,

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -4,6 +4,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import hydra
 import numpy as np
@@ -224,6 +225,7 @@ def _process_one_fov(
     """
     from dynacell.evaluation.runtime import (
         get_timings,
+        gpu_serialization_lock,
         maybe_empty_cuda_cache,
         region_timer,
     )
@@ -240,10 +242,10 @@ def _process_one_fov(
 
     T = predict.shape[0]
 
-    with region_timer("mask_gt", pos_name_pred):
+    with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock():
         gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
     if pred_cache_ctx.enabled:
-        with region_timer("mask_pred", pos_name_pred):
+        with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock():
             pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
     else:
         pred_mask_stack = None
@@ -254,18 +256,18 @@ def _process_one_fov(
     gt_celldino_per_t = None
     pred_per_t = None
     if config.compute_feature_metrics:
-        with region_timer("cp_gt", pos_name_pred):
+        with region_timer("cp_gt", pos_name_pred), gpu_serialization_lock():
             gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
-        with region_timer("deep_gt_dinov3", pos_name_pred):
+        with region_timer("deep_gt_dinov3", pos_name_pred), gpu_serialization_lock():
             gt_dinov3_per_t = fov_deep_features(
                 cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
             )
-        with region_timer("deep_gt_dynaclr", pos_name_pred):
+        with region_timer("deep_gt_dynaclr", pos_name_pred), gpu_serialization_lock():
             gt_dynaclr_per_t = fov_deep_features(
                 cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
             )
         if celldino_feature_extractor is not None:
-            with region_timer("deep_gt_celldino", pos_name_pred):
+            with region_timer("deep_gt_celldino", pos_name_pred), gpu_serialization_lock():
                 gt_celldino_per_t = fov_deep_features(
                     cache_ctx,
                     pos_name_pred,
@@ -274,7 +276,7 @@ def _process_one_fov(
                     celldino_feature_extractor,
                     "celldino",
                 )
-        with region_timer("features_pred_per_t", pos_name_pred):
+        with region_timer("features_pred_per_t", pos_name_pred), gpu_serialization_lock():
             pred_per_t = _fov_pred_features_per_t(
                 pred_cache_ctx,
                 pos_name_pred,
@@ -300,7 +302,7 @@ def _process_one_fov(
     for t in tqdm(range(T), desc="Processing timepoints", leave=False):
         data_info = {"FOV": pos_name_pred, "Timepoint": t}
 
-        with region_timer("pixel_metrics", pos_name_pred, t):
+        with region_timer("pixel_metrics", pos_name_pred, t), gpu_serialization_lock():
             pixel_metrics = compute_pixel_metrics(
                 predict[t],
                 target[t],
@@ -315,11 +317,13 @@ def _process_one_fov(
 
         with region_timer("mask_metrics", pos_name_pred, t):
             segmented_target = gt_mask_stack[t]
-            segmented_predict = (
-                pred_mask_stack[t]
-                if pred_mask_stack is not None
-                else np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(bool)
-            )
+            if pred_mask_stack is not None:
+                segmented_predict = pred_mask_stack[t]
+            else:
+                with gpu_serialization_lock():
+                    segmented_predict = np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(
+                        bool
+                    )
             fov_mask_metrics.append({**data_info, **evaluate_segmentations(segmented_predict, segmented_target)})
             segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
 
@@ -483,11 +487,147 @@ def _aggregate_fov_result(
     gt_celldino_ts.extend(result.celldino.gt_ts)
 
 
+# Worker-side state for ``executor=process``. A spawn-context child Python
+# interpreter calls ``_worker_run_fov`` once per submitted FOV; the first call
+# triggers ``_worker_setup`` which lazy-loads seg model + extractors + plate
+# handles under the GPU serialization lock and caches them here. Subsequent
+# FOVs in the same worker reuse the cached state.
+_WORKER_STATE: dict[str, Any] = {}
+
+
+def _worker_setup(config: DictConfig) -> None:
+    """First-FOV-per-worker initialization: load models, open plates, init caches.
+
+    Wraps all GPU touch sites in ``gpu_serialization_lock()`` so N workers
+    don't initialize CUDA contexts + load weights concurrently. Cache contexts
+    and iohub plates are opened outside the lock (no GPU touch).
+    """
+    if _WORKER_STATE.get("initialized"):
+        return
+    from dynacell.evaluation.pipeline_cache import init_cache_context, resolve_dynaclr_encoder_cfg
+    from dynacell.evaluation.runtime import gpu_serialization_lock
+    from dynacell.evaluation.segmentation import prepare_segmentation_model
+    from dynacell.evaluation.utils import (
+        CellDinoFeatureExtractor,
+        DinoV3FeatureExtractor,
+        DynaCLRFeatureExtractor,
+    )
+
+    with gpu_serialization_lock():
+        seg_model = prepare_segmentation_model(config)
+        dinov3_feature_extractor = None
+        dynaclr_feature_extractor = None
+        celldino_feature_extractor = None
+        dinov3_model_name = None
+        dynaclr_ckpt_path = None
+        dynaclr_encoder_cfg = None
+        celldino_weights_path = None
+        if config.compute_feature_metrics:
+            dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
+            dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
+            dynaclr_config = config.feature_extractor.dynaclr
+            dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
+            dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
+            dynaclr_feature_extractor = DynaCLRFeatureExtractor(
+                checkpoint=dynaclr_config.checkpoint,
+                encoder_config=dynaclr_encoder_cfg,
+            )
+            celldino_cfg = config.feature_extractor.celldino
+            if celldino_cfg.weights_path is not None:
+                celldino_weights_path = str(celldino_cfg.weights_path)
+                celldino_feature_extractor = CellDinoFeatureExtractor(
+                    weights_path=celldino_weights_path,
+                    img_size=int(celldino_cfg.img_size),
+                    patch_size=int(celldino_cfg.patch_size),
+                )
+
+    cache_ctx = init_cache_context(
+        config,
+        side="gt",
+        dinov3_model_name=dinov3_model_name,
+        dynaclr_ckpt_path=dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
+        celldino_weights_path=celldino_weights_path,
+    )
+    pred_cache_ctx = init_cache_context(
+        config,
+        side="pred",
+        dinov3_model_name=dinov3_model_name,
+        dynaclr_ckpt_path=dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
+        celldino_weights_path=celldino_weights_path,
+    )
+
+    pred_plate = open_ome_zarr(Path(config.io.pred_path), mode="r")
+    gt_plate = open_ome_zarr(Path(config.io.gt_path), mode="r")
+    seg_plate = None
+    if config.io.cell_segmentation_path is not None:
+        seg_plate = open_ome_zarr(Path(config.io.cell_segmentation_path), mode="r")
+
+    _WORKER_STATE.update(
+        {
+            "initialized": True,
+            "seg_model": seg_model,
+            "dinov3": dinov3_feature_extractor,
+            "dynaclr": dynaclr_feature_extractor,
+            "celldino": celldino_feature_extractor,
+            "cache_ctx": cache_ctx,
+            "pred_cache_ctx": pred_cache_ctx,
+            "pred_plate": pred_plate,
+            "gt_plate": gt_plate,
+            "seg_plate": seg_plate,
+            "pred_positions": dict(pred_plate.positions()),
+            "gt_positions": dict(gt_plate.positions()),
+            "seg_positions": dict(seg_plate.positions()) if seg_plate is not None else None,
+        }
+    )
+
+
+def _worker_run_fov(config: DictConfig, pos_name: str, cuda_empty_every_n: int) -> FovResult:
+    """Worker entry point: process one FOV by name and return FovResult.
+
+    Submitted via ``pool.submit`` in ``executor=process`` mode. Returns a
+    pickle-friendly ``FovResult`` (no plate handles or torch modules
+    cross the process boundary).
+    """
+    from dynacell.evaluation.pipeline_cache import flush_manifest
+
+    _worker_setup(config)
+    state = _WORKER_STATE
+    pos_pred = state["pred_positions"][pos_name]
+    pos_gt = state["gt_positions"][pos_name]
+    pos_seg = state["seg_positions"][pos_name] if state["seg_positions"] is not None else None
+
+    result = _process_one_fov(
+        config,
+        cuda_empty_every_n,
+        pos_name,
+        pos_pred,
+        pos_gt,
+        pos_seg,
+        config.io,
+        state["cache_ctx"],
+        state["pred_cache_ctx"],
+        state["seg_model"],
+        state["dinov3"],
+        state["dynaclr"],
+        state["celldino"],
+    )
+    # Worker-side manifest flush so interrupted runs preserve progress even
+    # when the parent dies. The global manifest lock at
+    # _pos_write_lock(ctx, "manifest", "global") serializes flushes across
+    # workers.
+    flush_manifest(state["cache_ctx"])
+    flush_manifest(state["pred_cache_ctx"])
+    return result
+
+
 def evaluate_predictions(config: DictConfig):
     """Evaluate predictions on all test images."""
     from dynacell.evaluation.runtime import (
         apply_thread_budget,
         dump_timings_csv,
+        make_fov_executor,
         maybe_gc_collect,
         reset_timings,
         resolve_runtime,
@@ -665,32 +805,16 @@ def evaluate_predictions(config: DictConfig):
                     for ctx in sides_for_precompute.values():
                         flush_manifest(ctx)
 
-            for fov_idx, (p1, p2, p3) in enumerate(
-                tqdm(
-                    zip(pred_positions, gt_positions, seg_positions),
-                    total=len(pred_positions),
-                    desc="Processing positions",
-                )
-            ):
-                pos_name_pred, pos_pred = p1
-                _, pos_gt = p2
-                _, pos_seg = p3
+            # Phase 2 runtime resolution: clamp fov_workers to n_positions
+            # now that we know it. threads_per_worker is frozen at Phase 1
+            # so the parent's BLAS cap matches what workers see.
+            runtime = resolve_runtime(
+                config,
+                n_positions=len(pred_positions),
+                freeze_threads_per_worker=runtime.threads_per_worker,
+            )
 
-                result = _process_one_fov(
-                    config,
-                    runtime.cuda_empty_cache_every_n_timepoints,
-                    pos_name_pred,
-                    pos_pred,
-                    pos_gt,
-                    pos_seg,
-                    io_config,
-                    cache_ctx,
-                    pred_cache_ctx,
-                    seg_model,
-                    dinov3_feature_extractor,
-                    dynaclr_feature_extractor,
-                    celldino_feature_extractor,
-                )
+            def _aggregate(result: FovResult) -> None:
                 _aggregate_fov_result(
                     result,
                     segmentation_results,
@@ -723,11 +847,66 @@ def evaluate_predictions(config: DictConfig):
                     gt_celldino_ts,
                 )
 
-                # Flush manifest after each position so interrupted runs preserve progress.
-                flush_manifest(cache_ctx)
-                flush_manifest(pred_cache_ctx)
+            if runtime.executor == "serial":
+                for fov_idx, (p1, p2, p3) in enumerate(
+                    tqdm(
+                        zip(pred_positions, gt_positions, seg_positions),
+                        total=len(pred_positions),
+                        desc="Processing positions",
+                    )
+                ):
+                    pos_name_pred, pos_pred = p1
+                    _, pos_gt = p2
+                    _, pos_seg = p3
 
-                maybe_gc_collect(fov_idx, runtime.gc_collect_every_n_fovs)
+                    result = _process_one_fov(
+                        config,
+                        runtime.cuda_empty_cache_every_n_timepoints,
+                        pos_name_pred,
+                        pos_pred,
+                        pos_gt,
+                        pos_seg,
+                        io_config,
+                        cache_ctx,
+                        pred_cache_ctx,
+                        seg_model,
+                        dinov3_feature_extractor,
+                        dynaclr_feature_extractor,
+                        celldino_feature_extractor,
+                    )
+                    _aggregate(result)
+
+                    # Flush manifest after each position so interrupted runs preserve progress.
+                    flush_manifest(cache_ctx)
+                    flush_manifest(pred_cache_ctx)
+
+                    maybe_gc_collect(fov_idx, runtime.gc_collect_every_n_fovs)
+            else:
+                # executor == "process": spawn-context ProcessPoolExecutor.
+                # Workers lazy-load their own seg_model + extractors under the
+                # GPU lock; parent's copy stays loaded (used only here for
+                # checkpoint pre-warm side effect — discarded after this block).
+                from concurrent.futures import as_completed
+
+                pos_names_in_order = [p[0] for p, _, _ in zip(pred_positions, gt_positions, seg_positions)]
+                with make_fov_executor(runtime) as pool:
+                    if pool is None:
+                        raise RuntimeError("make_fov_executor returned None for executor='process'")
+                    futures = {
+                        pool.submit(
+                            _worker_run_fov, config, pos_name, runtime.cuda_empty_cache_every_n_timepoints
+                        ): pos_name
+                        for pos_name in pos_names_in_order
+                    }
+                    results_by_pos: dict[str, FovResult] = {}
+                    for fut in tqdm(as_completed(futures), total=len(futures), desc="Processing positions"):
+                        pos_name = futures[fut]
+                        results_by_pos[pos_name] = fut.result()
+                # Aggregate in position order (independent of completion order)
+                # so per-FOV CSV / embedding NPZ row order is deterministic.
+                for fov_idx, pos_name in enumerate(pos_names_in_order):
+                    _aggregate(results_by_pos[pos_name])
+                    maybe_gc_collect(fov_idx, runtime.gc_collect_every_n_fovs)
         finally:
             if seg_plate is not None:
                 seg_plate.close()

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -155,7 +155,15 @@ def _save_embeddings(save_dir: Path, groups: dict[str, tuple[list, list, list]])
 
 def evaluate_predictions(config: DictConfig):
     """Evaluate predictions on all test images."""
-    from dynacell.evaluation.runtime import apply_thread_budget, resolve_runtime
+    from dynacell.evaluation.runtime import (
+        apply_thread_budget,
+        dump_timings_csv,
+        maybe_empty_cuda_cache,
+        maybe_gc_collect,
+        region_timer,
+        reset_timings,
+        resolve_runtime,
+    )
     from dynacell.evaluation.segmentation import prepare_segmentation_model, segment
     from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
@@ -165,6 +173,7 @@ def evaluate_predictions(config: DictConfig):
     # frozen across phases for parent/worker BLAS-cap consistency.
     runtime = resolve_runtime(config)
     apply_thread_budget(runtime.threads_per_worker)
+    reset_timings()
 
     all_pixel_metrics = []
     all_mask_metrics = []
@@ -328,10 +337,12 @@ def evaluate_predictions(config: DictConfig):
                     for ctx in sides_for_precompute.values():
                         flush_manifest(ctx)
 
-            for p1, p2, p3 in tqdm(
-                zip(pred_positions, gt_positions, seg_positions),
-                total=len(pred_positions),
-                desc="Processing positions",
+            for fov_idx, (p1, p2, p3) in enumerate(
+                tqdm(
+                    zip(pred_positions, gt_positions, seg_positions),
+                    total=len(pred_positions),
+                    desc="Processing positions",
+                )
             ):
                 pos_name_pred, pos_pred = p1
                 _, pos_gt = p2
@@ -346,37 +357,49 @@ def evaluate_predictions(config: DictConfig):
 
                 T = predict.shape[0]
 
-                gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
-                pred_mask_stack = (
-                    fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model) if pred_cache_ctx.enabled else None
-                )
+                with region_timer("mask_gt", pos_name_pred):
+                    gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
+                if pred_cache_ctx.enabled:
+                    with region_timer("mask_pred", pos_name_pred):
+                        pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
+                else:
+                    pred_mask_stack = None
 
                 if config.compute_feature_metrics:
-                    gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
-                    gt_dinov3_per_t = fov_deep_features(
-                        cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
-                    )
-                    gt_dynaclr_per_t = fov_deep_features(
-                        cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
-                    )
-                    gt_celldino_per_t = (
-                        fov_deep_features(
-                            cache_ctx, pos_name_pred, target, cell_segmentation, celldino_feature_extractor, "celldino"
+                    with region_timer("cp_gt", pos_name_pred):
+                        gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
+                    with region_timer("deep_gt_dinov3", pos_name_pred):
+                        gt_dinov3_per_t = fov_deep_features(
+                            cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
                         )
-                        if celldino_feature_extractor is not None
-                        else None
-                    )
-                    pred_per_t = _fov_pred_features_per_t(
-                        pred_cache_ctx,
-                        pos_name_pred,
-                        predict,
-                        cell_segmentation,
-                        dinov3_feature_extractor,
-                        dynaclr_feature_extractor,
-                        celldino_feature_extractor,
-                        config.feature_metrics.patch_size,
-                        config.pixel_metrics.spacing,
-                    )
+                    with region_timer("deep_gt_dynaclr", pos_name_pred):
+                        gt_dynaclr_per_t = fov_deep_features(
+                            cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
+                        )
+                    if celldino_feature_extractor is not None:
+                        with region_timer("deep_gt_celldino", pos_name_pred):
+                            gt_celldino_per_t = fov_deep_features(
+                                cache_ctx,
+                                pos_name_pred,
+                                target,
+                                cell_segmentation,
+                                celldino_feature_extractor,
+                                "celldino",
+                            )
+                    else:
+                        gt_celldino_per_t = None
+                    with region_timer("features_pred_per_t", pos_name_pred):
+                        pred_per_t = _fov_pred_features_per_t(
+                            pred_cache_ctx,
+                            pos_name_pred,
+                            predict,
+                            cell_segmentation,
+                            dinov3_feature_extractor,
+                            dynaclr_feature_extractor,
+                            celldino_feature_extractor,
+                            config.feature_metrics.patch_size,
+                            config.pixel_metrics.spacing,
+                        )
 
                 microssim_data = []
                 fov_pixel_metrics = []
@@ -385,51 +408,54 @@ def evaluate_predictions(config: DictConfig):
                 for t in tqdm(range(T), desc="Processing timepoints"):
                     data_info = {"FOV": pos_name_pred, "Timepoint": t}
 
-                    pixel_metrics = compute_pixel_metrics(
-                        predict[t],
-                        target[t],
-                        spacing=config.pixel_metrics.spacing,
-                        fsc_kwargs=config.pixel_metrics.fsc,
-                        spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
-                        use_gpu=config.use_gpu,
-                    )
+                    with region_timer("pixel_metrics", pos_name_pred, t):
+                        pixel_metrics = compute_pixel_metrics(
+                            predict[t],
+                            target[t],
+                            spacing=config.pixel_metrics.spacing,
+                            fsc_kwargs=config.pixel_metrics.fsc,
+                            spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
+                            use_gpu=config.use_gpu,
+                        )
                     if config.compute_microssim:
                         microssim_data.append({"target": target[t], "predict": predict[t]})
                     fov_pixel_metrics.append({**data_info, **pixel_metrics})
 
-                    segmented_target = gt_mask_stack[t]
-                    segmented_predict = (
-                        pred_mask_stack[t]
-                        if pred_mask_stack is not None
-                        else np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(bool)
-                    )
-                    all_mask_metrics.append(
-                        {**data_info, **evaluate_segmentations(segmented_predict, segmented_target)}
-                    )
-                    segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
+                    with region_timer("mask_metrics", pos_name_pred, t):
+                        segmented_target = gt_mask_stack[t]
+                        segmented_predict = (
+                            pred_mask_stack[t]
+                            if pred_mask_stack is not None
+                            else np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(bool)
+                        )
+                        all_mask_metrics.append(
+                            {**data_info, **evaluate_segmentations(segmented_predict, segmented_target)}
+                        )
+                        segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
 
                     if config.compute_feature_metrics:
-                        pred_cp = pred_per_t["cp"][t]
-                        pred_dinov3 = pred_per_t["dinov3"][t]
-                        pred_dynaclr = pred_per_t["dynaclr"][t]
-                        pred_celldino = pred_per_t["celldino"][t] if pred_per_t["celldino"] is not None else None
-                        pred_cp, gt_cp_t = drop_paired_nonfinite_rows(pred_cp, gt_cp_per_t[t])
-                        # Per-timepoint CP: drop target-zero columns + per-side z-score.
-                        # Deep features stay untouched.
-                        if pred_cp.size and gt_cp_t.size:
-                            pred_cp_z, gt_cp_z = _cp_dropzero_zscore(pred_cp, gt_cp_t)
-                        else:
-                            pred_cp_z, gt_cp_z = pred_cp, gt_cp_t
-                        pairwise_metrics = {
-                            **compute_feature_similarity_pairwise(pred_cp_z, gt_cp_z, "CP"),
-                            **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
-                            **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
-                        }
-                        if pred_celldino is not None:
-                            pairwise_metrics.update(
-                                compute_feature_similarity_pairwise(pred_celldino, gt_celldino_per_t[t], "CellDINO")
-                            )
-                        all_feature_metrics.append({**data_info, **pairwise_metrics})
+                        with region_timer("feature_pairwise", pos_name_pred, t):
+                            pred_cp = pred_per_t["cp"][t]
+                            pred_dinov3 = pred_per_t["dinov3"][t]
+                            pred_dynaclr = pred_per_t["dynaclr"][t]
+                            pred_celldino = pred_per_t["celldino"][t] if pred_per_t["celldino"] is not None else None
+                            pred_cp, gt_cp_t = drop_paired_nonfinite_rows(pred_cp, gt_cp_per_t[t])
+                            # Per-timepoint CP: drop target-zero columns + per-side z-score.
+                            # Deep features stay untouched.
+                            if pred_cp.size and gt_cp_t.size:
+                                pred_cp_z, gt_cp_z = _cp_dropzero_zscore(pred_cp, gt_cp_t)
+                            else:
+                                pred_cp_z, gt_cp_z = pred_cp, gt_cp_t
+                            pairwise_metrics = {
+                                **compute_feature_similarity_pairwise(pred_cp_z, gt_cp_z, "CP"),
+                                **compute_feature_similarity_pairwise(pred_dinov3, gt_dinov3_per_t[t], "DINOv3"),
+                                **compute_feature_similarity_pairwise(pred_dynaclr, gt_dynaclr_per_t[t], "DynaCLR"),
+                            }
+                            if pred_celldino is not None:
+                                pairwise_metrics.update(
+                                    compute_feature_similarity_pairwise(pred_celldino, gt_celldino_per_t[t], "CellDINO")
+                                )
+                            all_feature_metrics.append({**data_info, **pairwise_metrics})
                         # pred/gt fov+timepoint arrays are byte-identical per
                         # backbone; share one reference each (consumers only
                         # concatenate, never mutate in place).
@@ -470,21 +496,27 @@ def evaluate_predictions(config: DictConfig):
                             pred_celldino_ts.append(t_arr)
                             gt_celldino_ts.append(t_arr)
 
-                seg = np.stack(segmentations, axis=0)  # shape: (T, 2, D, H, W)
-                row, col, fov = pos_name_pred.split("/")
-                seg_pos = segmentation_results.create_position(row, col, fov)
-                seg_pos.create_image("0", seg.astype(bool))
+                    maybe_empty_cuda_cache(t, runtime.cuda_empty_cache_every_n_timepoints)
+
+                with region_timer("seg_write", pos_name_pred):
+                    seg = np.stack(segmentations, axis=0)  # shape: (T, 2, D, H, W)
+                    row, col, fov = pos_name_pred.split("/")
+                    seg_pos = segmentation_results.create_position(row, col, fov)
+                    seg_pos.create_image("0", seg.astype(bool))
 
                 if config.compute_microssim:
-                    microssim_scores = calculate_microssim(microssim_data)
-                    for i in range(T):
-                        fov_pixel_metrics[i]["MicroMS3IM"] = float(microssim_scores[i]["MicroMS3IM"])
+                    with region_timer("microssim", pos_name_pred):
+                        microssim_scores = calculate_microssim(microssim_data)
+                        for i in range(T):
+                            fov_pixel_metrics[i]["MicroMS3IM"] = float(microssim_scores[i]["MicroMS3IM"])
 
                 all_pixel_metrics.extend(fov_pixel_metrics)
 
                 # Flush manifest after each position so interrupted runs preserve progress.
                 flush_manifest(cache_ctx)
                 flush_manifest(pred_cache_ctx)
+
+                maybe_gc_collect(fov_idx, runtime.gc_collect_every_n_fovs)
         finally:
             if seg_plate is not None:
                 seg_plate.close()
@@ -601,6 +633,8 @@ def evaluate_predictions(config: DictConfig):
             embedding_groups["pred_celldino"] = (pred_celldino_feats, pred_celldino_fovs, pred_celldino_ts)
             embedding_groups["gt_celldino"] = (gt_celldino_feats, gt_celldino_fovs, gt_celldino_ts)
         _save_embeddings(save_dir, embedding_groups)
+
+    dump_timings_csv(save_dir)
 
     return all_pixel_metrics, all_mask_metrics, all_feature_metrics
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -447,15 +447,24 @@ def _aggregate_fov_result(
     gt_celldino_feats: list[np.ndarray],
     gt_celldino_fovs: list[np.ndarray],
     gt_celldino_ts: list[np.ndarray],
+    *,
+    extend_worker_timings: bool,
 ) -> None:
     """Apply one FOV's contributions to the parent-side run state.
 
     Writes the segmentation array to the HCS plate, extends the per-T row
     lists, and extends the 24 dataset-level accumulator lists.
+
+    ``extend_worker_timings`` toggles whether to append ``result.timings``
+    to the parent's global ``_TIMINGS`` collector. Set ``False`` in serial
+    mode (workers and parent share one collector, so the timings are
+    already there); set ``True`` in process mode (workers have separate
+    per-process collectors, so the parent must aggregate).
     """
     from dynacell.evaluation.runtime import extend_timings, region_timer
 
-    extend_timings(result.timings)
+    if extend_worker_timings:
+        extend_timings(result.timings)
 
     with region_timer("seg_write", result.pos_name):
         seg_pos = segmentation_results.create_position(result.row, result.col, result.fov)
@@ -839,6 +848,13 @@ def evaluate_predictions(config: DictConfig):
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
 
+            # Whether to fold result.timings into the parent's _TIMINGS:
+            # only when results come from spawn workers (separate per-process
+            # collector). In serial mode, _process_one_fov already wrote to
+            # the parent's collector via region_timer; re-extending here
+            # would double-count every row.
+            extend_worker_timings = runtime.executor == "process"
+
             def _aggregate(result: FovResult) -> None:
                 _aggregate_fov_result(
                     result,
@@ -870,6 +886,7 @@ def evaluate_predictions(config: DictConfig):
                     gt_celldino_feats,
                     gt_celldino_fovs,
                     gt_celldino_ts,
+                    extend_worker_timings=extend_worker_timings,
                 )
 
             if runtime.executor == "serial":

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -21,21 +21,18 @@ from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
 from dynacell.evaluation.metrics import build_crops
+from dynacell.evaluation.model_loader import LoadFlags, init_gt_cache_context, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
     DeepFeatureBatcher,
     flush_manifest,
     fov_cp_features,
     fov_masks,
-    init_cache_context,
-    resolve_dynaclr_encoder_cfg,
 )
 
 
 def precompute_gt_artifacts(config: DictConfig) -> None:
     """Build every GT-side artifact toggled on in ``config.build``."""
     from dynacell.evaluation.runtime import apply_thread_budget, resolve_runtime
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     if config.io.gt_cache_dir is None:
         raise ValueError("io.gt_cache_dir is required for dynacell precompute-gt")
@@ -62,46 +59,28 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
             "build.cp / build.dinov3 / build.dynaclr / build.celldino is true"
         )
 
-    seg_model = prepare_segmentation_model(config) if build.masks else None
+    # Stricter celldino gate than evaluate_predictions: precompute-gt
+    # requires an explicit weights path when build.celldino=true (the
+    # eval path soft-skips a null weights_path; here it would silently
+    # produce no cache, so we surface it as an error).
+    if build.celldino and config.feature_extractor.celldino.weights_path is None:
+        raise ValueError("feature_extractor.celldino.weights_path is required when build.celldino=true")
 
-    dinov3_model_name = None
-    dynaclr_ckpt_path = None
-    dynaclr_encoder_cfg = None
-    celldino_weights_path = None
-    dinov3_feature_extractor = None
-    dynaclr_feature_extractor = None
-    celldino_feature_extractor = None
-
-    if build.dinov3:
-        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-        dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-    if build.dynaclr:
-        dynaclr_config = config.feature_extractor.dynaclr
-        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-        dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-            checkpoint=dynaclr_config.checkpoint,
-            encoder_config=dynaclr_encoder_cfg,
-        )
-    if build.celldino:
-        celldino_cfg = config.feature_extractor.celldino
-        if celldino_cfg.weights_path is None:
-            raise ValueError("feature_extractor.celldino.weights_path is required when build.celldino=true")
-        celldino_weights_path = str(celldino_cfg.weights_path)
-        celldino_feature_extractor = CellDinoFeatureExtractor(
-            weights_path=celldino_weights_path,
-            img_size=int(celldino_cfg.img_size),
-            patch_size=int(celldino_cfg.patch_size),
-        )
-
-    cache_ctx = init_cache_context(
+    models = load_eval_models(
         config,
-        side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        flags=LoadFlags(
+            masks=bool(build.masks),
+            dinov3=bool(build.dinov3),
+            dynaclr=bool(build.dynaclr),
+            celldino=bool(build.celldino),
+        ),
     )
+    seg_model = models.seg_model
+    dinov3_feature_extractor = models.dinov3
+    dynaclr_feature_extractor = models.dynaclr
+    celldino_feature_extractor = models.celldino
+
+    cache_ctx = init_gt_cache_context(config, models)
 
     gt_path = Path(config.io.gt_path)
     seg_path = Path(config.io.cell_segmentation_path) if config.io.cell_segmentation_path is not None else None

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -33,11 +33,25 @@ from dynacell.evaluation.pipeline_cache import (
 
 def precompute_gt_artifacts(config: DictConfig) -> None:
     """Build every GT-side artifact toggled on in ``config.build``."""
+    from dynacell.evaluation.runtime import apply_thread_budget, resolve_runtime
     from dynacell.evaluation.segmentation import prepare_segmentation_model
     from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     if config.io.gt_cache_dir is None:
         raise ValueError("io.gt_cache_dir is required for dynacell precompute-gt")
+
+    # Precompute is single-process by design (DeepFeatureBatcher accumulates
+    # state across FOVs). Apply the thread cap but raise if the user requested
+    # FOV-level parallelism here — that belongs to evaluate_predictions only.
+    runtime = resolve_runtime(config)
+    if runtime.executor != "serial" or runtime.fov_workers != 1:
+        raise ValueError(
+            "dynacell precompute-gt does not support FOV-level parallelism. "
+            f"Got runtime.executor={runtime.executor!r}, "
+            f"runtime.fov_workers={runtime.fov_workers}. "
+            "Set runtime.executor='serial' and runtime.fov_workers=1 (or omit)."
+        )
+    apply_thread_budget(runtime.threads_per_worker)
 
     build = config.build
     build_any_features = bool(build.cp or build.dinov3 or build.dynaclr or build.celldino)

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -17,10 +17,15 @@ lazily inside function bodies so spawn-context workers can set
 
 from __future__ import annotations
 
+import csv
+import gc
 import logging
 import os
+import time
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Literal
+from pathlib import Path
+from typing import Any, Iterator, Literal
 
 from omegaconf import DictConfig, OmegaConf
 from threadpoolctl import threadpool_limits
@@ -277,3 +282,93 @@ def resolve_runtime(
         cuda_empty_cache_every_n_timepoints=cuda_empty_n,
         gc_collect_every_n_fovs=gc_collect_n,
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-T memory hygiene + region timing instrumentation.
+# ---------------------------------------------------------------------------
+
+# Per-process timing collector. Each entry is (pos_name, t_or_None, region,
+# seconds). Under executor=process (C3+), workers return their slice in
+# FovResult.timings; the parent's aggregator concatenates.
+_TIMINGS: list[tuple[str, int | None, str, float]] = []
+
+
+def reset_timings() -> None:
+    """Clear the per-process timing collector."""
+    _TIMINGS.clear()
+
+
+def get_timings() -> list[tuple[str, int | None, str, float]]:
+    """Return a copy of the per-process timing collector."""
+    return list(_TIMINGS)
+
+
+def extend_timings(rows: list[tuple[str, int | None, str, float]]) -> None:
+    """Append a batch of timing rows (used by parent aggregator under process mode)."""
+    _TIMINGS.extend(rows)
+
+
+@contextmanager
+def region_timer(region: str, pos_name: str, t: int | None = None) -> Iterator[None]:
+    """Record wall time of the wrapped block to the per-process timing collector.
+
+    Parameters
+    ----------
+    region : str
+        Region tag (e.g. "pixel_metrics", "mask_gt", "features_pred_per_t").
+    pos_name : str
+        FOV identifier (typically "<row>/<col>/<fov>").
+    t : int or None
+        Timepoint index when the region is per-T; ``None`` for FOV-level regions.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        _TIMINGS.append((pos_name, t, region, time.perf_counter() - start))
+
+
+def dump_timings_csv(save_dir: Path) -> Path | None:
+    """Write the collected timings to ``<save_dir>/eval_timing.csv`` and return the path.
+
+    Returns ``None`` if no timings were recorded.
+    """
+    if not _TIMINGS:
+        return None
+    save_dir.mkdir(parents=True, exist_ok=True)
+    out_path = save_dir / "eval_timing.csv"
+    with out_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["pos_name", "t", "region", "seconds"])
+        for pos_name, t, region, seconds in _TIMINGS:
+            writer.writerow([pos_name, "" if t is None else t, region, f"{seconds:.6f}"])
+    return out_path
+
+
+def maybe_empty_cuda_cache(t: int, every_n: int) -> None:
+    """Call ``torch.cuda.empty_cache()`` every ``every_n`` timepoints.
+
+    No-op when ``every_n <= 0`` or CUDA is unavailable.
+    """
+    if every_n <= 0:
+        return
+    if (t + 1) % every_n != 0:
+        return
+    import torch
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def maybe_gc_collect(fov_idx: int, every_n: int) -> None:
+    """Call ``gc.collect()`` every ``every_n`` FOVs.
+
+    ``fov_idx`` is 0-based; collects when ``(fov_idx + 1) % every_n == 0``.
+    No-op when ``every_n <= 0``.
+    """
+    if every_n <= 0:
+        return
+    if (fov_idx + 1) % every_n != 0:
+        return
+    gc.collect()

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -1,0 +1,279 @@
+"""Eval runtime: thread budgeting + (in later commits) process-pool primitives.
+
+Three layers of thread-cap discipline, in order of when they bite:
+
+1. ``early_apply_env_caps()`` reads ``DYNACELL_THREADS_PER_WORKER`` from the
+   environment and sets BLAS/OMP env vars before any C extension loads. Called
+   from ``dynacell.__main__:main_cli()`` as the first statement.
+2. ``apply_thread_budget(threads)`` is the in-process safety net: sets env
+   (respecting caller-set values), calls ``torch.set_num_threads``, and
+   activates a module-level ``threadpoolctl.threadpool_limits`` cap.
+3. (C3) per-worker initializer re-applies the cap in each spawned child.
+
+Module-level imports are stdlib + ``threadpoolctl`` only. ``torch`` is imported
+lazily inside function bodies so spawn-context workers can set
+``CUDA_VISIBLE_DEVICES`` before any torch-driven CUDA context creation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from omegaconf import DictConfig, OmegaConf
+from threadpoolctl import threadpool_limits
+
+logger = logging.getLogger(__name__)
+
+# Module-level handle for the active threadpool_limits context. We enter the
+# context once at startup and keep the handle live for the rest of the process
+# lifetime (threadpool_limits is a per-process thread-local API; the cap stays
+# armed as long as the context object is not exited).
+_ACTIVE_THREADPOOL_HANDLE: Any = None
+
+# Env vars that affect BLAS / OMP / framework thread counts. Listed in
+# priority order; the first three actually matter for this codebase (numpy is
+# scipy-openblas, torch + cellpose honor OMP), the rest are defense-in-depth.
+_THREAD_ENV_VARS: tuple[str, ...] = (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "NUMEXPR_MAX_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "TBB_NUM_THREADS",
+)
+
+# Env var that triggers the per-T memory hygiene knobs at runtime even when
+# the YAML defaults are off. Useful for operator mitigation post-ship.
+_FORCE_PER_T_HYGIENE_ENV: str = "DYNACELL_FORCE_PER_T_HYGIENE"
+
+
+@dataclass(frozen=True)
+class ResolvedRuntime:
+    """Materialized runtime config with all ``"auto"`` values resolved.
+
+    Parameters
+    ----------
+    fov_workers : int
+        Outer FOV-level parallelism. 1 = sequential.
+    threads_per_worker : int
+        BLAS/OMP/torch intra-op threads per worker process.
+    executor : {"serial", "process"}
+        FOV loop executor.
+    cuda_empty_cache_every_n_timepoints : int
+        Call ``torch.cuda.empty_cache()`` every N timepoints (0 = off).
+    gc_collect_every_n_fovs : int
+        Call ``gc.collect()`` every N FOVs (0 = off).
+    """
+
+    fov_workers: int
+    threads_per_worker: int
+    executor: Literal["serial", "process"]
+    cuda_empty_cache_every_n_timepoints: int
+    gc_collect_every_n_fovs: int
+
+
+def early_apply_env_caps() -> None:
+    """Set BLAS/OMP env vars before any C-extension load.
+
+    Reads ``DYNACELL_THREADS_PER_WORKER`` from env; if set, exports the BLAS
+    env vars to that value. This is the only layer that bites BLAS at
+    extension-load time. Idempotent: existing caller-set env vars are
+    respected (we only write if the var is unset).
+
+    Called from ``dynacell.__main__:main_cli()`` as the first statement,
+    before any heavy import triggers numpy/torch BLAS initialization.
+    """
+    threads = os.environ.get("DYNACELL_THREADS_PER_WORKER")
+    if threads is None:
+        return
+    for var in _THREAD_ENV_VARS:
+        os.environ.setdefault(var, threads)
+
+
+def apply_thread_budget(threads: int) -> None:
+    """Apply a thread budget to the current process.
+
+    Performs three layered actions:
+
+    1. Sets BLAS/OMP env vars (only when not already set by the caller);
+       logs at WARNING if a caller-set value differs from ``threads``.
+    2. Calls ``torch.set_num_threads(threads)``.
+    3. Calls ``torch.set_num_interop_threads(max(1, threads // 2))`` —
+       wrapped in try/except since this raises after any parallel op has
+       run (the common case from Hydra's main).
+    4. Activates a module-level ``threadpool_limits(limits=threads,
+       user_api="blas")`` context for the rest of the process lifetime.
+
+    Parameters
+    ----------
+    threads : int
+        Number of threads to cap BLAS/OMP/torch to. Must be >= 1.
+    """
+    global _ACTIVE_THREADPOOL_HANDLE
+    if threads < 1:
+        raise ValueError(f"apply_thread_budget: threads must be >= 1, got {threads}")
+
+    # 1. Env vars: respect caller-set values; WARN on mismatch.
+    threads_str = str(threads)
+    for var in _THREAD_ENV_VARS:
+        existing = os.environ.get(var)
+        if existing is None:
+            os.environ[var] = threads_str
+        elif existing != threads_str:
+            logger.log(
+                logging.WARNING,
+                "%s already set to %r by environment; not overriding with %r",
+                var,
+                existing,
+                threads_str,
+            )
+
+    # 2 + 3. Torch thread caps (deferred import).
+    import torch
+
+    torch.set_num_threads(threads)
+    try:
+        torch.set_num_interop_threads(max(1, threads // 2))
+    except RuntimeError as e:
+        logger.info("torch.set_num_interop_threads: %s; continuing with current value", e)
+
+    # 4. Activate threadpool_limits for the rest of the process.
+    if _ACTIVE_THREADPOOL_HANDLE is None:
+        _ACTIVE_THREADPOOL_HANDLE = threadpool_limits(limits=threads, user_api="blas")
+    else:
+        # Re-arming: enter a fresh context with the new limit. The old handle
+        # stays alive (its __exit__ is never called); threadpoolctl honors
+        # the innermost active limit. Acceptable for re-call from a worker
+        # initializer that inherited a parent's handle.
+        _ACTIVE_THREADPOOL_HANDLE = threadpool_limits(limits=threads, user_api="blas")
+
+
+def _get_int(config: DictConfig, key: str, default: int) -> int:
+    """Read an int field from a runtime config with a default fallback."""
+    val = OmegaConf.select(config, key, default=default)
+    return int(val)
+
+
+def resolve_runtime(
+    config: DictConfig,
+    n_positions: int | None = None,
+    freeze_threads_per_worker: int | None = None,
+) -> ResolvedRuntime:
+    """Materialize the runtime config block with all ``"auto"`` values resolved.
+
+    Two-phase use from ``evaluate_predictions``:
+
+    * **Phase 1** (top of function): ``resolve_runtime(config)``. Provisional
+      ``fov_workers`` from ``cpu_count // 4``; ``threads_per_worker`` from
+      ``cpu_count // provisional_fov_workers``. Parent applies BLAS cap with
+      this value.
+    * **Phase 2** (after position list built):
+      ``resolve_runtime(config, n_positions=N, freeze_threads_per_worker=T)``.
+      Clamps ``fov_workers`` to ``min(provisional, N)`` and returns
+      ``threads_per_worker == T`` unchanged so the worker initializer matches
+      what the parent already capped to.
+
+    The ``DYNACELL_FORCE_PER_T_HYGIENE=1`` env var flips both hygiene knobs
+    on at runtime regardless of YAML defaults — operator escape hatch.
+
+    Parameters
+    ----------
+    config : DictConfig
+        The eval config (with ``config.runtime`` block).
+    n_positions : int or None
+        Number of positions in the eval; used to clamp ``"auto"`` workers in
+        Phase 2. ``None`` in Phase 1.
+    freeze_threads_per_worker : int or None
+        If set, ``threads_per_worker`` returns this value unconditionally
+        (Phase 2 uses this to stay consistent with the parent's BLAS cap).
+
+    Returns
+    -------
+    ResolvedRuntime
+        Materialized config; safe to pass across pickle boundaries.
+
+    Raises
+    ------
+    ValueError
+        If literal ``fov_workers > 1`` is set with ``executor == "serial"``.
+    """
+    runtime = OmegaConf.select(config, "runtime", default=None)
+    if runtime is None:
+        # No runtime block configured — fall back to sequential defaults
+        # matching today's behavior.
+        return ResolvedRuntime(
+            fov_workers=1,
+            threads_per_worker=max(1, os.cpu_count() or 1),
+            executor="serial",
+            cuda_empty_cache_every_n_timepoints=0,
+            gc_collect_every_n_fovs=0,
+        )
+
+    executor = str(OmegaConf.select(runtime, "executor", default="serial"))
+    if executor not in ("serial", "process"):
+        raise ValueError(f"runtime.executor must be 'serial' or 'process', got {executor!r}")
+
+    cpu_count = max(1, os.cpu_count() or 1)
+    raw_fov_workers = OmegaConf.select(runtime, "fov_workers", default=1)
+    raw_threads = OmegaConf.select(runtime, "threads_per_worker", default="auto")
+
+    # Resolve fov_workers.
+    if isinstance(raw_fov_workers, int):
+        resolved_fov_workers = int(raw_fov_workers)
+        if resolved_fov_workers > 1 and executor == "serial":
+            raise ValueError(
+                f"runtime.fov_workers={resolved_fov_workers} requires runtime.executor='process' (got 'serial')"
+            )
+    elif raw_fov_workers == "auto":
+        if executor == "serial":
+            resolved_fov_workers = 1
+        else:
+            # Provisional divisor of 4 when threads_per_worker is also "auto".
+            divisor = int(raw_threads) if isinstance(raw_threads, int) else 4
+            provisional = max(1, cpu_count // divisor)
+            clamp = n_positions if n_positions is not None else cpu_count
+            resolved_fov_workers = max(1, min(provisional, clamp))
+    else:
+        raise ValueError(f"runtime.fov_workers must be int or 'auto', got {raw_fov_workers!r}")
+
+    # Auto-demote process→serial when only 1 worker resolves (avoids 5s spawn cost).
+    if executor == "process" and resolved_fov_workers == 1:
+        logger.info("runtime.fov_workers resolved to 1; auto-demoting executor 'process' -> 'serial'")
+        executor = "serial"
+
+    # Resolve threads_per_worker.
+    if freeze_threads_per_worker is not None:
+        resolved_threads = int(freeze_threads_per_worker)
+    elif isinstance(raw_threads, int):
+        resolved_threads = int(raw_threads)
+    elif raw_threads == "auto":
+        resolved_threads = max(1, cpu_count // resolved_fov_workers)
+    else:
+        raise ValueError(f"runtime.threads_per_worker must be int or 'auto', got {raw_threads!r}")
+
+    # Per-T memory hygiene knobs; env-var escape hatch flips both on.
+    force_hygiene = os.environ.get(_FORCE_PER_T_HYGIENE_ENV, "0") == "1"
+    if force_hygiene:
+        cuda_empty_n = max(1, _get_int(runtime, "cuda_empty_cache_every_n_timepoints", 0))
+        gc_collect_n = max(1, _get_int(runtime, "gc_collect_every_n_fovs", 0))
+        logger.warning(
+            "%s=1 — forcing cuda_empty_cache_every_n_timepoints=%d, gc_collect_every_n_fovs=%d",
+            _FORCE_PER_T_HYGIENE_ENV,
+            cuda_empty_n,
+            gc_collect_n,
+        )
+    else:
+        cuda_empty_n = _get_int(runtime, "cuda_empty_cache_every_n_timepoints", 0)
+        gc_collect_n = _get_int(runtime, "gc_collect_every_n_fovs", 0)
+
+    return ResolvedRuntime(
+        fov_workers=resolved_fov_workers,
+        threads_per_worker=resolved_threads,
+        executor=executor,  # type: ignore[arg-type]
+        cuda_empty_cache_every_n_timepoints=cuda_empty_n,
+        gc_collect_every_n_fovs=gc_collect_n,
+    )

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -56,6 +56,21 @@ _THREAD_ENV_VARS: tuple[str, ...] = (
 _FORCE_PER_T_HYGIENE_ENV: str = "DYNACELL_FORCE_PER_T_HYGIENE"
 
 
+def _cpu_count() -> int:
+    """Return the number of CPUs visible to this process.
+
+    Prefers ``os.sched_getaffinity(0)`` when available (Linux): it respects
+    SLURM cgroups + cpuset limits, so we don't oversize ``fov_workers`` or
+    ``threads_per_worker`` past the cgroup-visible budget. Falls back to
+    ``os.cpu_count()`` (which reports the host's logical CPU count, ignoring
+    cgroups) on platforms without ``sched_getaffinity``.
+    """
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except AttributeError:
+        return max(1, os.cpu_count() or 1)
+
+
 @dataclass(frozen=True)
 class ResolvedRuntime:
     """Materialized runtime config with all ``"auto"`` values resolved.
@@ -147,14 +162,13 @@ def apply_thread_budget(threads: int) -> None:
         logger.info("torch.set_num_interop_threads: %s; continuing with current value", e)
 
     # 4. Activate threadpool_limits for the rest of the process.
-    if _ACTIVE_THREADPOOL_HANDLE is None:
-        _ACTIVE_THREADPOOL_HANDLE = threadpool_limits(limits=threads, user_api="blas")
-    else:
-        # Re-arming: enter a fresh context with the new limit. The old handle
-        # stays alive (its __exit__ is never called); threadpoolctl honors
-        # the innermost active limit. Acceptable for re-call from a worker
-        # initializer that inherited a parent's handle.
-        _ACTIVE_THREADPOOL_HANDLE = threadpool_limits(limits=threads, user_api="blas")
+    # On re-arm, the old handle becomes unreachable and is GC'd. We don't
+    # call its __exit__ because that would *restore* the prior thread cap
+    # — but we want the new cap to be the active one. threadpoolctl's
+    # native thread-limit state is set when the new limiter is entered
+    # (via __enter__ inside threadpool_limits.__init__), so the new limit
+    # is active immediately; dropping the old handle is intentional.
+    _ACTIVE_THREADPOOL_HANDLE = threadpool_limits(limits=threads, user_api="blas")
 
 
 def _get_int(config: DictConfig, key: str, default: int) -> int:
@@ -212,7 +226,7 @@ def resolve_runtime(
         # matching today's behavior.
         return ResolvedRuntime(
             fov_workers=1,
-            threads_per_worker=max(1, os.cpu_count() or 1),
+            threads_per_worker=_cpu_count(),
             executor="serial",
             cuda_empty_cache_every_n_timepoints=0,
             gc_collect_every_n_fovs=0,
@@ -222,13 +236,15 @@ def resolve_runtime(
     if executor not in ("serial", "process"):
         raise ValueError(f"runtime.executor must be 'serial' or 'process', got {executor!r}")
 
-    cpu_count = max(1, os.cpu_count() or 1)
+    cpu_count = _cpu_count()
     raw_fov_workers = OmegaConf.select(runtime, "fov_workers", default=1)
     raw_threads = OmegaConf.select(runtime, "threads_per_worker", default="auto")
 
     # Resolve fov_workers.
     if isinstance(raw_fov_workers, int):
         resolved_fov_workers = int(raw_fov_workers)
+        if resolved_fov_workers < 1:
+            raise ValueError(f"runtime.fov_workers must be >= 1, got {resolved_fov_workers}")
         if resolved_fov_workers > 1 and executor == "serial":
             raise ValueError(
                 f"runtime.fov_workers={resolved_fov_workers} requires runtime.executor='process' (got 'serial')"
@@ -255,6 +271,8 @@ def resolve_runtime(
         resolved_threads = int(freeze_threads_per_worker)
     elif isinstance(raw_threads, int):
         resolved_threads = int(raw_threads)
+        if resolved_threads < 1:
+            raise ValueError(f"runtime.threads_per_worker must be >= 1, got {resolved_threads}")
     elif raw_threads == "auto":
         resolved_threads = max(1, cpu_count // resolved_fov_workers)
     else:
@@ -410,14 +428,23 @@ def is_worker() -> bool:
 
 
 @contextmanager
-def gpu_serialization_lock() -> Iterator[None]:
+def gpu_serialization_lock(gate: bool = True) -> Iterator[None]:
     """Serialize GPU operations across workers via an ``fcntl.flock``.
 
-    No-op when ``_GPU_LOCK_PATH`` is unset (parent / serial mode).
-    Used to wrap model loads and per-FOV GPU operations under
-    ``executor=process``.
+    Parameters
+    ----------
+    gate : bool
+        When False (e.g., the protected region runs CPU-only under
+        ``use_gpu=false``), this is a no-op even in process mode.
+        Callers pass ``gate=config.use_gpu`` for regions whose GPU
+        usage tracks the ``use_gpu`` flag, so CPU-only runs don't
+        serialize across workers needlessly.
+
+    Other no-op conditions: ``_GPU_LOCK_PATH`` unset (parent / serial
+    mode) or no CUDA available in the worker. Used to wrap model loads
+    and per-FOV GPU operations under ``executor=process``.
     """
-    if _GPU_LOCK_PATH is None:
+    if not gate or _GPU_LOCK_PATH is None:
         yield
         return
     import fcntl

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -399,6 +399,16 @@ def _worker_initializer(threads: int, gpu_lock_path: str | None) -> None:
     _GPU_LOCK_PATH = gpu_lock_path
 
 
+def is_worker() -> bool:
+    """Return True if called from a spawn worker (post-``_worker_initializer``).
+
+    Used to suppress inner per-T tqdm bars in workers — under
+    ``fov_workers>1`` the N concurrent inner bars interleave on the parent's
+    stderr unreadably. The outer per-FOV tqdm (in the parent) stays visible.
+    """
+    return _GPU_LOCK_PATH is not None
+
+
 @contextmanager
 def gpu_serialization_lock() -> Iterator[None]:
     """Serialize GPU operations across workers via an ``fcntl.flock``.

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -440,9 +440,11 @@ def gpu_serialization_lock(gate: bool = True) -> Iterator[None]:
         usage tracks the ``use_gpu`` flag, so CPU-only runs don't
         serialize across workers needlessly.
 
-    Other no-op conditions: ``_GPU_LOCK_PATH`` unset (parent / serial
-    mode) or no CUDA available in the worker. Used to wrap model loads
-    and per-FOV GPU operations under ``executor=process``.
+    Other no-op condition: ``_GPU_LOCK_PATH`` unset (parent / serial
+    mode). Used to wrap model loads and per-FOV GPU operations under
+    ``executor=process``. CPU-only execution is opted into at the call
+    site by passing ``gate=False`` (typically ``gate=config.use_gpu``);
+    the lock itself does NOT probe ``torch.cuda.is_available()``.
     """
     if not gate or _GPU_LOCK_PATH is None:
         yield

--- a/applications/dynacell/src/dynacell/evaluation/runtime.py
+++ b/applications/dynacell/src/dynacell/evaluation/runtime.py
@@ -372,3 +372,96 @@ def maybe_gc_collect(fov_idx: int, every_n: int) -> None:
     if (fov_idx + 1) % every_n != 0:
         return
     gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# Process-pool primitives for FOV-level parallelism (C4).
+# Spawn context so each worker gets its own CUDA context and BLAS load.
+# ---------------------------------------------------------------------------
+
+# Worker-global GPU lock path, set by _worker_initializer. ``None`` in the
+# parent / serial mode -> gpu_serialization_lock is a no-op.
+_GPU_LOCK_PATH: str | None = None
+
+
+def _worker_initializer(threads: int, gpu_lock_path: str | None) -> None:
+    """Initialize a freshly-spawned worker process.
+
+    Order matters: env caps are set BEFORE ``apply_thread_budget`` is called,
+    which lazy-imports torch. If torch were imported first, ``CUDA_VISIBLE_DEVICES``
+    overrides (if any) would come too late.
+    """
+    global _GPU_LOCK_PATH
+    # Env caps first so BLAS C-extensions load with the right thread count.
+    for var in _THREAD_ENV_VARS:
+        os.environ.setdefault(var, str(threads))
+    apply_thread_budget(threads)
+    _GPU_LOCK_PATH = gpu_lock_path
+
+
+@contextmanager
+def gpu_serialization_lock() -> Iterator[None]:
+    """Serialize GPU operations across workers via an ``fcntl.flock``.
+
+    No-op when ``_GPU_LOCK_PATH`` is unset (parent / serial mode).
+    Used to wrap model loads and per-FOV GPU operations under
+    ``executor=process``.
+    """
+    if _GPU_LOCK_PATH is None:
+        yield
+        return
+    import fcntl
+
+    with open(_GPU_LOCK_PATH, "w") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def gpu_lock_path_for_job() -> str:
+    """Return a node-local lock path tagged by SLURM_JOB_ID (or PID as fallback).
+
+    Stays on local /tmp so fcntl serialization is fast and doesn't go through
+    NFS lockd. One lock per job, shared across all workers in that job.
+    """
+    import tempfile
+
+    tag = os.environ.get("SLURM_JOB_ID", str(os.getpid()))
+    return str(Path(tempfile.gettempdir()) / f"dynacell_gpu_{tag}.lock")
+
+
+@contextmanager
+def make_fov_executor(runtime: ResolvedRuntime) -> Iterator[Any]:
+    """Yield a ``ProcessPoolExecutor`` for ``executor=process`` or ``None`` for serial.
+
+    Callers branch on the yielded value: ``None`` means run inline; an
+    ``Executor`` means submit ``_process_one_fov`` invocations to workers.
+
+    Cleanup: on exit (normal or exception), the pool is shut down with
+    ``cancel_futures=True``. In-flight workers continue to completion
+    (Python's ``ProcessPoolExecutor`` does not signal them); user may need
+    ``scancel`` to fully release GPU memory on Ctrl-C.
+    """
+    if runtime.executor == "serial":
+        yield None
+        return
+
+    import multiprocessing as mp
+    from concurrent.futures import ProcessPoolExecutor
+
+    lock_path = gpu_lock_path_for_job()
+    # Touch the lock file so workers can flock-open it before any FOV runs.
+    Path(lock_path).touch()
+    ctx = mp.get_context("spawn")
+    pool = ProcessPoolExecutor(
+        max_workers=runtime.fov_workers,
+        mp_context=ctx,
+        initializer=_worker_initializer,
+        initargs=(runtime.threads_per_worker, lock_path),
+    )
+    try:
+        yield pool
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)

--- a/applications/dynacell/src/dynacell/evaluation/segmentation.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation.py
@@ -92,11 +92,16 @@ def prepare_segmentation_model(config):
     Returns ``None`` for organelles that use classical (non-DL) workflows.
     Respects ``config.use_gpu`` when deciding whether to move models to GPU.
 
-    Returns ``None`` unconditionally when ``io.require_complete_cache=true``:
-    in that mode the caller asserts that all needed masks live in the cache,
-    so loading SuperModel (which hits a quilt download for nucleus/membrane
-    on a cold node) would be wasted work. If a mask cache-miss happens, the
-    cache layer raises ``StaleCacheError`` before any ``segment()`` call.
+    Returns ``None`` when ``io.require_complete_cache=true`` AND no per-FOV
+    call path can invoke ``segment()`` without a cached mask. Concretely:
+    organelle targets (``er``/``nucleoli``/``lysosomes``/``mitochondria``)
+    delegate to aicssegmentation workflows that don't take ``seg_model``,
+    so skipping the SuperModel load is safe. For ``nucleus``/``membrane``,
+    the per-T loop in ``pipeline._process_one_fov`` falls back to
+    ``segment(predict[t], seg_model=seg_model)`` whenever the pred-side
+    mask cache is disabled (``io.pred_cache_dir=None``); in that case we
+    must still load SuperModel even under ``require_complete_cache=true``
+    or the fallback raises ``ValueError`` mid-loop.
     """
     require_complete = bool(getattr(config.io, "require_complete_cache", False))
     if config.target_name not in [
@@ -109,7 +114,9 @@ def prepare_segmentation_model(config):
     ]:
         raise ValueError(f"Invalid target_name in config: {config.target_name!r}")
     if require_complete:
-        return None
+        pred_cache_dir = getattr(config.io, "pred_cache_dir", None)
+        if config.target_name not in ("nucleus", "membrane") or pred_cache_dir is not None:
+            return None
     if config.target_name in ["nucleus", "membrane"]:
         _require_segmenter_model_zoo()
         if config.target_name == "nucleus":

--- a/applications/dynacell/src/dynacell/evaluation/segmentation.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation.py
@@ -91,7 +91,14 @@ def prepare_segmentation_model(config):
 
     Returns ``None`` for organelles that use classical (non-DL) workflows.
     Respects ``config.use_gpu`` when deciding whether to move models to GPU.
+
+    Returns ``None`` unconditionally when ``io.require_complete_cache=true``:
+    in that mode the caller asserts that all needed masks live in the cache,
+    so loading SuperModel (which hits a quilt download for nucleus/membrane
+    on a cold node) would be wasted work. If a mask cache-miss happens, the
+    cache layer raises ``StaleCacheError`` before any ``segment()`` call.
     """
+    require_complete = bool(getattr(config.io, "require_complete_cache", False))
     if config.target_name not in [
         "nucleus",
         "membrane",
@@ -101,6 +108,8 @@ def prepare_segmentation_model(config):
         "mitochondria",
     ]:
         raise ValueError(f"Invalid target_name in config: {config.target_name!r}")
+    if require_complete:
+        return None
     if config.target_name in ["nucleus", "membrane"]:
         _require_segmenter_model_zoo()
         if config.target_name == "nucleus":

--- a/applications/dynacell/tests/_eval_fixtures.py
+++ b/applications/dynacell/tests/_eval_fixtures.py
@@ -1,0 +1,213 @@
+"""Shared cache-only fixture helpers for dynacell eval integration tests.
+
+Underscore prefix keeps pytest from collecting this file as tests. Imported
+by ``test_evaluation_pipeline_parallel_cpu.py`` and
+``test_evaluation_grouped.py`` (and any future eval test that wants the
+same scaffolding) — see CLAUDE.md "no ``sys.path`` edits" rule.
+
+Builds tiny iohub HCS plates + pre-populated mask caches so the
+cache-only eval path (``target_name=er`` + ``require_complete_cache=true``
++ ``compute_feature_metrics=false``) runs end-to-end without loading any
+segmenter / extractor / cubic — small enough to fit a single-CPU CI in
+under ~30 s.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+from iohub.ngff import open_ome_zarr
+from omegaconf import OmegaConf
+
+N_POSITIONS = 3
+T = 2
+D = 4
+H = 32
+W = 32
+
+
+def live_pipeline_module():
+    """Force-import a fresh ``dynacell.evaluation.pipeline`` module.
+
+    Other tests (e.g. ``test_evaluation_pipeline.py``) stub
+    ``dynacell.evaluation.metrics`` via ``monkeypatch.setitem(sys.modules,
+    ...)``. After teardown ``sys.modules`` may still hold the stubbed
+    modules AND the pipeline module's bound ``compute_pixel_metrics``
+    reference. Clear every ``dynacell.evaluation.*`` cache entry before
+    re-import so we get fresh modules with real implementations.
+    """
+    for name in list(sys.modules):
+        if name.startswith("dynacell.evaluation"):
+            sys.modules.pop(name, None)
+    return importlib.import_module("dynacell.evaluation.pipeline")
+
+
+def make_hcs_plate(path: Path, channel_name: str, seed: int) -> None:
+    """Create a tiny HCS plate with ``N_POSITIONS`` positions of shape ``(T, 1, D, H, W)``.
+
+    Positions are named ``A/1/{i}`` for ``i in range(N_POSITIONS)``. Pixel
+    values are deterministic from ``seed`` so pred and GT differ
+    predictably.
+    """
+    rng = np.random.default_rng(seed)
+    with open_ome_zarr(path, mode="w", layout="hcs", channel_names=[channel_name], version="0.5") as plate:
+        for i in range(N_POSITIONS):
+            pos = plate.create_position("A", "1", str(i))
+            data = rng.uniform(0.0, 1.0, size=(T, 1, D, H, W)).astype(np.float32)
+            pos.create_image("0", data)
+
+
+def make_mask_cache(
+    cache_dir: Path,
+    plate_path: Path,
+    channel_name: str,
+    side: str,
+    target_name: str = "er",
+) -> None:
+    """Prebuild a mask cache (zarr + manifest) for ``N_POSITIONS`` positions.
+
+    Mask values are deterministic per (side, position, t): GT masks fill
+    the upper half of the (H, W) plane; pred masks fill the upper
+    quadrant. This makes DICE / IoU deterministic and non-trivially
+    different between sides. ``side`` is ``"gt"`` or ``"pred"``.
+    """
+    from dynacell.evaluation.cache import (
+        CACHE_SCHEMA_VERSION,
+        cache_paths,
+        save_manifest,
+        write_mask,
+    )
+
+    paths = cache_paths(cache_dir)
+    mask_channel = "target_seg" if side == "gt" else "prediction_seg"
+
+    pos_names = [f"A/1/{i}" for i in range(N_POSITIONS)]
+    for pos_name in pos_names:
+        masks = np.zeros((T, D, H, W), dtype=bool)
+        if side == "gt":
+            masks[:, :, : H // 2, :] = True
+        else:
+            masks[:, :, : H // 2, : W // 2] = True
+        write_mask(paths, target_name, pos_name, masks, channel_name=mask_channel)
+
+    source_tag: dict[str, str] = {} if side == "gt" else {"source": "prediction"}
+    now = datetime.now(UTC).isoformat()
+    manifest = {
+        "cache_schema_version": CACHE_SCHEMA_VERSION,
+        "gt" if side == "gt" else "pred": {
+            "plate_path": str(plate_path),
+            "channel_name": channel_name,
+        },
+        "artifacts": {
+            "organelle_masks": {
+                target_name: {
+                    "target_name": target_name,
+                    "path": f"organelle_masks/{target_name}.zarr",
+                    "built_at": now,
+                    "positions": pos_names,
+                    **source_tag,
+                }
+            },
+        },
+    }
+    save_manifest(paths, manifest)
+
+
+def build_eval_config(
+    pred_path: Path,
+    gt_path: Path,
+    gt_cache_dir: Path,
+    pred_cache_dir: Path,
+    save_dir: Path,
+    *,
+    executor: str,
+    fov_workers: int,
+):
+    """Compose a minimal cache-only eval config."""
+    return OmegaConf.create(
+        {
+            "target_name": "er",
+            "io": {
+                "pred_path": str(pred_path),
+                "gt_path": str(gt_path),
+                "pred_channel_name": "prediction",
+                "gt_channel_name": "target",
+                "cell_segmentation_path": None,
+                "gt_cache_dir": str(gt_cache_dir),
+                "pred_cache_dir": str(pred_cache_dir),
+                "require_complete_cache": True,
+            },
+            "pixel_metrics": {
+                "spacing": [1.0, 1.0, 1.0],
+                "fsc": None,
+                "spectral_pcc": None,
+            },
+            "feature_metrics": {
+                "patch_size": 64,
+                "deep_feature_batch_threshold": 256,
+            },
+            "use_gpu": False,
+            "compute_microssim": False,
+            "compute_feature_metrics": False,
+            "limit_positions": None,
+            "force_recompute": {
+                "all": False,
+                "gt_masks": False,
+                "gt_cp": False,
+                "gt_dinov3": False,
+                "gt_dynaclr": False,
+                "gt_celldino": False,
+                "pred_masks": False,
+                "pred_cp": False,
+                "pred_dinov3": False,
+                "pred_dynaclr": False,
+                "pred_celldino": False,
+                "final_metrics": False,
+            },
+            "save": {
+                "save_dir": str(save_dir),
+                "pixel_csv_filename": "pixel_metrics.csv",
+                "pixel_metrics_filename": "pixel_metrics.npy",
+                "mask_csv_filename": "mask_metrics.csv",
+                "mask_metrics_filename": "mask_metrics.npy",
+                "feature_csv_filename": "feature_metrics.csv",
+                "feature_metrics_filename": "feature_metrics.npy",
+            },
+            "runtime": {
+                "fov_workers": fov_workers,
+                "threads_per_worker": "auto",
+                "executor": executor,
+                "cuda_empty_cache_every_n_timepoints": 0,
+                "gc_collect_every_n_fovs": 0,
+            },
+        }
+    )
+
+
+def build_fixture(root: Path):
+    """Build matched pred + GT plates and mask caches under ``root``.
+
+    Returns ``(pred_path, gt_path, gt_cache_dir, pred_cache_dir)``.
+    """
+    pred_path = root / "pred.zarr"
+    gt_path = root / "gt.zarr"
+    gt_cache_dir = root / "gt_cache"
+    pred_cache_dir = root / "pred_cache"
+    make_hcs_plate(pred_path, "prediction", seed=42)
+    make_hcs_plate(gt_path, "target", seed=7)
+    make_mask_cache(gt_cache_dir, gt_path, "target", side="gt")
+    make_mask_cache(pred_cache_dir, pred_path, "prediction", side="pred")
+    return pred_path, gt_path, gt_cache_dir, pred_cache_dir
+
+
+def read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
+    """Return ``{pos_name: data}`` for every position in an HCS plate."""
+    out: dict[str, np.ndarray] = {}
+    with open_ome_zarr(plate_path, mode="r") as plate:
+        for name, pos in plate.positions():
+            out[name] = np.asarray(pos.data[:])
+    return out

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -1,0 +1,306 @@
+"""Parity test for the grouped multi-condition eval driver.
+
+Builds two independent fixtures (each its own pred + GT plates + mask
+caches), runs them once via ``evaluate_predictions_grouped`` and once
+via two back-to-back ``evaluate_predictions`` calls, and asserts the
+outputs are byte-equal per condition.
+
+Cache-only design (same shape as
+``test_evaluation_pipeline_parallel_cpu.py``): ``target_name=er`` +
+``io.require_complete_cache=true`` + ``compute_feature_metrics=false``
+means no segmenter / extractors / cubic are loaded — the test
+validates the **loop structure** of the grouped driver, not the
+model-sharing speedup (which is hermetic-untestable).
+
+Fixture-building helpers live in ``_eval_fixtures.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from omegaconf import OmegaConf
+
+from ._eval_fixtures import (
+    N_POSITIONS,
+    T,
+    build_eval_config,
+    build_fixture,
+    live_pipeline_module,
+    read_position_arrays,
+)
+
+
+def _build_grouped_config(
+    cond_a_root: Path,
+    cond_b_root: Path,
+    save_root: Path,
+):
+    """Construct the grouped config with two condition overlays."""
+    pred_a, gt_a, gt_cache_a, pred_cache_a = build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = build_fixture(cond_b_root)
+
+    base = build_eval_config(
+        pred_a,
+        gt_a,
+        gt_cache_a,
+        pred_cache_a,
+        save_root / "_unused",
+        executor="serial",
+        fov_workers=1,
+    )
+    # Strip the placeholder io/save — conditions own those entirely.
+    base["io"]["pred_path"] = None
+    base["io"]["gt_path"] = None
+    base["io"]["gt_cache_dir"] = None
+    base["io"]["pred_cache_dir"] = None
+    base["save"]["save_dir"] = None
+
+    base["conditions"] = [
+        {
+            "name": "cond_a",
+            "io": {
+                "pred_path": str(pred_a),
+                "gt_path": str(gt_a),
+                "gt_cache_dir": str(gt_cache_a),
+                "pred_cache_dir": str(pred_cache_a),
+            },
+            "save": {"save_dir": str(save_root / "cond_a_grouped")},
+        },
+        {
+            "name": "cond_b",
+            "io": {
+                "pred_path": str(pred_b),
+                "gt_path": str(gt_b),
+                "gt_cache_dir": str(gt_cache_b),
+                "pred_cache_dir": str(pred_cache_b),
+            },
+            "save": {"save_dir": str(save_root / "cond_b_grouped")},
+        },
+    ]
+    return base
+
+
+def test_grouped_matches_sequential_per_condition(tmp_path: Path):
+    """Grouped eval produces byte-equal outputs to sequential per-condition runs."""
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    pred_a, gt_a, gt_cache_a, pred_cache_a = build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = build_fixture(cond_b_root)
+    save_a_seq = save_root / "cond_a_seq"
+    save_b_seq = save_root / "cond_b_seq"
+    save_a_seq.mkdir()
+    save_b_seq.mkdir()
+
+    pipeline = live_pipeline_module()
+    cfg_a_seq = build_eval_config(pred_a, gt_a, gt_cache_a, pred_cache_a, save_a_seq, executor="serial", fov_workers=1)
+    cfg_b_seq = build_eval_config(pred_b, gt_b, gt_cache_b, pred_cache_b, save_b_seq, executor="serial", fov_workers=1)
+    pixel_a_seq, mask_a_seq, _ = pipeline.evaluate_predictions(cfg_a_seq)
+    pixel_b_seq, mask_b_seq, _ = pipeline.evaluate_predictions(cfg_b_seq)
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    pipeline = live_pipeline_module()
+    results = pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+    assert [name for name, _ in results] == ["cond_a", "cond_b"]
+    (_, (pixel_a_grp, mask_a_grp, _)), (_, (pixel_b_grp, mask_b_grp, _)) = results
+
+    def _sort_key(row: dict):
+        return (row["FOV"], row["Timepoint"])
+
+    assert sorted(pixel_a_grp, key=_sort_key) == sorted(pixel_a_seq, key=_sort_key)
+    assert sorted(mask_a_grp, key=_sort_key) == sorted(mask_a_seq, key=_sort_key)
+    assert sorted(pixel_b_grp, key=_sort_key) == sorted(pixel_b_seq, key=_sort_key)
+    assert sorted(mask_b_grp, key=_sort_key) == sorted(mask_b_seq, key=_sort_key)
+
+    for cond_name, save_seq, save_grp in [
+        ("cond_a", save_a_seq, save_root / "cond_a_grouped"),
+        ("cond_b", save_b_seq, save_root / "cond_b_grouped"),
+    ]:
+        arrs_seq = read_position_arrays(save_seq / "segmentation_results.zarr")
+        arrs_grp = read_position_arrays(save_grp / "segmentation_results.zarr")
+        assert set(arrs_seq.keys()) == set(arrs_grp.keys()), f"{cond_name} position set mismatch"
+        for pos_name, arr_seq in arrs_seq.items():
+            np.testing.assert_array_equal(arr_seq, arrs_grp[pos_name], err_msg=f"{cond_name}/{pos_name}")
+
+    assert len(pixel_a_grp) == N_POSITIONS * T
+    assert len(pixel_b_grp) == N_POSITIONS * T
+
+
+def test_grouped_rejects_model_loading_field_overrides(tmp_path: Path):
+    """Per-condition overrides on model-loading fields must raise — including condition 0."""
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    # Sabotage condition B's target_name.
+    grouped_cfg["conditions"][1]["target_name"] = "membrane"
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="model-loading field"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_rejects_condition0_model_field_override(tmp_path: Path):
+    """A model-loading override smuggled into condition 0 must raise, not silently re-baseline.
+
+    Earlier wiring used ``conditions[0]``-merged config as the invariant
+    baseline, which would have made condition 0 implicitly trusted to
+    redefine ``target_name`` / ``feature_extractor.*`` etc. Guards
+    against regression of that asymmetry.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"][0]["target_name"] = "membrane"
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="model-loading field"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_warns_loudly_on_process_plus_cache_miss(tmp_path: Path, capsys):
+    """``executor=process`` + multiple conditions + cache-miss prints a loud WARNING.
+
+    This combination is the worst case for amortization: each
+    condition's worker pool independently re-loads SuperModel + the
+    three deep extractors, so cold-start cost multiplies by
+    ``N_workers × N_conditions``. The driver should warn the user
+    upfront and recommend ``executor=serial``.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["runtime"]["executor"] = "process"
+    grouped_cfg["runtime"]["fov_workers"] = 2
+    grouped_cfg["io"]["require_complete_cache"] = False
+
+    # The grouped driver prints the warning before iterating conditions.
+    # The eval will then fail/succeed depending on cache state; we don't
+    # care — we just want the warning text in stdout.
+    pipeline = live_pipeline_module()
+    try:
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+    except Exception:
+        pass
+
+    out = capsys.readouterr().out
+    assert "WARNING" in out, f"expected loud warning, got: {out!r}"
+    assert "executor=process" in out
+    assert "require_complete_cache=false" in out
+    assert "executor=serial" in out
+
+
+def test_grouped_mild_note_on_process_plus_cache_only(tmp_path: Path, capsys):
+    """``executor=process`` + ``require_complete_cache=true`` gets a mild note, not the loud WARNING.
+
+    Under the cache-only path, workers skip ``prepare_segmentation_model``
+    and don't instantiate extractors — pool re-spawn is the only
+    overhead, which is small. The driver should inform but not alarm.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["runtime"]["executor"] = "process"
+    grouped_cfg["runtime"]["fov_workers"] = 2
+    # require_complete_cache stays True from the cache-only fixture.
+
+    pipeline = live_pipeline_module()
+    pipeline.evaluate_predictions_grouped(grouped_cfg)
+    out = capsys.readouterr().out
+    assert "[grouped] note:" in out
+    assert "no models actually load" in out
+    assert "WARNING" not in out, f"unexpected loud warning under cache-only path: {out!r}"
+
+
+def test_grouped_rejects_require_complete_cache_override(tmp_path: Path):
+    """``io.require_complete_cache`` is a grouped invariant — overrides must raise.
+
+    The base config's ``io.require_complete_cache`` determines whether
+    ``load_eval_models`` instantiates a real ``SuperModel`` or returns
+    ``None``. Letting a condition flip this would mean the shared models
+    bundle disagrees with the condition's actual needs (None when
+    cache-miss expects a real segmenter, or loaded but never used). Guard
+    by treating it as a model-loading invariant.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"][1]["io"]["require_complete_cache"] = False
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="require_complete_cache"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_works_on_struct_mode_config(tmp_path: Path):
+    """Grouped driver must work on Hydra-composed (struct-mode) configs.
+
+    Real ``dynacell evaluate-grouped`` invocations go through
+    ``@hydra.main`` which always produces a struct-mode ``DictConfig``.
+    ``OmegaConf.merge`` propagates struct mode, so merging an overlay
+    carrying a ``name`` label (outside the schema) raises
+    ``ConfigKeyError``, and stripping ``conditions`` / ``name`` with
+    ``del`` raises ``ConfigTypeError``. The driver must escape struct
+    mode internally; this test guards against regression.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    OmegaConf.set_struct(grouped_cfg, True)
+
+    pipeline = live_pipeline_module()
+    results = pipeline.evaluate_predictions_grouped(grouped_cfg)
+    assert [name for name, _ in results] == ["cond_a", "cond_b"]
+
+
+def test_grouped_rejects_empty_conditions(tmp_path: Path):
+    """Missing or empty 'conditions' list must raise an informative error."""
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"] = []
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="non-empty"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -215,9 +215,10 @@ def test_grouped_warns_loudly_on_process_plus_cache_miss(tmp_path: Path, capsys)
 def test_grouped_mild_note_on_process_plus_cache_only(tmp_path: Path, capsys):
     """``executor=process`` + ``require_complete_cache=true`` gets a mild note, not the loud WARNING.
 
-    Under the cache-only path, workers skip ``prepare_segmentation_model``
-    and don't instantiate extractors — pool re-spawn is the only
-    overhead, which is small. The driver should inform but not alarm.
+    Under the cache-only path the segmenter is usually skipped (the
+    deep extractors still load when ``compute_feature_metrics=true``,
+    so the cost isn't strictly zero — but it's bounded). The driver
+    should inform but not alarm.
     """
     cond_a_root = tmp_path / "fixture_a"
     cond_b_root = tmp_path / "fixture_b"
@@ -235,7 +236,7 @@ def test_grouped_mild_note_on_process_plus_cache_only(tmp_path: Path, capsys):
     pipeline.evaluate_predictions_grouped(grouped_cfg)
     out = capsys.readouterr().out
     assert "[grouped] note:" in out
-    assert "no models actually load" in out
+    assert "segmenter usually skipped" in out
     assert "WARNING" not in out, f"unexpected loud warning under cache-only path: {out!r}"
 
 
@@ -261,6 +262,39 @@ def test_grouped_rejects_require_complete_cache_override(tmp_path: Path):
 
     pipeline = live_pipeline_module()
     with pytest.raises(ValueError, match="require_complete_cache"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_rejects_pred_cache_dir_flip_for_nucleus(tmp_path: Path):
+    """A per-condition ``io.pred_cache_dir=None`` flip must raise for nucleus/membrane.
+
+    Under ``target_name ∈ {nucleus, membrane}`` + ``require_complete_cache=true``,
+    ``prepare_segmentation_model`` returns ``None`` when ``io.pred_cache_dir``
+    is set (pred masks served from cache) but loads ``SuperModel`` when
+    ``io.pred_cache_dir is None`` (per-T loop falls back to
+    ``segment(predict[t], seg_model=...)``). If the base config has
+    ``pred_cache_dir`` set so the shared bundle skips SuperModel, but a
+    condition overrides ``pred_cache_dir=None``, the per-T loop in that
+    condition would call ``segment(...)`` with ``seg_model=None`` and crash.
+    The grouped driver must catch this dangerous-direction flip pre-eval.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["target_name"] = "nucleus"
+    # Force the dangerous direction: base has pred_cache_dir set (so the
+    # baseline doesn't load SuperModel), then cond_a flips it to None
+    # (which would crash at runtime as ``segment(predict[t], seg_model=None)``).
+    grouped_cfg["io"]["pred_cache_dir"] = str(cond_a_root / "_unused_base_pred_cache")
+    grouped_cfg["conditions"][0]["io"]["pred_cache_dir"] = None
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="pred_cache_dir"):
         pipeline.evaluate_predictions_grouped(grouped_cfg)
 
 

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel.py
@@ -211,6 +211,7 @@ def test_aggregate_fov_result_extends_24_accumulators():
         gt_celldino_feats,
         gt_celldino_fovs,
         gt_celldino_ts,
+        extend_worker_timings=True,
     )
 
     assert len(all_pix) == 2

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel.py
@@ -1,0 +1,228 @@
+"""Worker-side and aggregator-side smoke tests for the FOV parallelism wiring.
+
+These tests cover the cross-process boundary in two pieces:
+
+1. ``FovResult`` survives ``pickle`` round-trip with realistic
+   shapes (the ``concurrent.futures.ProcessPoolExecutor`` future-result
+   transport uses pickle).
+2. ``_aggregate_fov_result`` correctly extends the parent's 24
+   dataset-level accumulator lists from a synthetic FovResult, preserving
+   the existing ``if size > 0: append`` semantics that the worker
+   internally maintains.
+
+End-to-end serial/process parity on a real eval (with iohub fixtures and
+prebuilt mask caches) is a follow-up CPU integration test — see the plan
+``.claude/plans/eval-parallelism.md`` C5 section.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pickle
+
+import numpy as np
+
+
+def _live_pipeline_module():
+    """Return the *currently cached* dynacell.evaluation.pipeline module.
+
+    Other tests in the suite (notably ``test_evaluation_pipeline.py``)
+    use ``monkeypatch.setitem(sys.modules, ...)`` to swap the pipeline
+    module with a stubbed re-import. After teardown, ``sys.modules`` is
+    restored but any class references resolved at our module's import
+    time still point at the *stubbed* re-import — pickle then fails with
+    ``"it's not the same object as dynacell.evaluation.pipeline.FovResult"``.
+    Resolving lazily inside each test avoids the stale binding.
+    """
+    return importlib.import_module("dynacell.evaluation.pipeline")
+
+
+def _make_synthetic_result(
+    pos_name: str = "A/1/0",
+    t_count: int = 2,
+    d: int = 4,
+    h: int = 16,
+    w: int = 16,
+    cp_dim: int = 8,
+    deep_dim: int = 768,
+    cells_per_t: int = 3,
+):
+    """Build a FovResult with realistic shapes for round-trip testing."""
+    pipeline = _live_pipeline_module()
+    FovResult = pipeline.FovResult
+    _BackboneLists = pipeline._BackboneLists
+    row, col, fov = pos_name.split("/")
+    per_t_pixel = [{"FOV": pos_name, "Timepoint": t, "PCC": 0.9 + 0.01 * t, "MicroMS3IM": 0.85} for t in range(t_count)]
+    per_t_mask = [{"FOV": pos_name, "Timepoint": t, "DICE": 0.7 + 0.01 * t} for t in range(t_count)]
+    per_t_feat = [{"FOV": pos_name, "Timepoint": t, "CP_cos": 0.8, "DINOv3_cos": 0.95} for t in range(t_count)]
+    seg_array = np.zeros((t_count, 2, d, h, w), dtype=bool)
+    seg_array[:, 0, :, : h // 2, :] = True  # pred channel
+    seg_array[:, 1, :, : h // 2, : w // 2] = True  # gt channel
+
+    cp = _BackboneLists()
+    dinov3 = _BackboneLists()
+    dynaclr = _BackboneLists()
+    celldino = _BackboneLists()
+    for t in range(t_count):
+        fov_arr = np.full(cells_per_t, pos_name)
+        t_arr = np.full(cells_per_t, t, dtype=np.int32)
+        cp.pred_feats.append(np.full((cells_per_t, cp_dim), float(t), dtype=np.float32))
+        cp.gt_feats.append(np.full((cells_per_t, cp_dim), float(t) + 0.5, dtype=np.float32))
+        cp.pred_fovs.append(fov_arr)
+        cp.gt_fovs.append(fov_arr)
+        cp.pred_ts.append(t_arr)
+        cp.gt_ts.append(t_arr)
+        for bl in (dinov3, dynaclr, celldino):
+            bl.pred_feats.append(np.full((cells_per_t, deep_dim), float(t), dtype=np.float32))
+            bl.gt_feats.append(np.full((cells_per_t, deep_dim), float(t) + 0.5, dtype=np.float32))
+            bl.pred_fovs.append(fov_arr)
+            bl.gt_fovs.append(fov_arr)
+            bl.pred_ts.append(t_arr)
+            bl.gt_ts.append(t_arr)
+
+    return FovResult(
+        pos_name=pos_name,
+        row=row,
+        col=col,
+        fov=fov,
+        per_t_pixel_rows=per_t_pixel,
+        per_t_mask_rows=per_t_mask,
+        per_t_feature_rows=per_t_feat,
+        seg_array=seg_array,
+        cp=cp,
+        dinov3=dinov3,
+        dynaclr=dynaclr,
+        celldino=celldino,
+        timings=[(pos_name, None, "mask_gt", 0.05), (pos_name, 0, "pixel_metrics", 0.02)],
+    )
+
+
+def test_fov_result_pickle_round_trip_preserves_arrays():
+    result = _make_synthetic_result()
+    restored = pickle.loads(pickle.dumps(result))
+    assert restored.pos_name == result.pos_name
+    assert restored.row == "A"
+    assert restored.col == "1"
+    assert restored.fov == "0"
+    assert restored.seg_array.shape == result.seg_array.shape
+    assert restored.seg_array.dtype == np.bool_
+    assert np.array_equal(restored.seg_array, result.seg_array)
+    for backbone_attr in ("cp", "dinov3", "dynaclr", "celldino"):
+        original = getattr(result, backbone_attr)
+        restored_bb = getattr(restored, backbone_attr)
+        for list_name in ("pred_feats", "gt_feats", "pred_fovs", "gt_fovs", "pred_ts", "gt_ts"):
+            for a, b in zip(getattr(original, list_name), getattr(restored_bb, list_name)):
+                assert np.array_equal(a, b)
+    assert restored.per_t_pixel_rows == result.per_t_pixel_rows
+    assert restored.timings == result.timings
+
+
+def test_fov_result_pickle_handles_empty_backbones():
+    """An empty _BackboneLists round-trips correctly (no len-zero -> None coercion)."""
+    result = _make_synthetic_result()
+    # Wipe one backbone to simulate "feature_metrics disabled" / "zero cells".
+    result.celldino.pred_feats.clear()
+    result.celldino.gt_feats.clear()
+    result.celldino.pred_fovs.clear()
+    result.celldino.gt_fovs.clear()
+    result.celldino.pred_ts.clear()
+    result.celldino.gt_ts.clear()
+    restored = pickle.loads(pickle.dumps(result))
+    assert restored.celldino.pred_feats == []
+    assert restored.celldino.gt_feats == []
+
+
+def test_aggregate_fov_result_extends_24_accumulators():
+    """Aggregator must extend each backbone's 6 lists with worker contributions."""
+    pipeline = _live_pipeline_module()
+    _aggregate_fov_result = pipeline._aggregate_fov_result
+    # Mock segmentation_results plate handle (only create_position is exercised).
+    written = {}
+
+    class _FakeSegPos:
+        def create_image(self, name, data):
+            written[(row_, col_, fov_, name)] = np.asarray(data)
+
+    class _FakeSegPlate:
+        def create_position(self, row, col, fov):
+            nonlocal row_, col_, fov_
+            row_, col_, fov_ = row, col, fov
+            return _FakeSegPos()
+
+    row_ = col_ = fov_ = None
+
+    result = _make_synthetic_result()
+
+    all_pix: list[dict] = []
+    all_mask: list[dict] = []
+    all_feat: list[dict] = []
+    pred_cp_feats: list = []
+    pred_cp_fovs: list = []
+    pred_cp_ts: list = []
+    gt_cp_feats: list = []
+    gt_cp_fovs: list = []
+    gt_cp_ts: list = []
+    pred_dinov3_feats: list = []
+    pred_dinov3_fovs: list = []
+    pred_dinov3_ts: list = []
+    gt_dinov3_feats: list = []
+    gt_dinov3_fovs: list = []
+    gt_dinov3_ts: list = []
+    pred_dynaclr_feats: list = []
+    pred_dynaclr_fovs: list = []
+    pred_dynaclr_ts: list = []
+    gt_dynaclr_feats: list = []
+    gt_dynaclr_fovs: list = []
+    gt_dynaclr_ts: list = []
+    pred_celldino_feats: list = []
+    pred_celldino_fovs: list = []
+    pred_celldino_ts: list = []
+    gt_celldino_feats: list = []
+    gt_celldino_fovs: list = []
+    gt_celldino_ts: list = []
+
+    _aggregate_fov_result(
+        result,
+        _FakeSegPlate(),
+        all_pix,
+        all_mask,
+        all_feat,
+        pred_cp_feats,
+        pred_cp_fovs,
+        pred_cp_ts,
+        gt_cp_feats,
+        gt_cp_fovs,
+        gt_cp_ts,
+        pred_dinov3_feats,
+        pred_dinov3_fovs,
+        pred_dinov3_ts,
+        gt_dinov3_feats,
+        gt_dinov3_fovs,
+        gt_dinov3_ts,
+        pred_dynaclr_feats,
+        pred_dynaclr_fovs,
+        pred_dynaclr_ts,
+        gt_dynaclr_feats,
+        gt_dynaclr_fovs,
+        gt_dynaclr_ts,
+        pred_celldino_feats,
+        pred_celldino_fovs,
+        pred_celldino_ts,
+        gt_celldino_feats,
+        gt_celldino_fovs,
+        gt_celldino_ts,
+    )
+
+    assert len(all_pix) == 2
+    assert len(all_mask) == 2
+    assert len(all_feat) == 2
+    assert (row_, col_, fov_) == ("A", "1", "0")
+    assert written[("A", "1", "0", "0")].shape == result.seg_array.shape
+    # Each backbone contributes 2 entries (one per timepoint).
+    for lst in (
+        pred_cp_feats,
+        pred_dinov3_feats,
+        pred_dynaclr_feats,
+        pred_celldino_feats,
+    ):
+        assert len(lst) == 2

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
@@ -1,0 +1,318 @@
+"""End-to-end CPU integration test for serial-vs-process executor parity.
+
+Drives ``evaluate_predictions`` twice on the same tiny iohub fixture +
+prebuilt mask caches: once with ``runtime.executor=serial``, once with
+``runtime.executor=process runtime.fov_workers=2``. Asserts byte-equal
+CSV outputs (after sort by FOV) and per-position equality of the
+``segmentation_results.zarr`` HCS plate.
+
+Cache-only design (matches plan ``.claude/plans/eval-parallelism.md`` §C5):
+
+- ``target_name=er`` → ``prepare_segmentation_model`` returns None.
+- ``io.require_complete_cache=true`` → mask cache MUST satisfy every
+  request; we pre-populate the cache before the run.
+- ``compute_feature_metrics=false``, ``compute_microssim=false`` → no
+  extractors load, no microssim.
+- ``pixel_metrics.fsc=null`` and ``pixel_metrics.spectral_pcc=null`` →
+  ``compute_pixel_metrics`` only runs the torch metric block (PCC,
+  SSIM, NRMSE, PSNR), no cubic FFT path.
+
+Result: the full pipeline runs without instantiating cellpose,
+SuperModel, DinoV3, DynaCLR, CellDino, or cubic — exercises spawn
+boot, DictConfig pickling, ``FovResult`` transport, parent-side HCS
+plate write, and the dataset-level aggregation contract.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest  # noqa: F401  -- imported for future @pytest.mark uses
+from iohub.ngff import open_ome_zarr
+from omegaconf import OmegaConf
+
+
+def _live_pipeline_module():
+    """Force-import a fresh ``dynacell.evaluation.pipeline`` module.
+
+    Other tests (``test_evaluation_pipeline.py``) stub
+    ``dynacell.evaluation.metrics`` etc. via ``monkeypatch.setitem(sys.modules,
+    ...)``. After teardown, ``sys.modules`` may still hold the stubbed modules
+    AND the pipeline module's bound ``compute_pixel_metrics`` reference. Clear
+    every ``dynacell.evaluation.*`` cache entry before re-import so we get
+    fresh modules with real implementations.
+    """
+    for name in list(sys.modules):
+        if name.startswith("dynacell.evaluation"):
+            sys.modules.pop(name, None)
+    return importlib.import_module("dynacell.evaluation.pipeline")
+
+
+# Fixture dimensions — kept tiny so the test runs in CI (single-CPU) under ~30s.
+N_POSITIONS = 3
+T = 2
+D = 4
+H = 32
+W = 32
+
+
+def _make_hcs_plate(path: Path, channel_name: str, seed: int) -> None:
+    """Create a tiny HCS plate with ``N_POSITIONS`` positions of shape ``(T, 1, D, H, W)``.
+
+    Positions are named ``A/1/{i}`` for ``i in range(N_POSITIONS)``. Pixel
+    values are deterministic from ``seed`` so pred and GT differ predictably.
+    """
+    rng = np.random.default_rng(seed)
+    with open_ome_zarr(path, mode="w", layout="hcs", channel_names=[channel_name], version="0.5") as plate:
+        for i in range(N_POSITIONS):
+            pos = plate.create_position("A", "1", str(i))
+            data = rng.uniform(0.0, 1.0, size=(T, 1, D, H, W)).astype(np.float32)
+            pos.create_image("0", data)
+
+
+def _make_mask_cache(
+    cache_dir: Path,
+    plate_path: Path,
+    channel_name: str,
+    side: str,  # "gt" or "pred"
+    target_name: str = "er",
+) -> None:
+    """Prebuild a mask cache (zarr + manifest) for ``N_POSITIONS`` positions.
+
+    The mask values themselves are deterministic per (side, position, t):
+    GT masks are TRUE in the upper half of the (H, W) plane; pred masks
+    are TRUE in the upper quadrant. This guarantees the DICE / IoU
+    metrics are deterministic and non-trivially different between sides.
+    """
+    from dynacell.evaluation.cache import (
+        CACHE_SCHEMA_VERSION,
+        cache_paths,
+        save_manifest,
+        write_mask,
+    )
+
+    paths = cache_paths(cache_dir)
+    mask_channel = "target_seg" if side == "gt" else "prediction_seg"
+
+    pos_names = [f"A/1/{i}" for i in range(N_POSITIONS)]
+    for pos_name in pos_names:
+        masks = np.zeros((T, D, H, W), dtype=bool)
+        if side == "gt":
+            masks[:, :, : H // 2, :] = True  # upper half
+        else:
+            masks[:, :, : H // 2, : W // 2] = True  # upper quadrant
+        write_mask(paths, target_name, pos_name, masks, channel_name=mask_channel)
+
+    # Manifest entries must satisfy _validate_artifact_params: the
+    # masks_section.get(target_name) must equal {"target_name": ..., **source_tag}.
+    source_tag: dict[str, str] = {} if side == "gt" else {"source": "prediction"}
+    now = datetime.now(UTC).isoformat()
+    manifest = {
+        "cache_schema_version": CACHE_SCHEMA_VERSION,
+        "gt" if side == "gt" else "pred": {
+            "plate_path": str(plate_path),
+            "channel_name": channel_name,
+        },
+        "artifacts": {
+            "organelle_masks": {
+                target_name: {
+                    "target_name": target_name,
+                    "path": f"organelle_masks/{target_name}.zarr",
+                    "built_at": now,
+                    "positions": pos_names,
+                    **source_tag,
+                }
+            },
+        },
+    }
+    save_manifest(paths, manifest)
+
+
+def _build_eval_config(
+    pred_path: Path,
+    gt_path: Path,
+    gt_cache_dir: Path,
+    pred_cache_dir: Path,
+    save_dir: Path,
+    *,
+    executor: str,
+    fov_workers: int,
+):
+    """Compose a minimal eval config for the cache-only path."""
+    return OmegaConf.create(
+        {
+            "target_name": "er",
+            "io": {
+                "pred_path": str(pred_path),
+                "gt_path": str(gt_path),
+                "pred_channel_name": "prediction",
+                "gt_channel_name": "target",
+                "cell_segmentation_path": None,
+                "gt_cache_dir": str(gt_cache_dir),
+                "pred_cache_dir": str(pred_cache_dir),
+                "require_complete_cache": True,
+            },
+            "pixel_metrics": {
+                "spacing": [1.0, 1.0, 1.0],
+                "fsc": None,
+                "spectral_pcc": None,
+            },
+            "feature_metrics": {
+                "patch_size": 64,
+                "deep_feature_batch_threshold": 256,
+            },
+            "use_gpu": False,
+            "compute_microssim": False,
+            "compute_feature_metrics": False,
+            "limit_positions": None,
+            "force_recompute": {
+                "all": False,
+                "gt_masks": False,
+                "gt_cp": False,
+                "gt_dinov3": False,
+                "gt_dynaclr": False,
+                "gt_celldino": False,
+                "pred_masks": False,
+                "pred_cp": False,
+                "pred_dinov3": False,
+                "pred_dynaclr": False,
+                "pred_celldino": False,
+                "final_metrics": False,
+            },
+            "save": {
+                "save_dir": str(save_dir),
+                "pixel_csv_filename": "pixel_metrics.csv",
+                "pixel_metrics_filename": "pixel_metrics.npy",
+                "mask_csv_filename": "mask_metrics.csv",
+                "mask_metrics_filename": "mask_metrics.npy",
+                "feature_csv_filename": "feature_metrics.csv",
+                "feature_metrics_filename": "feature_metrics.npy",
+            },
+            "runtime": {
+                "fov_workers": fov_workers,
+                "threads_per_worker": "auto",
+                "executor": executor,
+                "cuda_empty_cache_every_n_timepoints": 0,
+                "gc_collect_every_n_fovs": 0,
+            },
+        }
+    )
+
+
+def _build_fixture(root: Path):
+    """Build pred + GT plates and matching mask caches under ``root``."""
+    pred_path = root / "pred.zarr"
+    gt_path = root / "gt.zarr"
+    gt_cache_dir = root / "gt_cache"
+    pred_cache_dir = root / "pred_cache"
+    _make_hcs_plate(pred_path, "prediction", seed=42)
+    _make_hcs_plate(gt_path, "target", seed=7)
+    _make_mask_cache(gt_cache_dir, gt_path, "target", side="gt")
+    _make_mask_cache(pred_cache_dir, pred_path, "prediction", side="pred")
+    return pred_path, gt_path, gt_cache_dir, pred_cache_dir
+
+
+def _read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
+    """Return ``{pos_name: data}`` for every position in an HCS plate."""
+    out: dict[str, np.ndarray] = {}
+    with open_ome_zarr(plate_path, mode="r") as plate:
+        for name, pos in plate.positions():
+            out[name] = np.asarray(pos.data[:])
+    return out
+
+
+def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
+    """End-to-end: serial-mode and process-mode produce byte-equal outputs.
+
+    Exercises the spawn boundary (pickling, worker startup, _process_one_fov
+    in workers, FovResult transport, parent-side aggregation + HCS plate
+    write) without invoking cellpose / extractors / cubic.
+    """
+    fixture_root = tmp_path / "fixture"
+    fixture_root.mkdir()
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+
+    save_dir_serial = tmp_path / "serial"
+    save_dir_process = tmp_path / "process"
+
+    # Re-import inside the test body — test_lazy_init.py pops dynacell.*
+    # modules from sys.modules, which would invalidate a module-level import.
+    pipeline = _live_pipeline_module()
+    evaluate_predictions = pipeline.evaluate_predictions
+
+    cfg_serial = _build_eval_config(
+        pred_path,
+        gt_path,
+        gt_cache_dir,
+        pred_cache_dir,
+        save_dir_serial,
+        executor="serial",
+        fov_workers=1,
+    )
+    cfg_process = _build_eval_config(
+        pred_path,
+        gt_path,
+        gt_cache_dir,
+        pred_cache_dir,
+        save_dir_process,
+        executor="process",
+        fov_workers=2,
+    )
+
+    save_dir_serial.mkdir(parents=True)
+    save_dir_process.mkdir(parents=True)
+
+    pixel_serial, mask_serial, _ = evaluate_predictions(cfg_serial)
+    pixel_process, mask_process, _ = evaluate_predictions(cfg_process)
+
+    # Pixel + mask rows: same set after sort. We sort by (FOV, Timepoint)
+    # because the process branch already sorts by pos_name and within-FOV
+    # iteration is deterministic, but we sort defensively.
+    def _sort_key(row: dict):
+        return (row["FOV"], row["Timepoint"])
+
+    assert sorted(pixel_serial, key=_sort_key) == sorted(pixel_process, key=_sort_key)
+    assert sorted(mask_serial, key=_sort_key) == sorted(mask_process, key=_sort_key)
+    # Per-position seg plate equality (both channels).
+    arrs_serial = _read_position_arrays(save_dir_serial / "segmentation_results.zarr")
+    arrs_process = _read_position_arrays(save_dir_process / "segmentation_results.zarr")
+    assert set(arrs_serial.keys()) == set(arrs_process.keys())
+    for pos_name, arr_a in arrs_serial.items():
+        arr_b = arrs_process[pos_name]
+        assert arr_a.shape == arr_b.shape, f"{pos_name} shape mismatch"
+        np.testing.assert_array_equal(arr_a, arr_b)
+
+
+def test_serial_path_runs_without_segmenter_loaded(tmp_path: Path):
+    """``require_complete_cache=true`` should skip ``prepare_segmentation_model``.
+
+    Confirms the cache-only fast-path: evaluate_predictions runs end-to-end
+    without ever instantiating SuperModel (which would trigger a quilt
+    download on a cold node).
+    """
+    fixture_root = tmp_path / "fixture"
+    fixture_root.mkdir()
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+    save_dir = tmp_path / "out"
+    save_dir.mkdir()
+
+    cfg = _build_eval_config(
+        pred_path,
+        gt_path,
+        gt_cache_dir,
+        pred_cache_dir,
+        save_dir,
+        executor="serial",
+        fov_workers=1,
+    )
+    pipeline = _live_pipeline_module()
+    pixel_rows, mask_rows, _ = pipeline.evaluate_predictions(cfg)
+    assert len(pixel_rows) == N_POSITIONS * T
+    assert len(mask_rows) == N_POSITIONS * T
+    # Confirms the no-segmenter contract: prepare_segmentation_model
+    # returned None and evaluate_predictions still produced valid outputs
+    # for every (FOV, t) pair.

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
@@ -21,208 +21,25 @@ Result: the full pipeline runs without instantiating cellpose,
 SuperModel, DinoV3, DynaCLR, CellDino, or cubic — exercises spawn
 boot, DictConfig pickling, ``FovResult`` transport, parent-side HCS
 plate write, and the dataset-level aggregation contract.
+
+Fixture-building helpers live in ``_eval_fixtures.py`` (shared with
+``test_evaluation_grouped.py``).
 """
 
 from __future__ import annotations
 
-import importlib
-import sys
-from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
-import pytest  # noqa: F401  -- imported for future @pytest.mark uses
-from iohub.ngff import open_ome_zarr
-from omegaconf import OmegaConf
 
-
-def _live_pipeline_module():
-    """Force-import a fresh ``dynacell.evaluation.pipeline`` module.
-
-    Other tests (``test_evaluation_pipeline.py``) stub
-    ``dynacell.evaluation.metrics`` etc. via ``monkeypatch.setitem(sys.modules,
-    ...)``. After teardown, ``sys.modules`` may still hold the stubbed modules
-    AND the pipeline module's bound ``compute_pixel_metrics`` reference. Clear
-    every ``dynacell.evaluation.*`` cache entry before re-import so we get
-    fresh modules with real implementations.
-    """
-    for name in list(sys.modules):
-        if name.startswith("dynacell.evaluation"):
-            sys.modules.pop(name, None)
-    return importlib.import_module("dynacell.evaluation.pipeline")
-
-
-# Fixture dimensions — kept tiny so the test runs in CI (single-CPU) under ~30s.
-N_POSITIONS = 3
-T = 2
-D = 4
-H = 32
-W = 32
-
-
-def _make_hcs_plate(path: Path, channel_name: str, seed: int) -> None:
-    """Create a tiny HCS plate with ``N_POSITIONS`` positions of shape ``(T, 1, D, H, W)``.
-
-    Positions are named ``A/1/{i}`` for ``i in range(N_POSITIONS)``. Pixel
-    values are deterministic from ``seed`` so pred and GT differ predictably.
-    """
-    rng = np.random.default_rng(seed)
-    with open_ome_zarr(path, mode="w", layout="hcs", channel_names=[channel_name], version="0.5") as plate:
-        for i in range(N_POSITIONS):
-            pos = plate.create_position("A", "1", str(i))
-            data = rng.uniform(0.0, 1.0, size=(T, 1, D, H, W)).astype(np.float32)
-            pos.create_image("0", data)
-
-
-def _make_mask_cache(
-    cache_dir: Path,
-    plate_path: Path,
-    channel_name: str,
-    side: str,  # "gt" or "pred"
-    target_name: str = "er",
-) -> None:
-    """Prebuild a mask cache (zarr + manifest) for ``N_POSITIONS`` positions.
-
-    The mask values themselves are deterministic per (side, position, t):
-    GT masks are TRUE in the upper half of the (H, W) plane; pred masks
-    are TRUE in the upper quadrant. This guarantees the DICE / IoU
-    metrics are deterministic and non-trivially different between sides.
-    """
-    from dynacell.evaluation.cache import (
-        CACHE_SCHEMA_VERSION,
-        cache_paths,
-        save_manifest,
-        write_mask,
-    )
-
-    paths = cache_paths(cache_dir)
-    mask_channel = "target_seg" if side == "gt" else "prediction_seg"
-
-    pos_names = [f"A/1/{i}" for i in range(N_POSITIONS)]
-    for pos_name in pos_names:
-        masks = np.zeros((T, D, H, W), dtype=bool)
-        if side == "gt":
-            masks[:, :, : H // 2, :] = True  # upper half
-        else:
-            masks[:, :, : H // 2, : W // 2] = True  # upper quadrant
-        write_mask(paths, target_name, pos_name, masks, channel_name=mask_channel)
-
-    # Manifest entries must satisfy _validate_artifact_params: the
-    # masks_section.get(target_name) must equal {"target_name": ..., **source_tag}.
-    source_tag: dict[str, str] = {} if side == "gt" else {"source": "prediction"}
-    now = datetime.now(UTC).isoformat()
-    manifest = {
-        "cache_schema_version": CACHE_SCHEMA_VERSION,
-        "gt" if side == "gt" else "pred": {
-            "plate_path": str(plate_path),
-            "channel_name": channel_name,
-        },
-        "artifacts": {
-            "organelle_masks": {
-                target_name: {
-                    "target_name": target_name,
-                    "path": f"organelle_masks/{target_name}.zarr",
-                    "built_at": now,
-                    "positions": pos_names,
-                    **source_tag,
-                }
-            },
-        },
-    }
-    save_manifest(paths, manifest)
-
-
-def _build_eval_config(
-    pred_path: Path,
-    gt_path: Path,
-    gt_cache_dir: Path,
-    pred_cache_dir: Path,
-    save_dir: Path,
-    *,
-    executor: str,
-    fov_workers: int,
-):
-    """Compose a minimal eval config for the cache-only path."""
-    return OmegaConf.create(
-        {
-            "target_name": "er",
-            "io": {
-                "pred_path": str(pred_path),
-                "gt_path": str(gt_path),
-                "pred_channel_name": "prediction",
-                "gt_channel_name": "target",
-                "cell_segmentation_path": None,
-                "gt_cache_dir": str(gt_cache_dir),
-                "pred_cache_dir": str(pred_cache_dir),
-                "require_complete_cache": True,
-            },
-            "pixel_metrics": {
-                "spacing": [1.0, 1.0, 1.0],
-                "fsc": None,
-                "spectral_pcc": None,
-            },
-            "feature_metrics": {
-                "patch_size": 64,
-                "deep_feature_batch_threshold": 256,
-            },
-            "use_gpu": False,
-            "compute_microssim": False,
-            "compute_feature_metrics": False,
-            "limit_positions": None,
-            "force_recompute": {
-                "all": False,
-                "gt_masks": False,
-                "gt_cp": False,
-                "gt_dinov3": False,
-                "gt_dynaclr": False,
-                "gt_celldino": False,
-                "pred_masks": False,
-                "pred_cp": False,
-                "pred_dinov3": False,
-                "pred_dynaclr": False,
-                "pred_celldino": False,
-                "final_metrics": False,
-            },
-            "save": {
-                "save_dir": str(save_dir),
-                "pixel_csv_filename": "pixel_metrics.csv",
-                "pixel_metrics_filename": "pixel_metrics.npy",
-                "mask_csv_filename": "mask_metrics.csv",
-                "mask_metrics_filename": "mask_metrics.npy",
-                "feature_csv_filename": "feature_metrics.csv",
-                "feature_metrics_filename": "feature_metrics.npy",
-            },
-            "runtime": {
-                "fov_workers": fov_workers,
-                "threads_per_worker": "auto",
-                "executor": executor,
-                "cuda_empty_cache_every_n_timepoints": 0,
-                "gc_collect_every_n_fovs": 0,
-            },
-        }
-    )
-
-
-def _build_fixture(root: Path):
-    """Build pred + GT plates and matching mask caches under ``root``."""
-    pred_path = root / "pred.zarr"
-    gt_path = root / "gt.zarr"
-    gt_cache_dir = root / "gt_cache"
-    pred_cache_dir = root / "pred_cache"
-    _make_hcs_plate(pred_path, "prediction", seed=42)
-    _make_hcs_plate(gt_path, "target", seed=7)
-    _make_mask_cache(gt_cache_dir, gt_path, "target", side="gt")
-    _make_mask_cache(pred_cache_dir, pred_path, "prediction", side="pred")
-    return pred_path, gt_path, gt_cache_dir, pred_cache_dir
-
-
-def _read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
-    """Return ``{pos_name: data}`` for every position in an HCS plate."""
-    out: dict[str, np.ndarray] = {}
-    with open_ome_zarr(plate_path, mode="r") as plate:
-        for name, pos in plate.positions():
-            out[name] = np.asarray(pos.data[:])
-    return out
+from ._eval_fixtures import (
+    N_POSITIONS,
+    T,
+    build_eval_config,
+    build_fixture,
+    live_pipeline_module,
+    read_position_arrays,
+)
 
 
 def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
@@ -234,17 +51,17 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
     """
     fixture_root = tmp_path / "fixture"
     fixture_root.mkdir()
-    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = build_fixture(fixture_root)
 
     save_dir_serial = tmp_path / "serial"
     save_dir_process = tmp_path / "process"
 
     # Re-import inside the test body — test_lazy_init.py pops dynacell.*
     # modules from sys.modules, which would invalidate a module-level import.
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     evaluate_predictions = pipeline.evaluate_predictions
 
-    cfg_serial = _build_eval_config(
+    cfg_serial = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -253,7 +70,7 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
         executor="serial",
         fov_workers=1,
     )
-    cfg_process = _build_eval_config(
+    cfg_process = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -269,17 +86,13 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
     pixel_serial, mask_serial, _ = evaluate_predictions(cfg_serial)
     pixel_process, mask_process, _ = evaluate_predictions(cfg_process)
 
-    # Pixel + mask rows: same set after sort. We sort by (FOV, Timepoint)
-    # because the process branch already sorts by pos_name and within-FOV
-    # iteration is deterministic, but we sort defensively.
     def _sort_key(row: dict):
         return (row["FOV"], row["Timepoint"])
 
     assert sorted(pixel_serial, key=_sort_key) == sorted(pixel_process, key=_sort_key)
     assert sorted(mask_serial, key=_sort_key) == sorted(mask_process, key=_sort_key)
-    # Per-position seg plate equality (both channels).
-    arrs_serial = _read_position_arrays(save_dir_serial / "segmentation_results.zarr")
-    arrs_process = _read_position_arrays(save_dir_process / "segmentation_results.zarr")
+    arrs_serial = read_position_arrays(save_dir_serial / "segmentation_results.zarr")
+    arrs_process = read_position_arrays(save_dir_process / "segmentation_results.zarr")
     assert set(arrs_serial.keys()) == set(arrs_process.keys())
     for pos_name, arr_a in arrs_serial.items():
         arr_b = arrs_process[pos_name]
@@ -296,11 +109,11 @@ def test_serial_path_runs_without_segmenter_loaded(tmp_path: Path):
     """
     fixture_root = tmp_path / "fixture"
     fixture_root.mkdir()
-    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = build_fixture(fixture_root)
     save_dir = tmp_path / "out"
     save_dir.mkdir()
 
-    cfg = _build_eval_config(
+    cfg = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -309,10 +122,7 @@ def test_serial_path_runs_without_segmenter_loaded(tmp_path: Path):
         executor="serial",
         fov_workers=1,
     )
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     pixel_rows, mask_rows, _ = pipeline.evaluate_predictions(cfg)
     assert len(pixel_rows) == N_POSITIONS * T
     assert len(mask_rows) == N_POSITIONS * T
-    # Confirms the no-segmenter contract: prepare_segmentation_model
-    # returned None and evaluate_predictions still produced valid outputs
-    # for every (FOV, t) pair.

--- a/applications/dynacell/tests/test_runtime.py
+++ b/applications/dynacell/tests/test_runtime.py
@@ -1,0 +1,256 @@
+"""Unit tests for ``dynacell.evaluation.runtime``."""
+
+from __future__ import annotations
+
+import csv
+import os
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from dynacell.evaluation.runtime import (
+    ResolvedRuntime,
+    apply_thread_budget,
+    dump_timings_csv,
+    early_apply_env_caps,
+    extend_timings,
+    get_timings,
+    gpu_lock_path_for_job,
+    gpu_serialization_lock,
+    make_fov_executor,
+    maybe_empty_cuda_cache,
+    maybe_gc_collect,
+    region_timer,
+    reset_timings,
+    resolve_runtime,
+)
+
+
+def test_apply_thread_budget_runs_without_error():
+    """apply_thread_budget should not raise even when called from Hydra's main.
+
+    set_num_interop_threads raises after any parallel op has run; the function
+    catches that and continues. Test covers the import-after-parallel-op path.
+    """
+    # Force-import torch (parallel op) before applying budget.
+    import torch
+
+    _ = torch.zeros(4) + torch.ones(4)
+    apply_thread_budget(2)  # should not raise
+
+
+def test_apply_thread_budget_rejects_zero():
+    with pytest.raises(ValueError, match="threads must be >= 1"):
+        apply_thread_budget(0)
+
+
+def test_resolve_runtime_no_runtime_block_falls_back_to_serial():
+    cfg = OmegaConf.create({"io": {}})
+    r = resolve_runtime(cfg)
+    assert r.fov_workers == 1
+    assert r.executor == "serial"
+    assert r.cuda_empty_cache_every_n_timepoints == 0
+    assert r.gc_collect_every_n_fovs == 0
+
+
+def test_resolve_runtime_auto_serial_clamps_workers_to_one():
+    cfg = OmegaConf.create({"runtime": {"fov_workers": "auto", "threads_per_worker": "auto", "executor": "serial"}})
+    r = resolve_runtime(cfg)
+    assert r.fov_workers == 1
+    assert r.executor == "serial"
+    assert r.threads_per_worker >= 1
+
+
+def test_resolve_runtime_auto_process_clamps_to_n_positions():
+    cfg = OmegaConf.create({"runtime": {"fov_workers": "auto", "threads_per_worker": "auto", "executor": "process"}})
+    r = resolve_runtime(cfg, n_positions=2)
+    assert r.fov_workers <= 2
+    # Auto-demotes to serial when only 1 position is left after clamping.
+    if r.fov_workers == 1:
+        assert r.executor == "serial"
+
+
+def test_resolve_runtime_freeze_threads_per_worker():
+    """Phase-2 contract: ``freeze_threads_per_worker`` returns the frozen value."""
+    cfg = OmegaConf.create({"runtime": {"fov_workers": "auto", "threads_per_worker": "auto", "executor": "process"}})
+    r = resolve_runtime(cfg, n_positions=3, freeze_threads_per_worker=4)
+    assert r.threads_per_worker == 4
+
+
+def test_resolve_runtime_literal_fov_workers_in_serial_raises():
+    cfg = OmegaConf.create({"runtime": {"fov_workers": 4, "executor": "serial"}})
+    with pytest.raises(ValueError, match=r"fov_workers=4 requires runtime.executor='process'"):
+        resolve_runtime(cfg)
+
+
+def test_resolve_runtime_auto_demote_process_to_serial_at_one_worker():
+    """fov_workers literally set to 1 with executor=process should auto-demote to serial."""
+    cfg = OmegaConf.create({"runtime": {"fov_workers": 1, "executor": "process"}})
+    r = resolve_runtime(cfg)
+    assert r.fov_workers == 1
+    assert r.executor == "serial"
+
+
+def test_resolve_runtime_invalid_executor_raises():
+    cfg = OmegaConf.create({"runtime": {"executor": "ray"}})
+    with pytest.raises(ValueError, match="executor must be 'serial' or 'process'"):
+        resolve_runtime(cfg)
+
+
+def test_resolve_runtime_force_per_t_hygiene_env(monkeypatch):
+    """DYNACELL_FORCE_PER_T_HYGIENE=1 turns on hygiene knobs regardless of YAML."""
+    monkeypatch.setenv("DYNACELL_FORCE_PER_T_HYGIENE", "1")
+    cfg = OmegaConf.create(
+        {
+            "runtime": {
+                "cuda_empty_cache_every_n_timepoints": 0,
+                "gc_collect_every_n_fovs": 0,
+            }
+        }
+    )
+    r = resolve_runtime(cfg)
+    assert r.cuda_empty_cache_every_n_timepoints >= 1
+    assert r.gc_collect_every_n_fovs >= 1
+
+
+def test_early_apply_env_caps_respects_existing(monkeypatch):
+    """Should only export env vars when DYNACELL_THREADS_PER_WORKER is set."""
+    monkeypatch.delenv("DYNACELL_THREADS_PER_WORKER", raising=False)
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    early_apply_env_caps()
+    assert os.environ.get("OMP_NUM_THREADS") is None  # noop without env set
+
+    monkeypatch.setenv("DYNACELL_THREADS_PER_WORKER", "3")
+    early_apply_env_caps()
+    assert os.environ.get("OMP_NUM_THREADS") == "3"
+
+
+def test_resolved_runtime_dataclass_is_pickleable():
+    # Import inside test body so we pick up the *currently cached*
+    # dynacell.evaluation.runtime module. test_lazy_init.py clears
+    # `dynacell.*` modules from sys.modules — a module-level import
+    # at collection time would bind to a stale class object.
+    import importlib
+
+    runtime_mod = importlib.import_module("dynacell.evaluation.runtime")
+    r = runtime_mod.ResolvedRuntime(
+        fov_workers=2,
+        threads_per_worker=4,
+        executor="process",
+        cuda_empty_cache_every_n_timepoints=0,
+        gc_collect_every_n_fovs=0,
+    )
+    restored = pickle.loads(pickle.dumps(r))
+    assert restored == r
+
+
+def test_region_timer_records_to_collector():
+    reset_timings()
+    with region_timer("test_region", "A/1/0"):
+        pass
+    with region_timer("test_per_t", "A/1/0", t=5):
+        pass
+    rows = get_timings()
+    assert len(rows) == 2
+    assert rows[0][0] == "A/1/0"
+    assert rows[0][1] is None
+    assert rows[0][2] == "test_region"
+    assert rows[0][3] >= 0.0
+    assert rows[1][1] == 5
+
+
+def test_dump_timings_csv_writes_correct_schema(tmp_path: Path):
+    reset_timings()
+    with region_timer("test_region", "A/1/0"):
+        pass
+    with region_timer("test_per_t", "A/1/0", t=2):
+        pass
+    out_path = dump_timings_csv(tmp_path)
+    assert out_path is not None
+    with out_path.open() as f:
+        rows = list(csv.reader(f))
+    assert rows[0] == ["pos_name", "t", "region", "seconds"]
+    assert rows[1][:3] == ["A/1/0", "", "test_region"]
+    assert rows[2][:3] == ["A/1/0", "2", "test_per_t"]
+
+
+def test_dump_timings_csv_returns_none_when_empty(tmp_path: Path):
+    reset_timings()
+    assert dump_timings_csv(tmp_path) is None
+
+
+def test_extend_timings_appends_batch():
+    reset_timings()
+    extend_timings([("X/1/0", None, "foo", 0.1), ("X/1/0", 0, "bar", 0.2)])
+    assert len(get_timings()) == 2
+
+
+def test_maybe_empty_cuda_cache_is_noop_when_every_n_zero():
+    # No-op should not raise even without CUDA.
+    maybe_empty_cuda_cache(t=3, every_n=0)
+
+
+def test_maybe_gc_collect_is_noop_when_every_n_zero():
+    maybe_gc_collect(fov_idx=0, every_n=0)
+
+
+def test_maybe_gc_collect_runs_at_interval():
+    """fov_idx+1 % every_n == 0 triggers the collect."""
+    # Just verify it doesn't raise for valid intervals; gc.collect side-effect
+    # is opaque but must not crash.
+    maybe_gc_collect(fov_idx=0, every_n=1)
+    maybe_gc_collect(fov_idx=4, every_n=5)
+
+
+def test_gpu_lock_path_for_job_uses_tmp():
+    path = gpu_lock_path_for_job()
+    assert path.startswith("/tmp/") or path.startswith("/var/")  # platform-dependent
+    assert path.endswith(".lock")
+
+
+def test_gpu_serialization_lock_is_noop_in_parent():
+    """No worker initializer has run, so the lock should yield immediately."""
+    with gpu_serialization_lock():
+        pass  # Must not block or raise.
+
+
+def test_make_fov_executor_serial_yields_none():
+    runtime = ResolvedRuntime(
+        fov_workers=1,
+        threads_per_worker=4,
+        executor="serial",
+        cuda_empty_cache_every_n_timepoints=0,
+        gc_collect_every_n_fovs=0,
+    )
+    with make_fov_executor(runtime) as pool:
+        assert pool is None
+
+
+def test_make_fov_executor_process_yields_real_executor():
+    """Spawn smoke: ProcessPoolExecutor with worker initializer comes up cleanly.
+
+    Submits ``os.getpid`` (stdlib, no test-tree imports needed in spawn workers
+    — tests/ is not on the python path so test-module-level helpers can't be
+    pickled into the child) and verifies the worker returns its own PID,
+    distinct from the parent's.
+    """
+    import importlib
+
+    runtime_mod = importlib.import_module("dynacell.evaluation.runtime")
+    runtime = runtime_mod.ResolvedRuntime(
+        fov_workers=2,
+        threads_per_worker=2,
+        executor="process",
+        cuda_empty_cache_every_n_timepoints=0,
+        gc_collect_every_n_fovs=0,
+    )
+    parent_pid = os.getpid()
+    with runtime_mod.make_fov_executor(runtime) as pool:
+        assert pool is not None
+        assert isinstance(pool, ProcessPoolExecutor)
+        worker_pid = pool.submit(os.getpid).result(timeout=60)
+        assert worker_pid != parent_pid
+        assert isinstance(worker_pid, int)

--- a/applications/dynacell/tools/run_eval_jointtrained_nucleus.slurm
+++ b/applications/dynacell/tools/run_eval_jointtrained_nucleus.slurm
@@ -26,6 +26,15 @@
 
 set -euo pipefail
 
+# Cap BLAS/OMP threads to the SLURM allocation before any C extension loads.
+# applications/dynacell/CLAUDE.md "Eval runtime / parallelism" section.
+# Set DYNACELL_THREADS_PER_WORKER to the cgroup-visible CPU count so
+# scipy-openblas + torch intra-op don't oversubscribe.
+export DYNACELL_THREADS_PER_WORKER="${SLURM_CPUS_PER_TASK}"
+# To enable FOV-level parallelism in a future run with a multi-FOV eval,
+# pass these overrides to the wrapped eval invocation (see the .sh script):
+#   runtime.executor=process runtime.fov_workers=4 runtime.threads_per_worker=4
+
 REPO=/hpc/mydata/alex.kalinin/VisCy
 EVAL_DIR="${REPO}/applications/dynacell/configs/evaluations"
 

--- a/applications/dynacell/tools/run_eval_unext2_jointtrained_membrane.slurm
+++ b/applications/dynacell/tools/run_eval_unext2_jointtrained_membrane.slurm
@@ -26,6 +26,13 @@
 
 set -euo pipefail
 
+# Cap BLAS/OMP threads to the SLURM allocation before any C extension loads.
+# applications/dynacell/CLAUDE.md "Eval runtime / parallelism" section.
+export DYNACELL_THREADS_PER_WORKER="${SLURM_CPUS_PER_TASK}"
+# To enable FOV-level parallelism in a future multi-FOV run, pass these
+# overrides to the wrapped eval invocation (see the .sh script):
+#   runtime.executor=process runtime.fov_workers=4 runtime.threads_per_worker=4
+
 REPO=/hpc/mydata/alex.kalinin/VisCy
 EVAL_DIR="${REPO}/applications/dynacell/configs/evaluations"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,11 @@ lint.pydocstyle.convention = "numpy"
 [tool.pytest.ini_options]
 minversion = "9.0"
 testpaths = [ "packages/*/tests", "applications/*/tests" ]
-addopts = [ "-ra", "-q", "--import-mode=importlib" ]
+addopts = [ "-ra", "-q", "--import-mode=importlib", "-m", "not slow" ]
 pythonpath = [ "applications/dynacell/tools" ]
+markers = [
+  "slow: marks tests requiring GPU/HPC resources (deselect with -m 'not slow')",
+]
 
 [tool.uv-dynamic-versioning]
 vcs = "git"


### PR DESCRIPTION
## Summary

Adds bounded FOV-level parallelism + explicit thread/process budgeting to dynacell eval. Default behavior is unchanged (sequential FOV loop); opt-in via `runtime.executor=process runtime.fov_workers=N`.

5 atomic commits:
- **C1**: new `dynacell.evaluation.runtime` module with `apply_thread_budget`, `resolve_runtime`, `early_apply_env_caps`. Tightens BLAS/OMP threads to `cpu_count` even in serial mode (corrects previously-loose OpenBLAS threading on SLURM where `--cpus-per-task` < host CPU count).
- **C2**: per-T memory hygiene knobs (`cuda_empty_cache_every_n_timepoints`, `gc_collect_every_n_fovs`, default 0) and always-on region timing instrumentation (writes `<save_dir>/eval_timing.csv`). `DYNACELL_FORCE_PER_T_HYGIENE=1` env-var escape hatch for operators.
- **C3**: extract per-FOV body into module-level `_process_one_fov(...) -> FovResult` + `_aggregate_fov_result(...)`. Pure refactor; serial path is bit-for-bit identical to today.
- **C4**: ProcessPoolExecutor wiring under spawn context. Per-job fcntl GPU lock at `/tmp/dynacell_gpu_<SLURM_JOB_ID>.lock`. Workers lazy-load models under the lock. Two-phase runtime resolution (Phase-1 caps BLAS; Phase-2 re-clamps `fov_workers` after position list is known with `freeze_threads_per_worker=` to keep parent/worker BLAS budgets consistent). Auto-demotes `executor=process` to `serial` when resolved `fov_workers=1`.
- **C5**: test_runtime.py (23 tests), test_evaluation_pipeline_parallel.py (3 tests covering FovResult pickle + aggregator). Registers `slow` pytest marker, adds new tests to the existing dynacell CI job. SLURM scripts export `DYNACELL_THREADS_PER_WORKER`. CLAUDE.md docs.

## Test plan

- [x] `uv run pytest applications/dynacell/tests/` — 410 passed / 48 failed / 65 skipped on this branch; same 48 pre-existing failures as `dynacell-models@HEAD`.
- [x] `uvx ruff check applications/dynacell/` — clean.
- [x] Smoke: `FovResult` pickle round-trip works with synthetic per-FOV shapes (2 timepoints, 3 cells/T, 4 backbones × 768-dim).
- [x] Spawn smoke: `make_fov_executor(executor=process)` returns a real `ProcessPoolExecutor`; child worker `os.getpid()` differs from parent's.
- [ ] **Not in this PR — follow-up**: end-to-end serial-vs-process parity on a real iohub fixture + prebuilt mask cache. The lightweight tests above cover pickle/aggregation contract; the heavier integration test needs a small zarr + cache fixture and is documented in `.claude/plans/eval-parallelism.md` §C5.

## Default behavior

| knob | default | effect |
| ---- | ------- | ------ |
| `runtime.executor` | `"serial"` | inline FOV loop, identical to today |
| `runtime.fov_workers` | `1` | no parallelism |
| `runtime.threads_per_worker` | `"auto"` | resolves to `cpu_count // fov_workers` |
| `runtime.cuda_empty_cache_every_n_timepoints` | `0` | off |
| `runtime.gc_collect_every_n_fovs` | `0` | off |

Opt-in process mode example: `runtime.executor=process runtime.fov_workers=4`.

## Plan reference

`.claude/plans/eval-parallelism.md` (4 review rounds, audit/regression/correctness/merge passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)