### PR TITLE
feat(dynacell): grouped multi-condition eval driver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,8 @@ jobs:
         # tiny iohub fixture + prebuilt mask cache — no eval extras (no
         # cellpose, transformers, cubic) needed since target_name=er +
         # require_complete_cache=true short-circuit segmenter and feature
-        # extractor loads.
+        # extractor loads. tests/test_evaluation_grouped.py drives the
+        # multi-condition driver against the same cache-only fixture.
         run: |
           uv run --frozen pytest \
             tests/test_benchmark_config_composition.py \
@@ -153,6 +154,7 @@ jobs:
             tests/test_runtime.py \
             tests/test_evaluation_pipeline_parallel.py \
             tests/test_evaluation_pipeline_parallel_cpu.py \
+            tests/test_evaluation_grouped.py \
             -v
         working-directory: applications/dynacell
 

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -67,7 +67,7 @@ Under `executor=process`, workers return their slice of the timing log inside `F
 
 ### Reality check for process mode
 
-- The parent still loads the seg model once at `pipeline.py:171` (used for checkpoint pre-warm side-effect under `process` mode + the seg model itself under `serial` mode).
+- The parent still loads the seg model once via `load_eval_models(config)` at the start of `evaluate_predictions` in `pipeline.py` (used for checkpoint pre-warm side-effect under `process` mode + the seg model itself under `serial` mode).
 - `precompute_deep_features` (the upfront batched feature pre-fill) stays in the parent — single-pass over positions with the `DeepFeatureBatcher` cross-FOV amortization. Parallelizing precompute is a separate plan.
 - Workers cannot share open iohub plate handles or torch modules across the pickle boundary; each worker re-opens plates on first FOV.
 - `ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)` cancels queued futures only — in-flight workers continue to completion (~minutes if mid-cellpose). Ctrl-C may need `scancel` to fully release GPU memory.
@@ -110,7 +110,7 @@ uv run dynacell evaluate-grouped -c eval_grouped_a549_mantis_er
 Constraints (enforced at runtime by `_check_grouped_field_invariants`):
 - Per-condition overlays may freely override `io.*`, `save.*`, `runtime.*`, `limit_positions`, `force_recompute.*`, and carry a `name` label.
 - Overlays MUST NOT change `target_name`, `feature_extractor.*`, `compute_feature_metrics`, or `use_gpu` — those gate model loading and must be identical across conditions. Run such variants separately.
-- Each condition independently honors `_final_metrics_cache_valid` — if a condition's CSV/NPY already exist with `force_recompute.final_metrics=false`, the driver skips it and loads the cached outputs.
+- Each condition independently honors `_final_metrics_cache_valid` — if a condition's CSV/NPY already exist AND both `force_recompute.all=false` and `force_recompute.final_metrics=false`, the driver skips it and loads the cached outputs. Either flag set to `true` bypasses the cache.
 
 Process-mode caveat: under `runtime.executor=process`, the parent's shared `EvalModels` is passed to `evaluate_predictions(..., models=...)` so the parent-side pre-warm is amortized, but each condition still spawns a fresh `ProcessPoolExecutor` whose workers re-load their own model copies. Use `executor=serial` to maximize the amortization benefit. The driver tiers its message based on the cache mode:
 

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -112,6 +112,11 @@ Constraints (enforced at runtime by `_check_grouped_field_invariants`):
 - Overlays MUST NOT change `target_name`, `feature_extractor.*`, `compute_feature_metrics`, or `use_gpu` — those gate model loading and must be identical across conditions. Run such variants separately.
 - Each condition independently honors `_final_metrics_cache_valid` — if a condition's CSV/NPY already exist with `force_recompute.final_metrics=false`, the driver skips it and loads the cached outputs.
 
-Process-mode caveat: under `runtime.executor=process`, the parent's shared `EvalModels` is passed to `evaluate_predictions(..., models=...)` so the parent-side pre-warm is amortized, but each condition still spawns a fresh `ProcessPoolExecutor` whose workers re-load their own model copies. Use `executor=serial` to maximize the amortization benefit; the driver prints a heads-up when it detects `process` mode. For an A40 / single-GPU interactive node where you'd run serial anyway, this is the default win.
+Process-mode caveat: under `runtime.executor=process`, the parent's shared `EvalModels` is passed to `evaluate_predictions(..., models=...)` so the parent-side pre-warm is amortized, but each condition still spawns a fresh `ProcessPoolExecutor` whose workers re-load their own model copies. Use `executor=serial` to maximize the amortization benefit. The driver tiers its message based on the cache mode:
+
+- `executor=process` + `require_complete_cache=true` + `n_conditions > 1` → mild **note**: workers re-init per condition but skip `prepare_segmentation_model` (returns None) and don't instantiate extractors, so the cost is just N pool spawns.
+- `executor=process` + `require_complete_cache=false` + `n_conditions > 1` → loud **WARNING**: each condition's worker pool independently loads SuperModel + DINOv3 + DynaCLR + CELL-DINO. Total waste is ~30-90 s × `runtime.fov_workers` × `n_conditions`. Fix: switch to `executor=serial` so the parent's pre-loaded models are reused across conditions; reserve `process` for per-FOV parallelism within a *single* condition.
+
+For an A40 / single-GPU interactive node where you'd run serial anyway, this is the default win.
 
 Tests: `applications/dynacell/tests/test_evaluation_grouped.py` validates byte-equal parity against sequential per-condition runs on the same cache-only fixture used by `test_evaluation_pipeline_parallel_cpu.py`, plus rejection cases for empty `conditions` and forbidden model-loading-field overrides.

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -72,3 +72,46 @@ Under `executor=process`, workers return their slice of the timing log inside `F
 - Workers cannot share open iohub plate handles or torch modules across the pickle boundary; each worker re-opens plates on first FOV.
 - `ProcessPoolExecutor.shutdown(wait=False, cancel_futures=True)` cancels queued futures only — in-flight workers continue to completion (~minutes if mid-cellpose). Ctrl-C may need `scancel` to fully release GPU memory.
 - Tests for the runtime module + FovResult pickle contract live in `applications/dynacell/tests/test_runtime.py` and `tests/test_evaluation_pipeline_parallel.py`. An end-to-end serial-vs-process parity test on a real iohub fixture is a follow-up (see plan `.claude/plans/eval-parallelism.md` §C5).
+
+### Grouped multi-condition eval
+
+When evaluating the same `(model, organelle)` across multiple I/O variants — typically the three A549 treatment plates (`mock`, `denv`, `zikv`), but also any case where the same trained model is scored on multiple datasets — use `dynacell evaluate-grouped`. The driver loads `SuperModel` + `DinoV3` + `DynaCLR` + `CELL-DINO` once, then loops over the conditions calling `evaluate_predictions(merged_cfg, models=...)` so the per-condition cold-start (~30–90 s of weight load + checkpoint warmup) is paid once total instead of N times.
+
+```yaml
+# applications/dynacell/configs/.../eval_grouped_a549_mantis_er.yml
+defaults:
+  - eval_grouped
+  - _self_
+
+target_name: er           # MUST be set at the base; conditions cannot override it
+compute_feature_metrics: true
+feature_extractor:
+  dinov3: { ... }         # shared across all conditions
+  dynaclr: { checkpoint: /path/to/dynaclr.ckpt, ... }
+  celldino: { weights_path: /path/to/celldino.ckpt, ... }
+
+conditions:
+  - name: a549_mock
+    io: { pred_path: ..., gt_path: ..., gt_cache_dir: ..., pred_cache_dir: ..., cell_segmentation_path: ... }
+    save: { save_dir: /path/to/out/a549_mock }
+  - name: a549_denv
+    io: { ... }
+    save: { save_dir: /path/to/out/a549_denv }
+  - name: a549_zikv
+    io: { ... }
+    save: { save_dir: /path/to/out/a549_zikv }
+```
+
+Invoke:
+```sh
+uv run dynacell evaluate-grouped -c eval_grouped_a549_mantis_er
+```
+
+Constraints (enforced at runtime by `_check_grouped_field_invariants`):
+- Per-condition overlays may freely override `io.*`, `save.*`, `runtime.*`, `limit_positions`, `force_recompute.*`, and carry a `name` label.
+- Overlays MUST NOT change `target_name`, `feature_extractor.*`, `compute_feature_metrics`, or `use_gpu` — those gate model loading and must be identical across conditions. Run such variants separately.
+- Each condition independently honors `_final_metrics_cache_valid` — if a condition's CSV/NPY already exist with `force_recompute.final_metrics=false`, the driver skips it and loads the cached outputs.
+
+Process-mode caveat: under `runtime.executor=process`, the parent's shared `EvalModels` is passed to `evaluate_predictions(..., models=...)` so the parent-side pre-warm is amortized, but each condition still spawns a fresh `ProcessPoolExecutor` whose workers re-load their own model copies. Use `executor=serial` to maximize the amortization benefit; the driver prints a heads-up when it detects `process` mode. For an A40 / single-GPU interactive node where you'd run serial anyway, this is the default win.
+
+Tests: `applications/dynacell/tests/test_evaluation_grouped.py` validates byte-equal parity against sequential per-condition runs on the same cache-only fixture used by `test_evaluation_pipeline_parallel_cpu.py`, plus rejection cases for empty `conditions` and forbidden model-loading-field overrides.

--- a/applications/dynacell/src/dynacell/__main__.py
+++ b/applications/dynacell/src/dynacell/__main__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 _HYDRA_COMMANDS: dict[str, tuple[str, str, str]] = {
     "evaluate": ("dynacell.evaluation.pipeline", "evaluate_model", "eval"),
+    "evaluate-grouped": ("dynacell.evaluation.pipeline", "evaluate_model_grouped", "eval"),
     "precompute-gt": ("dynacell.evaluation.precompute_cli", "precompute_gt", "eval"),
     "report": ("dynacell.reporting.cli", "generate_report", "report"),
 }

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval_grouped.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval_grouped.yaml
@@ -1,0 +1,34 @@
+defaults:
+  - eval
+  - _self_
+
+# Per-condition overlays for grouped multi-condition eval. Each entry is a
+# deep merge applied to the base config above. Use this to run e.g. all three
+# A549 treatment conditions (mock / denv / zikv) in one process, amortizing
+# the segmenter + DINOv3 + DynaCLR + CELL-DINO load.
+#
+# Each overlay may freely change ``io.*``, ``save.*``, ``runtime.*``,
+# ``limit_positions``, ``force_recompute.*``, and optionally carry a ``name``
+# label used in logs + the returned result tuple. Overlays MUST NOT touch
+# ``target_name``, ``feature_extractor.*``, ``compute_feature_metrics``, or
+# ``use_gpu`` — those gate model loading, which is shared. See
+# applications/dynacell/CLAUDE.md "Grouped multi-condition eval".
+#
+# Example:
+# conditions:
+#   - name: a549_mock
+#     io:
+#       pred_path: /path/to/mock_pred.zarr
+#       gt_path:   /path/to/mock_gt.zarr
+#       cell_segmentation_path: /path/to/mock_seg.zarr
+#       gt_cache_dir:   /path/to/mock_gt_cache
+#       pred_cache_dir: /path/to/mock_pred_cache
+#     save:
+#       save_dir: /path/to/eval_out/a549_mock
+#   - name: a549_denv
+#     io: { ... }
+#     save: { save_dir: /path/to/eval_out/a549_denv }
+#   - name: a549_zikv
+#     io: { ... }
+#     save: { save_dir: /path/to/eval_out/a549_zikv }
+conditions: []

--- a/applications/dynacell/src/dynacell/evaluation/model_loader.py
+++ b/applications/dynacell/src/dynacell/evaluation/model_loader.py
@@ -1,0 +1,119 @@
+"""Shared model-loading entry point for the dynacell eval pipeline.
+
+A single source of truth for instantiating the segmenter + deep-feature
+extractors used by ``evaluate_predictions``. Lifting the load out of the
+pipeline lets the grouped multi-condition driver build models once and
+reuse them across conditions that differ only in I/O paths.
+
+The dataclass carries the **identity tags** (model name, checkpoint sha
+sources) that ``init_cache_context`` needs, so callers don't have to
+recompute them per condition.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from omegaconf import DictConfig
+
+
+@dataclass
+class EvalModels:
+    """Bundle of pre-loaded segmenter + feature extractors with their identity tags.
+
+    Attributes
+    ----------
+    seg_model : Any | None
+        SuperModel returned by ``prepare_segmentation_model``. May be None
+        when ``io.require_complete_cache=true`` short-circuits the load.
+    dinov3, dynaclr, celldino : Any | None
+        Deep feature extractor instances. All None when
+        ``compute_feature_metrics=false``. ``celldino`` is None when its
+        ``weights_path`` is unset.
+    dinov3_model_name, dynaclr_ckpt_path, dynaclr_encoder_cfg,
+    celldino_weights_path : str | dict | None
+        Identity tags consumed by ``init_cache_context``. Stay None when
+        the corresponding extractor was not loaded.
+    """
+
+    seg_model: Any | None
+    dinov3: Any | None
+    dynaclr: Any | None
+    celldino: Any | None
+    dinov3_model_name: str | None
+    dynaclr_ckpt_path: str | None
+    dynaclr_encoder_cfg: dict[str, Any] | None
+    celldino_weights_path: str | None
+
+
+def load_eval_models(config: DictConfig) -> EvalModels:
+    """Instantiate the segmenter + deep feature extractors from ``config``.
+
+    No GPU serialization wrapping — callers (worker setup) wrap with
+    ``gpu_serialization_lock`` as needed. The parent of
+    ``evaluate_predictions`` calls this unwrapped today, so this entry
+    preserves that exact pattern.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Resolved eval config. Reads ``target_name``,
+        ``compute_feature_metrics``, ``feature_extractor.{dinov3,dynaclr,celldino}``,
+        and (transitively) ``io.require_complete_cache``.
+
+    Returns
+    -------
+    EvalModels
+        All model handles + identity tags. ``seg_model`` is None under
+        ``require_complete_cache=true``; extractors are None when
+        ``compute_feature_metrics=false`` (and celldino additionally
+        when its ``weights_path`` is null).
+    """
+    from dynacell.evaluation.pipeline_cache import resolve_dynaclr_encoder_cfg
+    from dynacell.evaluation.segmentation import prepare_segmentation_model
+    from dynacell.evaluation.utils import (
+        CellDinoFeatureExtractor,
+        DinoV3FeatureExtractor,
+        DynaCLRFeatureExtractor,
+    )
+
+    seg_model = prepare_segmentation_model(config)
+
+    dinov3_model_name: str | None = None
+    dynaclr_ckpt_path: str | None = None
+    dynaclr_encoder_cfg: dict[str, Any] | None = None
+    celldino_weights_path: str | None = None
+    dinov3 = None
+    dynaclr = None
+    celldino = None
+
+    if config.compute_feature_metrics:
+        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
+        dinov3 = DinoV3FeatureExtractor(dinov3_model_name)
+        dynaclr_config = config.feature_extractor.dynaclr
+        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
+        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
+        dynaclr = DynaCLRFeatureExtractor(
+            checkpoint=dynaclr_config.checkpoint,
+            encoder_config=dynaclr_encoder_cfg,
+        )
+        celldino_cfg = config.feature_extractor.celldino
+        if celldino_cfg.weights_path is not None:
+            celldino_weights_path = str(celldino_cfg.weights_path)
+            celldino = CellDinoFeatureExtractor(
+                weights_path=celldino_weights_path,
+                img_size=int(celldino_cfg.img_size),
+                patch_size=int(celldino_cfg.patch_size),
+            )
+
+    return EvalModels(
+        seg_model=seg_model,
+        dinov3=dinov3,
+        dynaclr=dynaclr,
+        celldino=celldino,
+        dinov3_model_name=dinov3_model_name,
+        dynaclr_ckpt_path=dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
+        celldino_weights_path=celldino_weights_path,
+    )

--- a/applications/dynacell/src/dynacell/evaluation/model_loader.py
+++ b/applications/dynacell/src/dynacell/evaluation/model_loader.py
@@ -1,9 +1,11 @@
 """Shared model-loading entry point for the dynacell eval pipeline.
 
 A single source of truth for instantiating the segmenter + deep-feature
-extractors used by ``evaluate_predictions``. Lifting the load out of the
-pipeline lets the grouped multi-condition driver build models once and
-reuse them across conditions that differ only in I/O paths.
+extractors used by ``evaluate_predictions`` and the precompute-gt CLI.
+Lifting the load out of the pipeline lets the grouped multi-condition
+driver build models once and reuse them across conditions that differ
+only in I/O paths; the precompute-gt CLI shares the same code path with
+its own per-extractor gates (``build.masks`` / ``build.dinov3`` / ...).
 
 The dataclass carries the **identity tags** (model name, checkpoint sha
 sources) that ``init_cache_context`` needs, so callers don't have to
@@ -26,10 +28,11 @@ class EvalModels:
     ----------
     seg_model : Any | None
         SuperModel returned by ``prepare_segmentation_model``. May be None
-        when ``io.require_complete_cache=true`` short-circuits the load.
+        when ``io.require_complete_cache=true`` short-circuits the load
+        or when ``LoadFlags.masks=False``.
     dinov3, dynaclr, celldino : Any | None
-        Deep feature extractor instances. All None when
-        ``compute_feature_metrics=false``. ``celldino`` is None when its
+        Deep feature extractor instances. Each is None when its
+        ``LoadFlags`` gate is False, or (for celldino) when its
         ``weights_path`` is unset.
     dinov3_model_name, dynaclr_ckpt_path, dynaclr_encoder_cfg,
     celldino_weights_path : str | dict | None
@@ -47,7 +50,35 @@ class EvalModels:
     celldino_weights_path: str | None
 
 
-def load_eval_models(config: DictConfig) -> EvalModels:
+@dataclass(frozen=True)
+class LoadFlags:
+    """Per-model gate for :func:`load_eval_models`.
+
+    Lets ``precompute-gt`` (per-extractor flags ``build.masks`` /
+    ``build.dinov3`` / ``build.dynaclr`` / ``build.celldino``) and
+    ``evaluate-predictions`` (all extractors gated together by
+    ``compute_feature_metrics``) share one loader.
+    """
+
+    masks: bool = True
+    dinov3: bool = False
+    dynaclr: bool = False
+    celldino: bool = False
+
+    @classmethod
+    def for_evaluate(cls, config: DictConfig) -> LoadFlags:
+        """Flags matching the ``evaluate_predictions`` call path.
+
+        Masks always on (``prepare_segmentation_model`` handles its own
+        ``require_complete_cache`` short-circuit). Extractors gated as a
+        group by ``config.compute_feature_metrics``; celldino additionally
+        soft-skips inside the loader when its ``weights_path`` is null.
+        """
+        ext_on = bool(config.compute_feature_metrics)
+        return cls(masks=True, dinov3=ext_on, dynaclr=ext_on, celldino=ext_on)
+
+
+def load_eval_models(config: DictConfig, *, flags: LoadFlags | None = None) -> EvalModels:
     """Instantiate the segmenter + deep feature extractors from ``config``.
 
     No GPU serialization wrapping — callers (worker setup) wrap with
@@ -59,16 +90,21 @@ def load_eval_models(config: DictConfig) -> EvalModels:
     ----------
     config : DictConfig
         Resolved eval config. Reads ``target_name``,
-        ``compute_feature_metrics``, ``feature_extractor.{dinov3,dynaclr,celldino}``,
+        ``feature_extractor.{dinov3,dynaclr,celldino}``,
         and (transitively) ``io.require_complete_cache``.
+    flags : LoadFlags, optional
+        Per-model gates. Defaults to :meth:`LoadFlags.for_evaluate`,
+        which preserves the historical ``evaluate_predictions``
+        behavior. Pass a custom :class:`LoadFlags` to load a subset
+        (e.g. for precompute-gt where ``build.dinov3`` / etc. are
+        toggled independently).
 
     Returns
     -------
     EvalModels
-        All model handles + identity tags. ``seg_model`` is None under
-        ``require_complete_cache=true``; extractors are None when
-        ``compute_feature_metrics=false`` (and celldino additionally
-        when its ``weights_path`` is null).
+        All model handles + identity tags. Each slot is None when its
+        flag is off; celldino additionally soft-skips when its
+        ``weights_path`` is null even with the flag on.
     """
     from dynacell.evaluation.pipeline_cache import resolve_dynaclr_encoder_cfg
     from dynacell.evaluation.segmentation import prepare_segmentation_model
@@ -78,7 +114,10 @@ def load_eval_models(config: DictConfig) -> EvalModels:
         DynaCLRFeatureExtractor,
     )
 
-    seg_model = prepare_segmentation_model(config)
+    if flags is None:
+        flags = LoadFlags.for_evaluate(config)
+
+    seg_model = prepare_segmentation_model(config) if flags.masks else None
 
     dinov3_model_name: str | None = None
     dynaclr_ckpt_path: str | None = None
@@ -88,9 +127,10 @@ def load_eval_models(config: DictConfig) -> EvalModels:
     dynaclr = None
     celldino = None
 
-    if config.compute_feature_metrics:
+    if flags.dinov3:
         dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
         dinov3 = DinoV3FeatureExtractor(dinov3_model_name)
+    if flags.dynaclr:
         dynaclr_config = config.feature_extractor.dynaclr
         dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
         dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
@@ -98,6 +138,7 @@ def load_eval_models(config: DictConfig) -> EvalModels:
             checkpoint=dynaclr_config.checkpoint,
             encoder_config=dynaclr_encoder_cfg,
         )
+    if flags.celldino:
         celldino_cfg = config.feature_extractor.celldino
         if celldino_cfg.weights_path is not None:
             celldino_weights_path = str(celldino_cfg.weights_path)
@@ -117,3 +158,36 @@ def load_eval_models(config: DictConfig) -> EvalModels:
         dynaclr_encoder_cfg=dynaclr_encoder_cfg,
         celldino_weights_path=celldino_weights_path,
     )
+
+
+def _identity_kwargs(models: EvalModels) -> dict[str, Any]:
+    """Identity tags forwarded into ``init_cache_context``."""
+    return {
+        "dinov3_model_name": models.dinov3_model_name,
+        "dynaclr_ckpt_path": models.dynaclr_ckpt_path,
+        "dynaclr_encoder_cfg": models.dynaclr_encoder_cfg,
+        "celldino_weights_path": models.celldino_weights_path,
+    }
+
+
+def init_cache_contexts(config: DictConfig, models: EvalModels) -> tuple[Any, Any]:
+    """Build ``(gt_ctx, pred_ctx)`` cache contexts using ``models``'s identity tags.
+
+    Replaces the four-call-site duplication in ``evaluate_predictions``
+    and ``_worker_setup`` where the same six kwargs flowed into
+    ``init_cache_context(..., side="gt")`` then again into
+    ``init_cache_context(..., side="pred")``.
+    """
+    from dynacell.evaluation.pipeline_cache import init_cache_context
+
+    kwargs = _identity_kwargs(models)
+    gt_ctx = init_cache_context(config, side="gt", **kwargs)
+    pred_ctx = init_cache_context(config, side="pred", **kwargs)
+    return gt_ctx, pred_ctx
+
+
+def init_gt_cache_context(config: DictConfig, models: EvalModels) -> Any:
+    """Build only the GT cache context — used by ``precompute-gt`` which is GT-only."""
+    from dynacell.evaluation.pipeline_cache import init_cache_context
+
+    return init_cache_context(config, side="gt", **_identity_kwargs(models))

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1101,6 +1101,12 @@ _MODEL_LOADING_FIELDS: tuple[str, ...] = (
     "feature_extractor",
     "compute_feature_metrics",
     "use_gpu",
+    # require_complete_cache flips ``prepare_segmentation_model`` between
+    # "load real SuperModel" and "return None" — letting a condition
+    # override it would mean the shared seg_model bundle is wrong for that
+    # condition (None when cache-miss expects a real model, or loaded but
+    # never used). Treat as a grouped invariant.
+    "io.require_complete_cache",
 )
 
 
@@ -1115,13 +1121,16 @@ def _snapshot_field(cfg: DictConfig, cfg_field: str):
 def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
     """Return a fresh DictConfig with ``overrides`` deep-merged into ``base``.
 
-    ``OmegaConf.merge`` already returns a config independent of its inputs,
-    so no upfront deep-copy is needed. The ``conditions`` field (the list
-    we're iterating over) and the per-overlay ``name`` label are stripped
-    from the result so each per-condition run sees a normal
-    single-condition config shape.
+    Hydra composition always returns struct-mode configs. ``OmegaConf.merge``
+    propagates struct mode from its first argument, so merging an overlay
+    that carries fields outside the base's schema (notably the per-condition
+    ``name`` label) raises ``ConfigKeyError``, and deleting the
+    ``conditions`` / ``name`` keys raises ``ConfigTypeError`` even when the
+    merge succeeds. The to_container round-trip below escapes struct mode
+    while still producing a config that's independent of ``base``.
     """
-    merged = OmegaConf.merge(base, OmegaConf.create(overrides))
+    base_copy = OmegaConf.create(OmegaConf.to_container(base, resolve=False))
+    merged = OmegaConf.merge(base_copy, OmegaConf.create(overrides))
     for key in ("conditions", "name"):
         if key in merged:
             del merged[key]
@@ -1219,8 +1228,10 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
 
     # Canonical baseline for invariant checks: the input config with the
     # ``conditions`` list dropped. Snapshot once; conditions are validated
-    # against this, including condition 0.
-    models_base = OmegaConf.merge(config, OmegaConf.create({}))
+    # against this, including condition 0. Round-trip through to_container
+    # to escape Hydra's struct-mode flag — ``del`` on a struct DictConfig
+    # raises ``ConfigTypeError``.
+    models_base = OmegaConf.create(OmegaConf.to_container(config, resolve=False))
     if "conditions" in models_base:
         del models_base["conditions"]
     base_snapshot = {field: _snapshot_field(models_base, field) for field in _MODEL_LOADING_FIELDS}

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -35,6 +35,7 @@ from dynacell.evaluation.metrics import (
     evaluate_segmentations,
     features_from_crops,
 )
+from dynacell.evaluation.model_loader import EvalModels, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
     flush_manifest,
     fov_cp_features,
@@ -42,7 +43,6 @@ from dynacell.evaluation.pipeline_cache import (
     fov_masks,
     init_cache_context,
     precompute_deep_features,
-    resolve_dynaclr_encoder_cfg,
 )
 from dynacell.evaluation.utils import plot_metrics
 
@@ -528,68 +528,36 @@ def _worker_setup(config: DictConfig) -> None:
     """
     if _WORKER_STATE.get("initialized"):
         return
-    from dynacell.evaluation.pipeline_cache import init_cache_context, resolve_dynaclr_encoder_cfg
     from dynacell.evaluation.runtime import gpu_serialization_lock
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import (
-        CellDinoFeatureExtractor,
-        DinoV3FeatureExtractor,
-        DynaCLRFeatureExtractor,
-    )
 
     use_gpu = bool(getattr(config, "use_gpu", True))
     with gpu_serialization_lock(gate=use_gpu):
-        seg_model = prepare_segmentation_model(config)
-        dinov3_feature_extractor = None
-        dynaclr_feature_extractor = None
-        celldino_feature_extractor = None
-        dinov3_model_name = None
-        dynaclr_ckpt_path = None
-        dynaclr_encoder_cfg = None
-        celldino_weights_path = None
-        if config.compute_feature_metrics:
-            dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-            dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-            dynaclr_config = config.feature_extractor.dynaclr
-            dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-            dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-            dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-                checkpoint=dynaclr_config.checkpoint,
-                encoder_config=dynaclr_encoder_cfg,
-            )
-            celldino_cfg = config.feature_extractor.celldino
-            if celldino_cfg.weights_path is not None:
-                celldino_weights_path = str(celldino_cfg.weights_path)
-                celldino_feature_extractor = CellDinoFeatureExtractor(
-                    weights_path=celldino_weights_path,
-                    img_size=int(celldino_cfg.img_size),
-                    patch_size=int(celldino_cfg.patch_size),
-                )
+        models = load_eval_models(config)
 
     cache_ctx = init_cache_context(
         config,
         side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        dinov3_model_name=models.dinov3_model_name,
+        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
+        celldino_weights_path=models.celldino_weights_path,
     )
     pred_cache_ctx = init_cache_context(
         config,
         side="pred",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        dinov3_model_name=models.dinov3_model_name,
+        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
+        celldino_weights_path=models.celldino_weights_path,
     )
 
     _WORKER_STATE.update(
         {
             "initialized": True,
-            "seg_model": seg_model,
-            "dinov3": dinov3_feature_extractor,
-            "dynaclr": dynaclr_feature_extractor,
-            "celldino": celldino_feature_extractor,
+            "seg_model": models.seg_model,
+            "dinov3": models.dinov3,
+            "dynaclr": models.dynaclr,
+            "celldino": models.celldino,
             "cache_ctx": cache_ctx,
             "pred_cache_ctx": pred_cache_ctx,
         }
@@ -673,8 +641,22 @@ def _worker_run_fov(config: DictConfig, pos_name: str, cuda_empty_every_n: int) 
     return result
 
 
-def evaluate_predictions(config: DictConfig):
-    """Evaluate predictions on all test images."""
+def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None):
+    """Evaluate predictions on all test images.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Resolved eval config.
+    models : EvalModels | None, optional
+        Pre-loaded segmenter + feature extractors. When provided, the
+        inline ``load_eval_models(config)`` call is skipped — used by the
+        grouped multi-condition driver to amortize model loads across
+        conditions sharing the same target/extractors. Default ``None``
+        preserves the historical single-condition behavior. Note: under
+        ``runtime.executor=process``, workers still load their own model
+        copies; this kwarg saves only the parent-side load.
+    """
     from dynacell.evaluation.runtime import (
         apply_thread_budget,
         dump_timings_csv,
@@ -683,8 +665,6 @@ def evaluate_predictions(config: DictConfig):
         reset_timings,
         resolve_runtime,
     )
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     # Phase 1 runtime resolution: lock in executor + thread caps before any
     # heavy work. fov_workers may be provisional when "auto"; re-resolved in
@@ -709,52 +689,31 @@ def evaluate_predictions(config: DictConfig):
     save_dir = Path(config.save.save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)
 
-    seg_model = prepare_segmentation_model(config)
+    if config.compute_feature_metrics and io_config.cell_segmentation_path is None:
+        raise ValueError("io.cell_segmentation_path is required when compute_feature_metrics=true")
 
-    dinov3_model_name = None
-    dynaclr_ckpt_path = None
-    dynaclr_encoder_cfg = None
-    celldino_weights_path = None
-    dinov3_feature_extractor = None
-    dynaclr_feature_extractor = None
-    celldino_feature_extractor = None
-
-    if config.compute_feature_metrics:
-        if io_config.cell_segmentation_path is None:
-            raise ValueError("io.cell_segmentation_path is required when compute_feature_metrics=true")
-        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-        dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-        dynaclr_config = config.feature_extractor.dynaclr
-        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-        dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-            checkpoint=dynaclr_config.checkpoint,
-            encoder_config=dynaclr_encoder_cfg,
-        )
-        celldino_cfg = config.feature_extractor.celldino
-        if celldino_cfg.weights_path is not None:
-            celldino_weights_path = str(celldino_cfg.weights_path)
-            celldino_feature_extractor = CellDinoFeatureExtractor(
-                weights_path=celldino_weights_path,
-                img_size=int(celldino_cfg.img_size),
-                patch_size=int(celldino_cfg.patch_size),
-            )
+    if models is None:
+        models = load_eval_models(config)
+    seg_model = models.seg_model
+    dinov3_feature_extractor = models.dinov3
+    dynaclr_feature_extractor = models.dynaclr
+    celldino_feature_extractor = models.celldino
 
     cache_ctx = init_cache_context(
         config,
         side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        dinov3_model_name=models.dinov3_model_name,
+        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
+        celldino_weights_path=models.celldino_weights_path,
     )
     pred_cache_ctx = init_cache_context(
         config,
         side="pred",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        dinov3_model_name=models.dinov3_model_name,
+        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
+        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
+        celldino_weights_path=models.celldino_weights_path,
     )
 
     seg_path = Path(io_config.cell_segmentation_path) if io_config.cell_segmentation_path is not None else None
@@ -1156,6 +1115,136 @@ def _final_metrics_cache_valid(config: DictConfig) -> bool:
     return pixel_ok and mask_ok and feature_ok
 
 
+_MODEL_LOADING_FIELDS: tuple[str, ...] = (
+    "target_name",
+    "feature_extractor",
+    "compute_feature_metrics",
+    "use_gpu",
+)
+
+
+def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
+    """Return a deep copy of ``base`` with ``overrides`` deep-merged in.
+
+    The returned config is fully independent (mutations don't leak into
+    ``base``). The ``conditions`` field is stripped from the copy so each
+    per-condition run sees a normal single-condition shape.
+    """
+    base_copy = OmegaConf.create(OmegaConf.to_container(base, resolve=False))
+    if "conditions" in base_copy:
+        del base_copy["conditions"]
+    merged = OmegaConf.merge(base_copy, OmegaConf.create(overrides))
+    if "name" in merged:
+        del merged["name"]
+    return merged  # type: ignore[return-value]
+
+
+def _check_grouped_field_invariants(base: DictConfig, merged: DictConfig, condition_name: str) -> None:
+    """Raise if any model-loading field differs between base and merged.
+
+    Per-condition overrides may freely change ``io.*``, ``save.*``,
+    ``runtime.*``, ``limit_positions``, and ``force_recompute.*``, but
+    must NOT touch the fields that determine which models get loaded —
+    that would defeat the whole point of sharing models across conditions.
+    """
+
+    def _snapshot(cfg: DictConfig, field: str):
+        node = OmegaConf.select(cfg, field, default=None)
+        if isinstance(node, (DictConfig, type(OmegaConf.create([])))):
+            return OmegaConf.to_container(node, resolve=False)
+        return node
+
+    for cfg_field in _MODEL_LOADING_FIELDS:
+        base_val = _snapshot(base, cfg_field)
+        merged_val = _snapshot(merged, cfg_field)
+        if base_val != merged_val:
+            raise ValueError(
+                f"Condition {condition_name!r}: overrides changed model-loading field "
+                f"{cfg_field!r}. Move it to the base config or run this condition separately."
+            )
+
+
+def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
+    """Run ``evaluate_predictions`` over a list of conditions sharing one model load.
+
+    Reads ``config.conditions`` (list of per-condition overrides). For each
+    condition, merges its overrides into a copy of the base config and
+    calls :func:`evaluate_predictions` with the shared ``EvalModels``.
+
+    Conditions may freely override ``io.*``, ``save.*``, ``runtime.*``,
+    ``limit_positions``, and ``force_recompute.*``. They must NOT change
+    ``target_name``, ``feature_extractor.*``, ``compute_feature_metrics``,
+    or ``use_gpu`` — those gate which models get loaded.
+
+    Parameters
+    ----------
+    config : DictConfig
+        Eval config with an extra top-level ``conditions: [...]`` list.
+        Each entry is a dict-like overlay applied to the base.
+
+    Returns
+    -------
+    list[tuple[str, tuple]]
+        ``[(condition_name, (pixel_rows, mask_rows, feature_rows)), ...]``
+        in input order. ``condition_name`` is taken from the entry's
+        ``name`` field, falling back to its index as a string.
+
+    Notes
+    -----
+    Under ``runtime.executor=process``, workers still load their own
+    model copies per condition (the pool is rebuilt inside each
+    ``evaluate_predictions`` call). Only the parent-side load is shared.
+    Use ``executor=serial`` to maximize the amortization benefit.
+    """
+    conditions = OmegaConf.select(config, "conditions", default=None)
+    if not conditions:
+        raise ValueError("evaluate_predictions_grouped requires a non-empty top-level 'conditions' list")
+
+    executor = OmegaConf.select(config, "runtime.executor", default="serial")
+    if executor == "process":
+        print(
+            "[grouped] note: runtime.executor=process — workers re-load models per "
+            "condition; only the parent-side load is amortized. Use executor=serial "
+            "to share extractors across all conditions."
+        )
+
+    base_for_models = _merge_condition(config, conditions[0])
+    apply_dataset_ref(base_for_models)
+    print(f"[grouped] loading shared models from condition 0 of {len(conditions)} ...")
+    models = load_eval_models(base_for_models)
+
+    results: list[tuple[str, tuple]] = []
+    for idx, cond in enumerate(conditions):
+        name = (
+            cond.get("name", str(idx)) if isinstance(cond, dict) else OmegaConf.select(cond, "name", default=str(idx))
+        )
+        merged = _merge_condition(config, cond)
+        apply_dataset_ref(merged)
+        _check_grouped_field_invariants(base_for_models, merged, name)
+        print(f"[grouped] ({idx + 1}/{len(conditions)}) evaluating {name!r} → {merged.save.save_dir}")
+
+        if _final_metrics_cache_valid(merged):
+            print(f"[grouped] ({idx + 1}/{len(conditions)}) {name!r}: reusing cached final metrics")
+            save_dir = Path(merged.save.save_dir)
+            pixel_metrics = np.load(save_dir / merged.save.pixel_metrics_filename, allow_pickle=True).tolist()
+            mask_metrics = np.load(save_dir / merged.save.mask_metrics_filename, allow_pickle=True).tolist()
+            if merged.compute_feature_metrics:
+                feature_metrics = np.load(save_dir / merged.save.feature_metrics_filename, allow_pickle=True).tolist()
+            else:
+                feature_metrics = []
+        else:
+            pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(merged, models=models)
+            save_metrics(
+                merged,
+                pixel_metrics=pixel_metrics,
+                mask_metrics=mask_metrics,
+                feature_metrics=feature_metrics,
+            )
+        results.append((name, (pixel_metrics, mask_metrics, feature_metrics)))
+
+    return results
+
+
 @hydra.main(version_base="1.2", config_path="_configs", config_name="eval")
 def evaluate_model(config: DictConfig):
     """Evaluate model on test images."""
@@ -1181,6 +1270,12 @@ def evaluate_model(config: DictConfig):
             feature_metrics=feature_metrics,
         )
     return pixel_metrics, mask_metrics, feature_metrics
+
+
+@hydra.main(version_base="1.2", config_path="_configs", config_name="eval_grouped")
+def evaluate_model_grouped(config: DictConfig):
+    """Run grouped multi-condition eval, amortizing model loads across conditions."""
+    return evaluate_predictions_grouped(config)
 
 
 if __name__ == "__main__":

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1186,12 +1186,36 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
         raise ValueError("evaluate_predictions_grouped requires a non-empty top-level 'conditions' list")
 
     executor = OmegaConf.select(config, "runtime.executor", default="serial")
-    if executor == "process":
-        print(
-            "[grouped] note: runtime.executor=process — workers re-load models per "
-            "condition; only the parent-side load is amortized. Use executor=serial "
-            "to share extractors across all conditions."
-        )
+    require_complete = bool(OmegaConf.select(config, "io.require_complete_cache", default=False))
+    n_conditions = len(conditions)
+    if executor == "process" and n_conditions > 1:
+        if require_complete:
+            # Cache-only path: workers skip prepare_segmentation_model (returns
+            # None) and don't instantiate extractors. Pool re-spawn is the only
+            # overhead — mild informational note, not a warning.
+            print(
+                "[grouped] note: runtime.executor=process with require_complete_cache=true — "
+                f"workers re-init per condition but no models actually load. "
+                f"{n_conditions} pool spawns total; consider executor=serial to skip "
+                "spawn overhead entirely."
+            )
+        else:
+            # Worst-case: each condition's worker pool independently loads
+            # SuperModel + DINOv3 + DynaCLR + CELL-DINO. Total wasted
+            # cold-start ≈ load_time × N_workers × N_conditions.
+            print(
+                "\n"
+                "[grouped] !!! WARNING: runtime.executor=process + "
+                f"{n_conditions} conditions + require_complete_cache=false !!!\n"
+                "  Each condition's worker pool independently loads SuperModel + "
+                "DINOv3 + DynaCLR + CELL-DINO.\n"
+                "  Expected waste: ~30-90 s × N_workers × "
+                f"{n_conditions} conditions of redundant cold-start.\n"
+                "  Fix: set runtime.executor=serial to share the parent's pre-loaded "
+                "models across conditions.\n"
+                "  Use process mode only when you need per-FOV parallelism within a "
+                "single condition.\n"
+            )
 
     # Canonical baseline for invariant checks: the input config with the
     # ``conditions`` list dropped. Snapshot once; conditions are validated

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -35,13 +35,12 @@ from dynacell.evaluation.metrics import (
     evaluate_segmentations,
     features_from_crops,
 )
-from dynacell.evaluation.model_loader import EvalModels, load_eval_models
+from dynacell.evaluation.model_loader import EvalModels, init_cache_contexts, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
     flush_manifest,
     fov_cp_features,
     fov_deep_features,
     fov_masks,
-    init_cache_context,
     precompute_deep_features,
 )
 from dynacell.evaluation.utils import plot_metrics
@@ -534,22 +533,7 @@ def _worker_setup(config: DictConfig) -> None:
     with gpu_serialization_lock(gate=use_gpu):
         models = load_eval_models(config)
 
-    cache_ctx = init_cache_context(
-        config,
-        side="gt",
-        dinov3_model_name=models.dinov3_model_name,
-        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
-        celldino_weights_path=models.celldino_weights_path,
-    )
-    pred_cache_ctx = init_cache_context(
-        config,
-        side="pred",
-        dinov3_model_name=models.dinov3_model_name,
-        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
-        celldino_weights_path=models.celldino_weights_path,
-    )
+    cache_ctx, pred_cache_ctx = init_cache_contexts(config, models)
 
     _WORKER_STATE.update(
         {
@@ -699,22 +683,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
     dynaclr_feature_extractor = models.dynaclr
     celldino_feature_extractor = models.celldino
 
-    cache_ctx = init_cache_context(
-        config,
-        side="gt",
-        dinov3_model_name=models.dinov3_model_name,
-        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
-        celldino_weights_path=models.celldino_weights_path,
-    )
-    pred_cache_ctx = init_cache_context(
-        config,
-        side="pred",
-        dinov3_model_name=models.dinov3_model_name,
-        dynaclr_ckpt_path=models.dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=models.dynaclr_encoder_cfg,
-        celldino_weights_path=models.celldino_weights_path,
-    )
+    cache_ctx, pred_cache_ctx = init_cache_contexts(config, models)
 
     seg_path = Path(io_config.cell_segmentation_path) if io_config.cell_segmentation_path is not None else None
 
@@ -1115,6 +1084,18 @@ def _final_metrics_cache_valid(config: DictConfig) -> bool:
     return pixel_ok and mask_ok and feature_ok
 
 
+def _load_cached_final_metrics(config: DictConfig) -> tuple[list, list, list]:
+    """Reload the (pixel, mask, feature) NPY caches saved by ``save_metrics``."""
+    save_dir = Path(config.save.save_dir)
+    pixel = np.load(save_dir / config.save.pixel_metrics_filename, allow_pickle=True).tolist()
+    mask = np.load(save_dir / config.save.mask_metrics_filename, allow_pickle=True).tolist()
+    if config.compute_feature_metrics:
+        feature = np.load(save_dir / config.save.feature_metrics_filename, allow_pickle=True).tolist()
+    else:
+        feature = []
+    return pixel, mask, feature
+
+
 _MODEL_LOADING_FIELDS: tuple[str, ...] = (
     "target_name",
     "feature_extractor",
@@ -1123,41 +1104,42 @@ _MODEL_LOADING_FIELDS: tuple[str, ...] = (
 )
 
 
-def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
-    """Return a deep copy of ``base`` with ``overrides`` deep-merged in.
+def _snapshot_field(cfg: DictConfig, cfg_field: str):
+    """Resolve a model-loading field to a comparable plain Python value."""
+    node = OmegaConf.select(cfg, cfg_field, default=None)
+    if OmegaConf.is_config(node):
+        return OmegaConf.to_container(node, resolve=False)
+    return node
 
-    The returned config is fully independent (mutations don't leak into
-    ``base``). The ``conditions`` field is stripped from the copy so each
-    per-condition run sees a normal single-condition shape.
+
+def _merge_condition(base: DictConfig, overrides: DictConfig | dict) -> DictConfig:
+    """Return a fresh DictConfig with ``overrides`` deep-merged into ``base``.
+
+    ``OmegaConf.merge`` already returns a config independent of its inputs,
+    so no upfront deep-copy is needed. The ``conditions`` field (the list
+    we're iterating over) and the per-overlay ``name`` label are stripped
+    from the result so each per-condition run sees a normal
+    single-condition config shape.
     """
-    base_copy = OmegaConf.create(OmegaConf.to_container(base, resolve=False))
-    if "conditions" in base_copy:
-        del base_copy["conditions"]
-    merged = OmegaConf.merge(base_copy, OmegaConf.create(overrides))
-    if "name" in merged:
-        del merged["name"]
+    merged = OmegaConf.merge(base, OmegaConf.create(overrides))
+    for key in ("conditions", "name"):
+        if key in merged:
+            del merged[key]
     return merged  # type: ignore[return-value]
 
 
-def _check_grouped_field_invariants(base: DictConfig, merged: DictConfig, condition_name: str) -> None:
-    """Raise if any model-loading field differs between base and merged.
+def _check_grouped_field_invariants(base_snapshot: dict[str, object], merged: DictConfig, condition_name: str) -> None:
+    """Raise if a per-condition merged config disagrees with the baseline on model-loading fields.
 
-    Per-condition overrides may freely change ``io.*``, ``save.*``,
-    ``runtime.*``, ``limit_positions``, and ``force_recompute.*``, but
-    must NOT touch the fields that determine which models get loaded —
-    that would defeat the whole point of sharing models across conditions.
+    ``base_snapshot`` is computed once per grouped run from the
+    conditions-stripped base, so condition 0 is validated symmetrically
+    with all later conditions (a condition 0 overlay that sneaks in e.g.
+    ``target_name`` would be rejected, not silently adopted as the new
+    "base").
     """
-
-    def _snapshot(cfg: DictConfig, field: str):
-        node = OmegaConf.select(cfg, field, default=None)
-        if isinstance(node, (DictConfig, type(OmegaConf.create([])))):
-            return OmegaConf.to_container(node, resolve=False)
-        return node
-
     for cfg_field in _MODEL_LOADING_FIELDS:
-        base_val = _snapshot(base, cfg_field)
-        merged_val = _snapshot(merged, cfg_field)
-        if base_val != merged_val:
+        merged_val = _snapshot_field(merged, cfg_field)
+        if base_snapshot[cfg_field] != merged_val:
             raise ValueError(
                 f"Condition {condition_name!r}: overrides changed model-loading field "
                 f"{cfg_field!r}. Move it to the base config or run this condition separately."
@@ -1170,6 +1152,9 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
     Reads ``config.conditions`` (list of per-condition overrides). For each
     condition, merges its overrides into a copy of the base config and
     calls :func:`evaluate_predictions` with the shared ``EvalModels``.
+    Models are loaded lazily on the first condition that misses its
+    ``_final_metrics_cache_valid`` short-circuit, so restarts where every
+    condition is cache-hit pay no cold-start.
 
     Conditions may freely override ``io.*``, ``save.*``, ``runtime.*``,
     ``limit_positions``, and ``force_recompute.*``. They must NOT change
@@ -1208,10 +1193,22 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
             "to share extractors across all conditions."
         )
 
-    base_for_models = _merge_condition(config, conditions[0])
-    apply_dataset_ref(base_for_models)
-    print(f"[grouped] loading shared models from condition 0 of {len(conditions)} ...")
-    models = load_eval_models(base_for_models)
+    # Canonical baseline for invariant checks: the input config with the
+    # ``conditions`` list dropped. Snapshot once; conditions are validated
+    # against this, including condition 0.
+    models_base = OmegaConf.merge(config, OmegaConf.create({}))
+    if "conditions" in models_base:
+        del models_base["conditions"]
+    base_snapshot = {field: _snapshot_field(models_base, field) for field in _MODEL_LOADING_FIELDS}
+
+    models: EvalModels | None = None
+
+    def get_models() -> EvalModels:
+        nonlocal models
+        if models is None:
+            print(f"[grouped] loading shared models for {len(conditions)} conditions ...")
+            models = load_eval_models(models_base)
+        return models
 
     results: list[tuple[str, tuple]] = []
     for idx, cond in enumerate(conditions):
@@ -1220,20 +1217,14 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
         )
         merged = _merge_condition(config, cond)
         apply_dataset_ref(merged)
-        _check_grouped_field_invariants(base_for_models, merged, name)
+        _check_grouped_field_invariants(base_snapshot, merged, name)
         print(f"[grouped] ({idx + 1}/{len(conditions)}) evaluating {name!r} → {merged.save.save_dir}")
 
         if _final_metrics_cache_valid(merged):
             print(f"[grouped] ({idx + 1}/{len(conditions)}) {name!r}: reusing cached final metrics")
-            save_dir = Path(merged.save.save_dir)
-            pixel_metrics = np.load(save_dir / merged.save.pixel_metrics_filename, allow_pickle=True).tolist()
-            mask_metrics = np.load(save_dir / merged.save.mask_metrics_filename, allow_pickle=True).tolist()
-            if merged.compute_feature_metrics:
-                feature_metrics = np.load(save_dir / merged.save.feature_metrics_filename, allow_pickle=True).tolist()
-            else:
-                feature_metrics = []
+            pixel_metrics, mask_metrics, feature_metrics = _load_cached_final_metrics(merged)
         else:
-            pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(merged, models=models)
+            pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(merged, models=get_models())
             save_metrics(
                 merged,
                 pixel_metrics=pixel_metrics,
@@ -1249,18 +1240,9 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
 def evaluate_model(config: DictConfig):
     """Evaluate model on test images."""
     apply_dataset_ref(config)
-    save_dir = Path(config.save.save_dir)
-    pixel_metrics_path = save_dir / config.save.pixel_metrics_filename
-    mask_metrics_path = save_dir / config.save.mask_metrics_filename
-    feature_metrics_path = save_dir / config.save.feature_metrics_filename
     if _final_metrics_cache_valid(config):
         print("Found existing metrics.")
-        pixel_metrics = np.load(pixel_metrics_path, allow_pickle=True).tolist()
-        mask_metrics = np.load(mask_metrics_path, allow_pickle=True).tolist()
-        if config.compute_feature_metrics:
-            feature_metrics = np.load(feature_metrics_path, allow_pickle=True).tolist()
-        else:
-            feature_metrics = []
+        pixel_metrics, mask_metrics, feature_metrics = _load_cached_final_metrics(config)
     else:
         pixel_metrics, mask_metrics, feature_metrics = evaluate_predictions(config)
         save_metrics(

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -21,21 +21,18 @@ from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
 from dynacell.evaluation.metrics import build_crops
+from dynacell.evaluation.model_loader import LoadFlags, init_gt_cache_context, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
     DeepFeatureBatcher,
     flush_manifest,
     fov_cp_features,
     fov_masks,
-    init_cache_context,
-    resolve_dynaclr_encoder_cfg,
 )
 
 
 def precompute_gt_artifacts(config: DictConfig) -> None:
     """Build every GT-side artifact toggled on in ``config.build``."""
     from dynacell.evaluation.runtime import apply_thread_budget, resolve_runtime
-    from dynacell.evaluation.segmentation import prepare_segmentation_model
-    from dynacell.evaluation.utils import CellDinoFeatureExtractor, DinoV3FeatureExtractor, DynaCLRFeatureExtractor
 
     if config.io.gt_cache_dir is None:
         raise ValueError("io.gt_cache_dir is required for dynacell precompute-gt")
@@ -62,46 +59,28 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
             "build.cp / build.dinov3 / build.dynaclr / build.celldino is true"
         )
 
-    seg_model = prepare_segmentation_model(config) if build.masks else None
+    # Stricter celldino gate than evaluate_predictions: precompute-gt
+    # requires an explicit weights path when build.celldino=true (the
+    # eval path soft-skips a null weights_path; here it would silently
+    # produce no cache, so we surface it as an error).
+    if build.celldino and config.feature_extractor.celldino.weights_path is None:
+        raise ValueError("feature_extractor.celldino.weights_path is required when build.celldino=true")
 
-    dinov3_model_name = None
-    dynaclr_ckpt_path = None
-    dynaclr_encoder_cfg = None
-    celldino_weights_path = None
-    dinov3_feature_extractor = None
-    dynaclr_feature_extractor = None
-    celldino_feature_extractor = None
-
-    if build.dinov3:
-        dinov3_model_name = config.feature_extractor.dinov3.pretrained_model_name
-        dinov3_feature_extractor = DinoV3FeatureExtractor(dinov3_model_name)
-    if build.dynaclr:
-        dynaclr_config = config.feature_extractor.dynaclr
-        dynaclr_ckpt_path = str(dynaclr_config.checkpoint)
-        dynaclr_encoder_cfg = resolve_dynaclr_encoder_cfg(config)
-        dynaclr_feature_extractor = DynaCLRFeatureExtractor(
-            checkpoint=dynaclr_config.checkpoint,
-            encoder_config=dynaclr_encoder_cfg,
-        )
-    if build.celldino:
-        celldino_cfg = config.feature_extractor.celldino
-        if celldino_cfg.weights_path is None:
-            raise ValueError("feature_extractor.celldino.weights_path is required when build.celldino=true")
-        celldino_weights_path = str(celldino_cfg.weights_path)
-        celldino_feature_extractor = CellDinoFeatureExtractor(
-            weights_path=celldino_weights_path,
-            img_size=int(celldino_cfg.img_size),
-            patch_size=int(celldino_cfg.patch_size),
-        )
-
-    cache_ctx = init_cache_context(
+    models = load_eval_models(
         config,
-        side="gt",
-        dinov3_model_name=dinov3_model_name,
-        dynaclr_ckpt_path=dynaclr_ckpt_path,
-        dynaclr_encoder_cfg=dynaclr_encoder_cfg,
-        celldino_weights_path=celldino_weights_path,
+        flags=LoadFlags(
+            masks=bool(build.masks),
+            dinov3=bool(build.dinov3),
+            dynaclr=bool(build.dynaclr),
+            celldino=bool(build.celldino),
+        ),
     )
+    seg_model = models.seg_model
+    dinov3_feature_extractor = models.dinov3
+    dynaclr_feature_extractor = models.dynaclr
+    celldino_feature_extractor = models.celldino
+
+    cache_ctx = init_gt_cache_context(config, models)
 
     gt_path = Path(config.io.gt_path)
     seg_path = Path(config.io.cell_segmentation_path) if config.io.cell_segmentation_path is not None else None

--- a/applications/dynacell/tests/_eval_fixtures.py
+++ b/applications/dynacell/tests/_eval_fixtures.py
@@ -1,0 +1,213 @@
+"""Shared cache-only fixture helpers for dynacell eval integration tests.
+
+Underscore prefix keeps pytest from collecting this file as tests. Imported
+by ``test_evaluation_pipeline_parallel_cpu.py`` and
+``test_evaluation_grouped.py`` (and any future eval test that wants the
+same scaffolding) — see CLAUDE.md "no ``sys.path`` edits" rule.
+
+Builds tiny iohub HCS plates + pre-populated mask caches so the
+cache-only eval path (``target_name=er`` + ``require_complete_cache=true``
++ ``compute_feature_metrics=false``) runs end-to-end without loading any
+segmenter / extractor / cubic — small enough to fit a single-CPU CI in
+under ~30 s.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+from iohub.ngff import open_ome_zarr
+from omegaconf import OmegaConf
+
+N_POSITIONS = 3
+T = 2
+D = 4
+H = 32
+W = 32
+
+
+def live_pipeline_module():
+    """Force-import a fresh ``dynacell.evaluation.pipeline`` module.
+
+    Other tests (e.g. ``test_evaluation_pipeline.py``) stub
+    ``dynacell.evaluation.metrics`` via ``monkeypatch.setitem(sys.modules,
+    ...)``. After teardown ``sys.modules`` may still hold the stubbed
+    modules AND the pipeline module's bound ``compute_pixel_metrics``
+    reference. Clear every ``dynacell.evaluation.*`` cache entry before
+    re-import so we get fresh modules with real implementations.
+    """
+    for name in list(sys.modules):
+        if name.startswith("dynacell.evaluation"):
+            sys.modules.pop(name, None)
+    return importlib.import_module("dynacell.evaluation.pipeline")
+
+
+def make_hcs_plate(path: Path, channel_name: str, seed: int) -> None:
+    """Create a tiny HCS plate with ``N_POSITIONS`` positions of shape ``(T, 1, D, H, W)``.
+
+    Positions are named ``A/1/{i}`` for ``i in range(N_POSITIONS)``. Pixel
+    values are deterministic from ``seed`` so pred and GT differ
+    predictably.
+    """
+    rng = np.random.default_rng(seed)
+    with open_ome_zarr(path, mode="w", layout="hcs", channel_names=[channel_name], version="0.5") as plate:
+        for i in range(N_POSITIONS):
+            pos = plate.create_position("A", "1", str(i))
+            data = rng.uniform(0.0, 1.0, size=(T, 1, D, H, W)).astype(np.float32)
+            pos.create_image("0", data)
+
+
+def make_mask_cache(
+    cache_dir: Path,
+    plate_path: Path,
+    channel_name: str,
+    side: str,
+    target_name: str = "er",
+) -> None:
+    """Prebuild a mask cache (zarr + manifest) for ``N_POSITIONS`` positions.
+
+    Mask values are deterministic per (side, position, t): GT masks fill
+    the upper half of the (H, W) plane; pred masks fill the upper
+    quadrant. This makes DICE / IoU deterministic and non-trivially
+    different between sides. ``side`` is ``"gt"`` or ``"pred"``.
+    """
+    from dynacell.evaluation.cache import (
+        CACHE_SCHEMA_VERSION,
+        cache_paths,
+        save_manifest,
+        write_mask,
+    )
+
+    paths = cache_paths(cache_dir)
+    mask_channel = "target_seg" if side == "gt" else "prediction_seg"
+
+    pos_names = [f"A/1/{i}" for i in range(N_POSITIONS)]
+    for pos_name in pos_names:
+        masks = np.zeros((T, D, H, W), dtype=bool)
+        if side == "gt":
+            masks[:, :, : H // 2, :] = True
+        else:
+            masks[:, :, : H // 2, : W // 2] = True
+        write_mask(paths, target_name, pos_name, masks, channel_name=mask_channel)
+
+    source_tag: dict[str, str] = {} if side == "gt" else {"source": "prediction"}
+    now = datetime.now(UTC).isoformat()
+    manifest = {
+        "cache_schema_version": CACHE_SCHEMA_VERSION,
+        "gt" if side == "gt" else "pred": {
+            "plate_path": str(plate_path),
+            "channel_name": channel_name,
+        },
+        "artifacts": {
+            "organelle_masks": {
+                target_name: {
+                    "target_name": target_name,
+                    "path": f"organelle_masks/{target_name}.zarr",
+                    "built_at": now,
+                    "positions": pos_names,
+                    **source_tag,
+                }
+            },
+        },
+    }
+    save_manifest(paths, manifest)
+
+
+def build_eval_config(
+    pred_path: Path,
+    gt_path: Path,
+    gt_cache_dir: Path,
+    pred_cache_dir: Path,
+    save_dir: Path,
+    *,
+    executor: str,
+    fov_workers: int,
+):
+    """Compose a minimal cache-only eval config."""
+    return OmegaConf.create(
+        {
+            "target_name": "er",
+            "io": {
+                "pred_path": str(pred_path),
+                "gt_path": str(gt_path),
+                "pred_channel_name": "prediction",
+                "gt_channel_name": "target",
+                "cell_segmentation_path": None,
+                "gt_cache_dir": str(gt_cache_dir),
+                "pred_cache_dir": str(pred_cache_dir),
+                "require_complete_cache": True,
+            },
+            "pixel_metrics": {
+                "spacing": [1.0, 1.0, 1.0],
+                "fsc": None,
+                "spectral_pcc": None,
+            },
+            "feature_metrics": {
+                "patch_size": 64,
+                "deep_feature_batch_threshold": 256,
+            },
+            "use_gpu": False,
+            "compute_microssim": False,
+            "compute_feature_metrics": False,
+            "limit_positions": None,
+            "force_recompute": {
+                "all": False,
+                "gt_masks": False,
+                "gt_cp": False,
+                "gt_dinov3": False,
+                "gt_dynaclr": False,
+                "gt_celldino": False,
+                "pred_masks": False,
+                "pred_cp": False,
+                "pred_dinov3": False,
+                "pred_dynaclr": False,
+                "pred_celldino": False,
+                "final_metrics": False,
+            },
+            "save": {
+                "save_dir": str(save_dir),
+                "pixel_csv_filename": "pixel_metrics.csv",
+                "pixel_metrics_filename": "pixel_metrics.npy",
+                "mask_csv_filename": "mask_metrics.csv",
+                "mask_metrics_filename": "mask_metrics.npy",
+                "feature_csv_filename": "feature_metrics.csv",
+                "feature_metrics_filename": "feature_metrics.npy",
+            },
+            "runtime": {
+                "fov_workers": fov_workers,
+                "threads_per_worker": "auto",
+                "executor": executor,
+                "cuda_empty_cache_every_n_timepoints": 0,
+                "gc_collect_every_n_fovs": 0,
+            },
+        }
+    )
+
+
+def build_fixture(root: Path):
+    """Build matched pred + GT plates and mask caches under ``root``.
+
+    Returns ``(pred_path, gt_path, gt_cache_dir, pred_cache_dir)``.
+    """
+    pred_path = root / "pred.zarr"
+    gt_path = root / "gt.zarr"
+    gt_cache_dir = root / "gt_cache"
+    pred_cache_dir = root / "pred_cache"
+    make_hcs_plate(pred_path, "prediction", seed=42)
+    make_hcs_plate(gt_path, "target", seed=7)
+    make_mask_cache(gt_cache_dir, gt_path, "target", side="gt")
+    make_mask_cache(pred_cache_dir, pred_path, "prediction", side="pred")
+    return pred_path, gt_path, gt_cache_dir, pred_cache_dir
+
+
+def read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
+    """Return ``{pos_name: data}`` for every position in an HCS plate."""
+    out: dict[str, np.ndarray] = {}
+    with open_ome_zarr(plate_path, mode="r") as plate:
+        for name, pos in plate.positions():
+            out[name] = np.asarray(pos.data[:])
+    return out

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -1,0 +1,191 @@
+"""Parity test for the grouped multi-condition eval driver.
+
+Builds two independent fixtures (each its own pred + GT plates + mask
+caches), runs them once via ``evaluate_predictions_grouped`` and once
+via two back-to-back ``evaluate_predictions`` calls, and asserts the
+outputs are byte-equal per condition.
+
+Cache-only design (same shape as
+``test_evaluation_pipeline_parallel_cpu.py``): ``target_name=er`` +
+``io.require_complete_cache=true`` + ``compute_feature_metrics=false``
+means no segmenter / extractors / cubic are loaded — the test
+validates the **loop structure** of the grouped driver, not the
+model-sharing speedup (which is hermetic-untestable).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from iohub.ngff import open_ome_zarr
+from omegaconf import OmegaConf
+
+# Reuse the fixture builders from the parallel-CPU integration test —
+# they already produce a deterministic, cache-complete fixture for the
+# cache-only fast path.
+sys.path.insert(0, str(Path(__file__).parent))
+from test_evaluation_pipeline_parallel_cpu import (  # noqa: E402
+    N_POSITIONS,
+    T,
+    _build_eval_config,
+    _build_fixture,
+    _live_pipeline_module,
+)
+
+
+def _read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
+    out: dict[str, np.ndarray] = {}
+    with open_ome_zarr(plate_path, mode="r") as plate:
+        for name, pos in plate.positions():
+            out[name] = np.asarray(pos.data[:])
+    return out
+
+
+def _build_grouped_config(
+    cond_a_root: Path,
+    cond_b_root: Path,
+    save_root: Path,
+) -> OmegaConf:
+    """Construct the grouped config with two condition overlays.
+
+    The base mirrors ``_build_eval_config`` (cache-only flags) and the
+    conditions overlay only the per-condition io + save paths.
+    """
+    pred_a, gt_a, gt_cache_a, pred_cache_a = _build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = _build_fixture(cond_b_root)
+
+    base = _build_eval_config(
+        pred_a,  # placeholder; overridden per condition
+        gt_a,
+        gt_cache_a,
+        pred_cache_a,
+        save_root / "_unused",
+        executor="serial",
+        fov_workers=1,
+    )
+    # Strip the placeholder io/save — conditions own those entirely.
+    base["io"]["pred_path"] = None
+    base["io"]["gt_path"] = None
+    base["io"]["gt_cache_dir"] = None
+    base["io"]["pred_cache_dir"] = None
+    base["save"]["save_dir"] = None
+
+    base["conditions"] = [
+        {
+            "name": "cond_a",
+            "io": {
+                "pred_path": str(pred_a),
+                "gt_path": str(gt_a),
+                "gt_cache_dir": str(gt_cache_a),
+                "pred_cache_dir": str(pred_cache_a),
+            },
+            "save": {"save_dir": str(save_root / "cond_a_grouped")},
+        },
+        {
+            "name": "cond_b",
+            "io": {
+                "pred_path": str(pred_b),
+                "gt_path": str(gt_b),
+                "gt_cache_dir": str(gt_cache_b),
+                "pred_cache_dir": str(pred_cache_b),
+            },
+            "save": {"save_dir": str(save_root / "cond_b_grouped")},
+        },
+    ]
+    return base
+
+
+def test_grouped_matches_sequential_per_condition(tmp_path: Path):
+    """Grouped eval produces byte-equal outputs to sequential per-condition runs.
+
+    Validates the loop structure of ``evaluate_predictions_grouped``:
+    per-condition merge, config independence (no cross-contamination),
+    seg plate write paths, CSV output paths.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    # Sequential per-condition baseline.
+    pred_a, gt_a, gt_cache_a, pred_cache_a = _build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = _build_fixture(cond_b_root)
+    save_a_seq = save_root / "cond_a_seq"
+    save_b_seq = save_root / "cond_b_seq"
+    save_a_seq.mkdir()
+    save_b_seq.mkdir()
+
+    pipeline = _live_pipeline_module()
+    cfg_a_seq = _build_eval_config(pred_a, gt_a, gt_cache_a, pred_cache_a, save_a_seq, executor="serial", fov_workers=1)
+    cfg_b_seq = _build_eval_config(pred_b, gt_b, gt_cache_b, pred_cache_b, save_b_seq, executor="serial", fov_workers=1)
+    pixel_a_seq, mask_a_seq, _ = pipeline.evaluate_predictions(cfg_a_seq)
+    pixel_b_seq, mask_b_seq, _ = pipeline.evaluate_predictions(cfg_b_seq)
+
+    # Grouped run reuses the same fixture roots (deterministic) but uses
+    # its own save dirs so we can compare side by side.
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    pipeline = _live_pipeline_module()
+    results = pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+    assert [name for name, _ in results] == ["cond_a", "cond_b"]
+    (_, (pixel_a_grp, mask_a_grp, _)), (_, (pixel_b_grp, mask_b_grp, _)) = results
+
+    def _sort_key(row: dict):
+        return (row["FOV"], row["Timepoint"])
+
+    assert sorted(pixel_a_grp, key=_sort_key) == sorted(pixel_a_seq, key=_sort_key)
+    assert sorted(mask_a_grp, key=_sort_key) == sorted(mask_a_seq, key=_sort_key)
+    assert sorted(pixel_b_grp, key=_sort_key) == sorted(pixel_b_seq, key=_sort_key)
+    assert sorted(mask_b_grp, key=_sort_key) == sorted(mask_b_seq, key=_sort_key)
+
+    for cond_name, save_seq, save_grp in [
+        ("cond_a", save_a_seq, save_root / "cond_a_grouped"),
+        ("cond_b", save_b_seq, save_root / "cond_b_grouped"),
+    ]:
+        arrs_seq = _read_position_arrays(save_seq / "segmentation_results.zarr")
+        arrs_grp = _read_position_arrays(save_grp / "segmentation_results.zarr")
+        assert set(arrs_seq.keys()) == set(arrs_grp.keys()), f"{cond_name} position set mismatch"
+        for pos_name, arr_seq in arrs_seq.items():
+            np.testing.assert_array_equal(arr_seq, arrs_grp[pos_name], err_msg=f"{cond_name}/{pos_name}")
+
+    assert len(pixel_a_grp) == N_POSITIONS * T
+    assert len(pixel_b_grp) == N_POSITIONS * T
+
+
+def test_grouped_rejects_model_loading_field_overrides(tmp_path: Path):
+    """Per-condition overrides on model-loading fields must raise."""
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    # Sabotage: condition B tries to override target_name.
+    grouped_cfg["conditions"][1]["target_name"] = "membrane"
+
+    pipeline = _live_pipeline_module()
+    with pytest.raises(ValueError, match="model-loading field"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_rejects_empty_conditions(tmp_path: Path):
+    """Missing or empty 'conditions' list must raise an informative error."""
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"] = []
+
+    pipeline = _live_pipeline_module()
+    with pytest.raises(ValueError, match="non-empty"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from omegaconf import OmegaConf
 
 from ._eval_fixtures import (
     N_POSITIONS,
@@ -236,6 +237,57 @@ def test_grouped_mild_note_on_process_plus_cache_only(tmp_path: Path, capsys):
     assert "[grouped] note:" in out
     assert "no models actually load" in out
     assert "WARNING" not in out, f"unexpected loud warning under cache-only path: {out!r}"
+
+
+def test_grouped_rejects_require_complete_cache_override(tmp_path: Path):
+    """``io.require_complete_cache`` is a grouped invariant — overrides must raise.
+
+    The base config's ``io.require_complete_cache`` determines whether
+    ``load_eval_models`` instantiates a real ``SuperModel`` or returns
+    ``None``. Letting a condition flip this would mean the shared models
+    bundle disagrees with the condition's actual needs (None when
+    cache-miss expects a real segmenter, or loaded but never used). Guard
+    by treating it as a model-loading invariant.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"][1]["io"]["require_complete_cache"] = False
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="require_complete_cache"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_works_on_struct_mode_config(tmp_path: Path):
+    """Grouped driver must work on Hydra-composed (struct-mode) configs.
+
+    Real ``dynacell evaluate-grouped`` invocations go through
+    ``@hydra.main`` which always produces a struct-mode ``DictConfig``.
+    ``OmegaConf.merge`` propagates struct mode, so merging an overlay
+    carrying a ``name`` label (outside the schema) raises
+    ``ConfigKeyError``, and stripping ``conditions`` / ``name`` with
+    ``del`` raises ``ConfigTypeError``. The driver must escape struct
+    mode internally; this test guards against regression.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    OmegaConf.set_struct(grouped_cfg, True)
+
+    pipeline = live_pipeline_module()
+    results = pipeline.evaluate_predictions_grouped(grouped_cfg)
+    assert [name for name, _ in results] == ["cond_a", "cond_b"]
 
 
 def test_grouped_rejects_empty_conditions(tmp_path: Path):

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -11,54 +11,38 @@ Cache-only design (same shape as
 means no segmenter / extractors / cubic are loaded — the test
 validates the **loop structure** of the grouped driver, not the
 model-sharing speedup (which is hermetic-untestable).
+
+Fixture-building helpers live in ``_eval_fixtures.py``.
 """
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import numpy as np
 import pytest
-from iohub.ngff import open_ome_zarr
-from omegaconf import OmegaConf
 
-# Reuse the fixture builders from the parallel-CPU integration test —
-# they already produce a deterministic, cache-complete fixture for the
-# cache-only fast path.
-sys.path.insert(0, str(Path(__file__).parent))
-from test_evaluation_pipeline_parallel_cpu import (  # noqa: E402
+from ._eval_fixtures import (
     N_POSITIONS,
     T,
-    _build_eval_config,
-    _build_fixture,
-    _live_pipeline_module,
+    build_eval_config,
+    build_fixture,
+    live_pipeline_module,
+    read_position_arrays,
 )
-
-
-def _read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
-    out: dict[str, np.ndarray] = {}
-    with open_ome_zarr(plate_path, mode="r") as plate:
-        for name, pos in plate.positions():
-            out[name] = np.asarray(pos.data[:])
-    return out
 
 
 def _build_grouped_config(
     cond_a_root: Path,
     cond_b_root: Path,
     save_root: Path,
-) -> OmegaConf:
-    """Construct the grouped config with two condition overlays.
+):
+    """Construct the grouped config with two condition overlays."""
+    pred_a, gt_a, gt_cache_a, pred_cache_a = build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = build_fixture(cond_b_root)
 
-    The base mirrors ``_build_eval_config`` (cache-only flags) and the
-    conditions overlay only the per-condition io + save paths.
-    """
-    pred_a, gt_a, gt_cache_a, pred_cache_a = _build_fixture(cond_a_root)
-    pred_b, gt_b, gt_cache_b, pred_cache_b = _build_fixture(cond_b_root)
-
-    base = _build_eval_config(
-        pred_a,  # placeholder; overridden per condition
+    base = build_eval_config(
+        pred_a,
         gt_a,
         gt_cache_a,
         pred_cache_a,
@@ -99,12 +83,7 @@ def _build_grouped_config(
 
 
 def test_grouped_matches_sequential_per_condition(tmp_path: Path):
-    """Grouped eval produces byte-equal outputs to sequential per-condition runs.
-
-    Validates the loop structure of ``evaluate_predictions_grouped``:
-    per-condition merge, config independence (no cross-contamination),
-    seg plate write paths, CSV output paths.
-    """
+    """Grouped eval produces byte-equal outputs to sequential per-condition runs."""
     cond_a_root = tmp_path / "fixture_a"
     cond_b_root = tmp_path / "fixture_b"
     cond_a_root.mkdir()
@@ -112,24 +91,21 @@ def test_grouped_matches_sequential_per_condition(tmp_path: Path):
     save_root = tmp_path / "saves"
     save_root.mkdir()
 
-    # Sequential per-condition baseline.
-    pred_a, gt_a, gt_cache_a, pred_cache_a = _build_fixture(cond_a_root)
-    pred_b, gt_b, gt_cache_b, pred_cache_b = _build_fixture(cond_b_root)
+    pred_a, gt_a, gt_cache_a, pred_cache_a = build_fixture(cond_a_root)
+    pred_b, gt_b, gt_cache_b, pred_cache_b = build_fixture(cond_b_root)
     save_a_seq = save_root / "cond_a_seq"
     save_b_seq = save_root / "cond_b_seq"
     save_a_seq.mkdir()
     save_b_seq.mkdir()
 
-    pipeline = _live_pipeline_module()
-    cfg_a_seq = _build_eval_config(pred_a, gt_a, gt_cache_a, pred_cache_a, save_a_seq, executor="serial", fov_workers=1)
-    cfg_b_seq = _build_eval_config(pred_b, gt_b, gt_cache_b, pred_cache_b, save_b_seq, executor="serial", fov_workers=1)
+    pipeline = live_pipeline_module()
+    cfg_a_seq = build_eval_config(pred_a, gt_a, gt_cache_a, pred_cache_a, save_a_seq, executor="serial", fov_workers=1)
+    cfg_b_seq = build_eval_config(pred_b, gt_b, gt_cache_b, pred_cache_b, save_b_seq, executor="serial", fov_workers=1)
     pixel_a_seq, mask_a_seq, _ = pipeline.evaluate_predictions(cfg_a_seq)
     pixel_b_seq, mask_b_seq, _ = pipeline.evaluate_predictions(cfg_b_seq)
 
-    # Grouped run reuses the same fixture roots (deterministic) but uses
-    # its own save dirs so we can compare side by side.
     grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     results = pipeline.evaluate_predictions_grouped(grouped_cfg)
 
     assert [name for name, _ in results] == ["cond_a", "cond_b"]
@@ -147,8 +123,8 @@ def test_grouped_matches_sequential_per_condition(tmp_path: Path):
         ("cond_a", save_a_seq, save_root / "cond_a_grouped"),
         ("cond_b", save_b_seq, save_root / "cond_b_grouped"),
     ]:
-        arrs_seq = _read_position_arrays(save_seq / "segmentation_results.zarr")
-        arrs_grp = _read_position_arrays(save_grp / "segmentation_results.zarr")
+        arrs_seq = read_position_arrays(save_seq / "segmentation_results.zarr")
+        arrs_grp = read_position_arrays(save_grp / "segmentation_results.zarr")
         assert set(arrs_seq.keys()) == set(arrs_grp.keys()), f"{cond_name} position set mismatch"
         for pos_name, arr_seq in arrs_seq.items():
             np.testing.assert_array_equal(arr_seq, arrs_grp[pos_name], err_msg=f"{cond_name}/{pos_name}")
@@ -158,7 +134,7 @@ def test_grouped_matches_sequential_per_condition(tmp_path: Path):
 
 
 def test_grouped_rejects_model_loading_field_overrides(tmp_path: Path):
-    """Per-condition overrides on model-loading fields must raise."""
+    """Per-condition overrides on model-loading fields must raise — including condition 0."""
     cond_a_root = tmp_path / "fixture_a"
     cond_b_root = tmp_path / "fixture_b"
     cond_a_root.mkdir()
@@ -167,10 +143,33 @@ def test_grouped_rejects_model_loading_field_overrides(tmp_path: Path):
     save_root.mkdir()
 
     grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
-    # Sabotage: condition B tries to override target_name.
+    # Sabotage condition B's target_name.
     grouped_cfg["conditions"][1]["target_name"] = "membrane"
 
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="model-loading field"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
+def test_grouped_rejects_condition0_model_field_override(tmp_path: Path):
+    """A model-loading override smuggled into condition 0 must raise, not silently re-baseline.
+
+    Earlier wiring used ``conditions[0]``-merged config as the invariant
+    baseline, which would have made condition 0 implicitly trusted to
+    redefine ``target_name`` / ``feature_extractor.*`` etc. Guards
+    against regression of that asymmetry.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"][0]["target_name"] = "membrane"
+
+    pipeline = live_pipeline_module()
     with pytest.raises(ValueError, match="model-loading field"):
         pipeline.evaluate_predictions_grouped(grouped_cfg)
 
@@ -186,6 +185,6 @@ def test_grouped_rejects_empty_conditions(tmp_path: Path):
     grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
     grouped_cfg["conditions"] = []
 
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     with pytest.raises(ValueError, match="non-empty"):
         pipeline.evaluate_predictions_grouped(grouped_cfg)

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -174,6 +174,70 @@ def test_grouped_rejects_condition0_model_field_override(tmp_path: Path):
         pipeline.evaluate_predictions_grouped(grouped_cfg)
 
 
+def test_grouped_warns_loudly_on_process_plus_cache_miss(tmp_path: Path, capsys):
+    """``executor=process`` + multiple conditions + cache-miss prints a loud WARNING.
+
+    This combination is the worst case for amortization: each
+    condition's worker pool independently re-loads SuperModel + the
+    three deep extractors, so cold-start cost multiplies by
+    ``N_workers × N_conditions``. The driver should warn the user
+    upfront and recommend ``executor=serial``.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["runtime"]["executor"] = "process"
+    grouped_cfg["runtime"]["fov_workers"] = 2
+    grouped_cfg["io"]["require_complete_cache"] = False
+
+    # The grouped driver prints the warning before iterating conditions.
+    # The eval will then fail/succeed depending on cache state; we don't
+    # care — we just want the warning text in stdout.
+    pipeline = live_pipeline_module()
+    try:
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+    except Exception:
+        pass
+
+    out = capsys.readouterr().out
+    assert "WARNING" in out, f"expected loud warning, got: {out!r}"
+    assert "executor=process" in out
+    assert "require_complete_cache=false" in out
+    assert "executor=serial" in out
+
+
+def test_grouped_mild_note_on_process_plus_cache_only(tmp_path: Path, capsys):
+    """``executor=process`` + ``require_complete_cache=true`` gets a mild note, not the loud WARNING.
+
+    Under the cache-only path, workers skip ``prepare_segmentation_model``
+    and don't instantiate extractors — pool re-spawn is the only
+    overhead, which is small. The driver should inform but not alarm.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["runtime"]["executor"] = "process"
+    grouped_cfg["runtime"]["fov_workers"] = 2
+    # require_complete_cache stays True from the cache-only fixture.
+
+    pipeline = live_pipeline_module()
+    pipeline.evaluate_predictions_grouped(grouped_cfg)
+    out = capsys.readouterr().out
+    assert "[grouped] note:" in out
+    assert "no models actually load" in out
+    assert "WARNING" not in out, f"unexpected loud warning under cache-only path: {out!r}"
+
+
 def test_grouped_rejects_empty_conditions(tmp_path: Path):
     """Missing or empty 'conditions' list must raise an informative error."""
     cond_a_root = tmp_path / "fixture_a"

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
@@ -21,208 +21,25 @@ Result: the full pipeline runs without instantiating cellpose,
 SuperModel, DinoV3, DynaCLR, CellDino, or cubic — exercises spawn
 boot, DictConfig pickling, ``FovResult`` transport, parent-side HCS
 plate write, and the dataset-level aggregation contract.
+
+Fixture-building helpers live in ``_eval_fixtures.py`` (shared with
+``test_evaluation_grouped.py``).
 """
 
 from __future__ import annotations
 
-import importlib
-import sys
-from datetime import UTC, datetime
 from pathlib import Path
 
 import numpy as np
-import pytest  # noqa: F401  -- imported for future @pytest.mark uses
-from iohub.ngff import open_ome_zarr
-from omegaconf import OmegaConf
 
-
-def _live_pipeline_module():
-    """Force-import a fresh ``dynacell.evaluation.pipeline`` module.
-
-    Other tests (``test_evaluation_pipeline.py``) stub
-    ``dynacell.evaluation.metrics`` etc. via ``monkeypatch.setitem(sys.modules,
-    ...)``. After teardown, ``sys.modules`` may still hold the stubbed modules
-    AND the pipeline module's bound ``compute_pixel_metrics`` reference. Clear
-    every ``dynacell.evaluation.*`` cache entry before re-import so we get
-    fresh modules with real implementations.
-    """
-    for name in list(sys.modules):
-        if name.startswith("dynacell.evaluation"):
-            sys.modules.pop(name, None)
-    return importlib.import_module("dynacell.evaluation.pipeline")
-
-
-# Fixture dimensions — kept tiny so the test runs in CI (single-CPU) under ~30s.
-N_POSITIONS = 3
-T = 2
-D = 4
-H = 32
-W = 32
-
-
-def _make_hcs_plate(path: Path, channel_name: str, seed: int) -> None:
-    """Create a tiny HCS plate with ``N_POSITIONS`` positions of shape ``(T, 1, D, H, W)``.
-
-    Positions are named ``A/1/{i}`` for ``i in range(N_POSITIONS)``. Pixel
-    values are deterministic from ``seed`` so pred and GT differ predictably.
-    """
-    rng = np.random.default_rng(seed)
-    with open_ome_zarr(path, mode="w", layout="hcs", channel_names=[channel_name], version="0.5") as plate:
-        for i in range(N_POSITIONS):
-            pos = plate.create_position("A", "1", str(i))
-            data = rng.uniform(0.0, 1.0, size=(T, 1, D, H, W)).astype(np.float32)
-            pos.create_image("0", data)
-
-
-def _make_mask_cache(
-    cache_dir: Path,
-    plate_path: Path,
-    channel_name: str,
-    side: str,  # "gt" or "pred"
-    target_name: str = "er",
-) -> None:
-    """Prebuild a mask cache (zarr + manifest) for ``N_POSITIONS`` positions.
-
-    The mask values themselves are deterministic per (side, position, t):
-    GT masks are TRUE in the upper half of the (H, W) plane; pred masks
-    are TRUE in the upper quadrant. This guarantees the DICE / IoU
-    metrics are deterministic and non-trivially different between sides.
-    """
-    from dynacell.evaluation.cache import (
-        CACHE_SCHEMA_VERSION,
-        cache_paths,
-        save_manifest,
-        write_mask,
-    )
-
-    paths = cache_paths(cache_dir)
-    mask_channel = "target_seg" if side == "gt" else "prediction_seg"
-
-    pos_names = [f"A/1/{i}" for i in range(N_POSITIONS)]
-    for pos_name in pos_names:
-        masks = np.zeros((T, D, H, W), dtype=bool)
-        if side == "gt":
-            masks[:, :, : H // 2, :] = True  # upper half
-        else:
-            masks[:, :, : H // 2, : W // 2] = True  # upper quadrant
-        write_mask(paths, target_name, pos_name, masks, channel_name=mask_channel)
-
-    # Manifest entries must satisfy _validate_artifact_params: the
-    # masks_section.get(target_name) must equal {"target_name": ..., **source_tag}.
-    source_tag: dict[str, str] = {} if side == "gt" else {"source": "prediction"}
-    now = datetime.now(UTC).isoformat()
-    manifest = {
-        "cache_schema_version": CACHE_SCHEMA_VERSION,
-        "gt" if side == "gt" else "pred": {
-            "plate_path": str(plate_path),
-            "channel_name": channel_name,
-        },
-        "artifacts": {
-            "organelle_masks": {
-                target_name: {
-                    "target_name": target_name,
-                    "path": f"organelle_masks/{target_name}.zarr",
-                    "built_at": now,
-                    "positions": pos_names,
-                    **source_tag,
-                }
-            },
-        },
-    }
-    save_manifest(paths, manifest)
-
-
-def _build_eval_config(
-    pred_path: Path,
-    gt_path: Path,
-    gt_cache_dir: Path,
-    pred_cache_dir: Path,
-    save_dir: Path,
-    *,
-    executor: str,
-    fov_workers: int,
-):
-    """Compose a minimal eval config for the cache-only path."""
-    return OmegaConf.create(
-        {
-            "target_name": "er",
-            "io": {
-                "pred_path": str(pred_path),
-                "gt_path": str(gt_path),
-                "pred_channel_name": "prediction",
-                "gt_channel_name": "target",
-                "cell_segmentation_path": None,
-                "gt_cache_dir": str(gt_cache_dir),
-                "pred_cache_dir": str(pred_cache_dir),
-                "require_complete_cache": True,
-            },
-            "pixel_metrics": {
-                "spacing": [1.0, 1.0, 1.0],
-                "fsc": None,
-                "spectral_pcc": None,
-            },
-            "feature_metrics": {
-                "patch_size": 64,
-                "deep_feature_batch_threshold": 256,
-            },
-            "use_gpu": False,
-            "compute_microssim": False,
-            "compute_feature_metrics": False,
-            "limit_positions": None,
-            "force_recompute": {
-                "all": False,
-                "gt_masks": False,
-                "gt_cp": False,
-                "gt_dinov3": False,
-                "gt_dynaclr": False,
-                "gt_celldino": False,
-                "pred_masks": False,
-                "pred_cp": False,
-                "pred_dinov3": False,
-                "pred_dynaclr": False,
-                "pred_celldino": False,
-                "final_metrics": False,
-            },
-            "save": {
-                "save_dir": str(save_dir),
-                "pixel_csv_filename": "pixel_metrics.csv",
-                "pixel_metrics_filename": "pixel_metrics.npy",
-                "mask_csv_filename": "mask_metrics.csv",
-                "mask_metrics_filename": "mask_metrics.npy",
-                "feature_csv_filename": "feature_metrics.csv",
-                "feature_metrics_filename": "feature_metrics.npy",
-            },
-            "runtime": {
-                "fov_workers": fov_workers,
-                "threads_per_worker": "auto",
-                "executor": executor,
-                "cuda_empty_cache_every_n_timepoints": 0,
-                "gc_collect_every_n_fovs": 0,
-            },
-        }
-    )
-
-
-def _build_fixture(root: Path):
-    """Build pred + GT plates and matching mask caches under ``root``."""
-    pred_path = root / "pred.zarr"
-    gt_path = root / "gt.zarr"
-    gt_cache_dir = root / "gt_cache"
-    pred_cache_dir = root / "pred_cache"
-    _make_hcs_plate(pred_path, "prediction", seed=42)
-    _make_hcs_plate(gt_path, "target", seed=7)
-    _make_mask_cache(gt_cache_dir, gt_path, "target", side="gt")
-    _make_mask_cache(pred_cache_dir, pred_path, "prediction", side="pred")
-    return pred_path, gt_path, gt_cache_dir, pred_cache_dir
-
-
-def _read_position_arrays(plate_path: Path) -> dict[str, np.ndarray]:
-    """Return ``{pos_name: data}`` for every position in an HCS plate."""
-    out: dict[str, np.ndarray] = {}
-    with open_ome_zarr(plate_path, mode="r") as plate:
-        for name, pos in plate.positions():
-            out[name] = np.asarray(pos.data[:])
-    return out
+from ._eval_fixtures import (
+    N_POSITIONS,
+    T,
+    build_eval_config,
+    build_fixture,
+    live_pipeline_module,
+    read_position_arrays,
+)
 
 
 def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
@@ -234,17 +51,17 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
     """
     fixture_root = tmp_path / "fixture"
     fixture_root.mkdir()
-    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = build_fixture(fixture_root)
 
     save_dir_serial = tmp_path / "serial"
     save_dir_process = tmp_path / "process"
 
     # Re-import inside the test body — test_lazy_init.py pops dynacell.*
     # modules from sys.modules, which would invalidate a module-level import.
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     evaluate_predictions = pipeline.evaluate_predictions
 
-    cfg_serial = _build_eval_config(
+    cfg_serial = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -253,7 +70,7 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
         executor="serial",
         fov_workers=1,
     )
-    cfg_process = _build_eval_config(
+    cfg_process = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -269,17 +86,13 @@ def test_serial_vs_process_evaluate_predictions_parity(tmp_path: Path):
     pixel_serial, mask_serial, _ = evaluate_predictions(cfg_serial)
     pixel_process, mask_process, _ = evaluate_predictions(cfg_process)
 
-    # Pixel + mask rows: same set after sort. We sort by (FOV, Timepoint)
-    # because the process branch already sorts by pos_name and within-FOV
-    # iteration is deterministic, but we sort defensively.
     def _sort_key(row: dict):
         return (row["FOV"], row["Timepoint"])
 
     assert sorted(pixel_serial, key=_sort_key) == sorted(pixel_process, key=_sort_key)
     assert sorted(mask_serial, key=_sort_key) == sorted(mask_process, key=_sort_key)
-    # Per-position seg plate equality (both channels).
-    arrs_serial = _read_position_arrays(save_dir_serial / "segmentation_results.zarr")
-    arrs_process = _read_position_arrays(save_dir_process / "segmentation_results.zarr")
+    arrs_serial = read_position_arrays(save_dir_serial / "segmentation_results.zarr")
+    arrs_process = read_position_arrays(save_dir_process / "segmentation_results.zarr")
     assert set(arrs_serial.keys()) == set(arrs_process.keys())
     for pos_name, arr_a in arrs_serial.items():
         arr_b = arrs_process[pos_name]
@@ -296,11 +109,11 @@ def test_serial_path_runs_without_segmenter_loaded(tmp_path: Path):
     """
     fixture_root = tmp_path / "fixture"
     fixture_root.mkdir()
-    pred_path, gt_path, gt_cache_dir, pred_cache_dir = _build_fixture(fixture_root)
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = build_fixture(fixture_root)
     save_dir = tmp_path / "out"
     save_dir.mkdir()
 
-    cfg = _build_eval_config(
+    cfg = build_eval_config(
         pred_path,
         gt_path,
         gt_cache_dir,
@@ -309,10 +122,7 @@ def test_serial_path_runs_without_segmenter_loaded(tmp_path: Path):
         executor="serial",
         fov_workers=1,
     )
-    pipeline = _live_pipeline_module()
+    pipeline = live_pipeline_module()
     pixel_rows, mask_rows, _ = pipeline.evaluate_predictions(cfg)
     assert len(pixel_rows) == N_POSITIONS * T
     assert len(mask_rows) == N_POSITIONS * T
-    # Confirms the no-segmenter contract: prepare_segmentation_model
-    # returned None and evaluate_predictions still produced valid outputs
-    # for every (FOV, t) pair.


### PR DESCRIPTION
## Summary

Adds a new ``dynacell evaluate-grouped`` subcommand that runs the same ``(model, organelle)`` across multiple I/O variants — typically the three A549 treatment plates (``mock``/``denv``/``zikv``) — in **one Python process**, amortizing the segmenter + DINOv3 + DynaCLR + CELL-DINO cold-start (~30–90 s) across all conditions instead of paying it N times.

The driver is **opt-in**. Existing per-condition runs via ``dynacell evaluate`` are unchanged.

## Stacked on #426

This branch is based on ``eval-parallelism`` (PR #426). The diff here is **only this feature's 3 commits**; #426 should land first. The base PR's ``EvalModels`` extraction was the prerequisite — that's why ``c271d3f0`` consolidates the dual ``init_cache_context`` call sites and the inline-load duplication in ``precompute_cli.py`` behind the same bundle.

## Commits

| SHA | Title |
|---|---|
| ``d69d9709`` | feat: grouped multi-condition eval driver (model_loader extract + ``evaluate_predictions(..., models=)`` kwarg + ``evaluate_predictions_grouped`` + Hydra entry) |
| ``c271d3f0`` | refactor: simplify grouped driver (lazy load on all-cache-hit; symmetric condition-0 invariant; ``LoadFlags`` consolidates ``precompute_cli`` load; ``init_cache_contexts`` helper) |
| ``e84ed6a1`` | feat: tier process-mode message by cache state (mild note for ``require_complete_cache=true``; loud WARNING for the cache-miss × N-conditions × N-workers worst case) |

## Performance characteristics

The amortization win depends on the executor mode:

- ``runtime.executor=serial`` (recommended for grouped): the parent's ``EvalModels`` bundle is passed to ``evaluate_predictions(..., models=...)`` for every condition. Models load **once** total. **Full amortization.**
- ``runtime.executor=process``: only the parent-side pre-warm is amortized; each condition spawns a fresh ``ProcessPoolExecutor`` whose workers re-load their own model copies. The driver detects this and tiers its output:
  - + ``require_complete_cache=true`` + ``n_conditions > 1`` → mild informational note (workers don't actually load any models on the cache-only path, so re-init is cheap)
  - + ``require_complete_cache=false`` + ``n_conditions > 1`` → loud multi-line WARNING with explicit cost estimate and pointer to ``executor=serial``

## Constraints on per-condition overlays

Per-condition entries may freely override ``io.*``, ``save.*``, ``runtime.*``, ``limit_positions``, ``force_recompute.*``, and carry a ``name`` label. They MUST NOT change ``target_name``, ``feature_extractor.*``, ``compute_feature_metrics``, or ``use_gpu`` — those gate which models get loaded. The invariant check is **symmetric** across all conditions (including condition 0), so a model-loading override smuggled into the first condition is rejected, not silently re-baselined.

## Example config

```yaml
# eval_grouped_a549_mantis_er.yml
defaults:
  - eval_grouped
  - _self_

target_name: er
compute_feature_metrics: true
feature_extractor: { ... }   # shared across all conditions

conditions:
  - name: a549_mock
    io: { pred_path: ..., gt_path: ..., gt_cache_dir: ..., pred_cache_dir: ..., cell_segmentation_path: ... }
    save: { save_dir: /path/to/out/a549_mock }
  - name: a549_denv
    io: { ... }
    save: { save_dir: /path/to/out/a549_denv }
  - name: a549_zikv
    io: { ... }
    save: { save_dir: /path/to/out/a549_zikv }
```

Run:
```sh
uv run dynacell evaluate-grouped -c eval_grouped_a549_mantis_er.yml
```

## Test plan

- [x] ``tests/test_evaluation_grouped.py`` (NEW, 6 tests):
  - [x] ``test_grouped_matches_sequential_per_condition`` — byte-equal parity vs sequential per-condition runs (pixel CSV, mask CSV, seg plate)
  - [x] ``test_grouped_rejects_model_loading_field_overrides`` — condition N>0 sneaking in ``target_name`` raises
  - [x] ``test_grouped_rejects_condition0_model_field_override`` — condition 0 sneaking in ``target_name`` raises (regression guard for symmetric baseline)
  - [x] ``test_grouped_rejects_empty_conditions`` — missing/empty conditions list raises
  - [x] ``test_grouped_warns_loudly_on_process_plus_cache_miss`` — WARNING fires on the bad-config combo
  - [x] ``test_grouped_mild_note_on_process_plus_cache_only`` — only mild note on cache-only path
- [x] ``tests/test_evaluation_precompute_cli.py`` — covers the unified ``LoadFlags``/``load_eval_models`` path now used by precompute-gt
- [x] All 104 tests in affected eval suites pass locally
- [x] Pre-existing 48-test baseline failures (``test_benchmark_config_composition``, one ``test_evaluation_metrics`` case) unchanged
- [x] ``.github/workflows/test.yml`` extended to run ``test_evaluation_grouped.py`` in the ``test-dynacell-configs`` job
- [ ] CI green on PR

## Files touched

- NEW: ``applications/dynacell/src/dynacell/evaluation/model_loader.py``
- NEW: ``applications/dynacell/src/dynacell/evaluation/_configs/eval_grouped.yaml``
- NEW: ``applications/dynacell/tests/_eval_fixtures.py`` (extracted from ``test_evaluation_pipeline_parallel_cpu.py`` so the new test imports normally instead of ``sys.path.insert``)
- NEW: ``applications/dynacell/tests/test_evaluation_grouped.py``
- MODIFIED: ``applications/dynacell/src/dynacell/evaluation/pipeline.py`` (kwarg + grouped driver + cache-load helper extraction)
- MODIFIED: ``applications/dynacell/src/dynacell/evaluation/precompute_cli.py`` (uses unified ``load_eval_models`` + ``init_gt_cache_context``)
- MODIFIED: ``applications/dynacell/src/dynacell/__main__.py`` (registers ``evaluate-grouped``)
- MODIFIED: ``applications/dynacell/CLAUDE.md`` (new "Grouped multi-condition eval" subsection)
- MODIFIED: ``applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py`` (imports from ``_eval_fixtures``)
- MODIFIED: ``.github/workflows/test.yml`` (adds grouped test to CI matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)