### PR TITLE
Address review findings on #432 (cell_dino regression + eval cleanup)

### DIFF
--- a/applications/dynacell/src/dynacell/evaluation/utils.py
+++ b/applications/dynacell/src/dynacell/evaluation/utils.py
@@ -177,8 +177,10 @@ class CellDinoFeatureExtractor:
     Wraps :class:`viscy_models.foundation.CellDinoModel` so the eval pipeline
     can use it via the same ``extract_features(image_2d)`` contract as the
     DINOv3 and DynaCLR extractors. The underlying model's ``preprocess_2d``
-    handles the 224×224 resize and per-image min/max scaling, so the caller
-    can feed the same masked 2-D cell crop used for the other backbones.
+    handles the 224×224 resize and per-image per-channel spatial z-score
+    (the ``self_normalize`` recipe used during CELL-DINO pretraining), so
+    the caller can feed the same masked 2-D cell crop used for the other
+    backbones.
     """
 
     def __init__(self, weights_path: str, img_size: int = 224, patch_size: int = 16):

--- a/applications/dynaclr/src/dynaclr/evaluation/append_predictions.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/append_predictions.py
@@ -143,6 +143,16 @@ def append_predictions(
                     continue
 
                 pipeline = joblib.load(pipeline_path)
+                # Class-space contract: every marker pipeline within a task must
+                # share the first pipeline's class labels and order, otherwise
+                # `all_proba[marker_mask] = probas` silently misaligns columns.
+                entry_classes = pipeline.classifier.classes_.tolist()
+                if entry_classes != classes:
+                    raise ValueError(
+                        f"{task}/{marker_filter}: classifier.classes_ {entry_classes!r} "
+                        f"does not match the first pipeline's classes_ {classes!r}; "
+                        "per-marker probability columns would be misaligned."
+                    )
                 adata_subset = adata[marker_mask]
 
                 X_subset = adata_subset.X if isinstance(adata_subset.X, np.ndarray) else adata_subset.X.toarray()

--- a/applications/dynaclr/src/dynaclr/evaluation/benchmarking/smoothness/config.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/benchmarking/smoothness/config.py
@@ -1,7 +1,7 @@
 """Configuration models for smoothness evaluation."""
 
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -48,7 +48,7 @@ class SmoothnessEvalConfig(BaseModel):
     save_distributions: bool = False
     use_optimized: bool = True
     verbose: bool = False
-    group_by: Optional[str] = "marker"
+    group_by: str | None = "marker"
 
     @model_validator(mode="after")
     def validate_paths(self):
@@ -75,7 +75,7 @@ class CompareModelsConfig(BaseModel):
         List of CSV result files to compare.
     metrics : list[str]
         Metric columns to include in the comparison table.
-    output_path : Optional[str]
+    output_path : str | None
         Path to save combined results.
     output_format : str
         Output format for combined results.
@@ -92,5 +92,5 @@ class CompareModelsConfig(BaseModel):
             "random_frame_peak",
         ]
     )
-    output_path: Optional[str] = None
+    output_path: str | None = None
     output_format: Literal["markdown", "csv", "json"] = "markdown"

--- a/applications/dynaclr/src/dynaclr/evaluation/dimensionality_reduction/config.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/dimensionality_reduction/config.py
@@ -1,7 +1,6 @@
 """Configuration models for dimensionality reduction."""
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -9,7 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 class PCAConfig(BaseModel):
     """PCA reduction parameters."""
 
-    n_components: Optional[int] = None
+    n_components: int | None = None
     normalize_features: bool = True
 
 
@@ -30,8 +29,8 @@ class PHATEConfig(BaseModel):
     knn_dist: str = "cosine"
     scale_embeddings: bool = False
     random_state: int = 42
-    n_pca: Optional[int] = 50
-    subsample: Optional[int] = 50_000
+    n_pca: int | None = 50
+    subsample: int | None = 50_000
     n_jobs: int = 1
 
 
@@ -55,10 +54,10 @@ class DimensionalityReductionConfig(BaseModel):
     """
 
     input_path: str = Field(...)
-    output_path: Optional[str] = None
-    pca: Optional[PCAConfig] = None
-    umap: Optional[UMAPConfig] = None
-    phate: Optional[PHATEConfig] = None
+    output_path: str | None = None
+    pca: PCAConfig | None = None
+    umap: UMAPConfig | None = None
+    phate: PHATEConfig | None = None
     overwrite_keys: bool = False
 
     @model_validator(mode="after")
@@ -82,7 +81,7 @@ class CombinedDatasetConfig(BaseModel):
     """
 
     anndata: str = Field(...)
-    hcs_plate: Optional[str] = None
+    hcs_plate: str | None = None
 
 
 class CombinedDimensionalityReductionConfig(BaseModel):
@@ -106,11 +105,11 @@ class CombinedDimensionalityReductionConfig(BaseModel):
         If True, overwrite existing ``.obsm`` keys. Otherwise raise on conflict.
     """
 
-    input_paths: Optional[list[str]] = None
-    datasets: Optional[dict[str, CombinedDatasetConfig]] = None
-    pca: Optional[PCAConfig] = None
-    umap: Optional[UMAPConfig] = None
-    phate: Optional[PHATEConfig] = None
+    input_paths: list[str] | None = None
+    datasets: dict[str, CombinedDatasetConfig] | None = None
+    pca: PCAConfig | None = None
+    umap: UMAPConfig | None = None
+    phate: PHATEConfig | None = None
     overwrite_keys: bool = False
 
     @model_validator(mode="after")

--- a/applications/dynaclr/src/dynaclr/evaluation/evaluate_config.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/evaluate_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -57,9 +57,9 @@ class ReduceCombinedStepConfig(BaseModel):
     """
 
     overwrite_keys: bool = True
-    pca: Optional[PCAConfig] = PCAConfig(n_components=32, normalize_features=True)
-    umap: Optional[UMAPConfig] = None
-    phate: Optional[PHATEConfig] = PHATEConfig(n_components=2, knn=5, decay=40, scale_embeddings=False)
+    pca: PCAConfig | None = PCAConfig(n_components=32, normalize_features=True)
+    umap: UMAPConfig | None = None
+    phate: PHATEConfig | None = PHATEConfig(n_components=2, knn=5, decay=40, scale_embeddings=False)
 
 
 class ReduceStepConfig(BaseModel):
@@ -78,9 +78,9 @@ class ReduceStepConfig(BaseModel):
     """
 
     overwrite_keys: bool = True
-    pca: Optional[PCAConfig] = PCAConfig(n_components=32, normalize_features=True)
-    umap: Optional[UMAPConfig] = None
-    phate: Optional[PHATEConfig] = None  # PHATE runs jointly in reduce_combined, not per-experiment
+    pca: PCAConfig | None = PCAConfig(n_components=32, normalize_features=True)
+    umap: UMAPConfig | None = None
+    phate: PHATEConfig | None = None  # PHATE runs jointly in reduce_combined, not per-experiment
 
 
 class SmoothnessStepConfig(BaseModel):
@@ -169,7 +169,7 @@ class TaskSpec(BaseModel):
     """
 
     task: str
-    marker_filters: Optional[list[str]] = None
+    marker_filters: list[str] | None = None
 
 
 class MMDStepConfig(BaseModel):
@@ -215,15 +215,15 @@ class MMDStepConfig(BaseModel):
 
     comparisons: list[ComparisonSpec]
     group_by: str = "perturbation"
-    obs_filter: Optional[dict[str, str]] = None
-    embedding_key: Optional[str] = None
+    obs_filter: dict[str, str] | None = None
+    embedding_key: str | None = None
     mmd: MMDSettings = MMDSettings()
     map_settings: MAPSettings = MAPSettings()
-    temporal_bin_size: Optional[float] = None
-    combined_temporal_bin_size: Optional[float] = None
+    temporal_bin_size: float | None = None
+    combined_temporal_bin_size: float | None = None
     save_plots: bool = True
     combined_mode: bool = False
-    name: Optional[str] = None
+    name: str | None = None
 
 
 class LinearClassifiersStepConfig(BaseModel):
@@ -271,16 +271,16 @@ class LinearClassifiersStepConfig(BaseModel):
 
     annotations: list[AnnotationSource]
     tasks: list[TaskSpec]
-    publish_dir: Optional[str] = None
+    publish_dir: str | None = None
     use_scaling: bool = True
     use_pca: bool = False
-    n_pca_components: Optional[int] = None
+    n_pca_components: int | None = None
     max_iter: int = 1000
-    class_weight: Optional[str] = "balanced"
+    class_weight: str | None = "balanced"
     solver: str = "liblinear"
     split_train_data: float = 0.8
     random_seed: int = 42
-    split_groups_by: Optional[list[str]] = None
+    split_groups_by: list[str] | None = None
 
 
 class AppendPredictionsStepConfig(BaseModel):
@@ -297,7 +297,7 @@ class AppendPredictionsStepConfig(BaseModel):
         pipelines trained by a separate Wave-1 run.
     """
 
-    pipelines_dir: Optional[str] = None
+    pipelines_dir: str | None = None
 
 
 class AppendAnnotationsStepConfig(BaseModel):
@@ -366,8 +366,8 @@ class EvaluationConfig(BaseModel):
     # ckpt_path is None for foundation-model baselines (e.g. DINOv3-frozen) where
     # weights are loaded from HuggingFace inside the model __init__ and there is
     # no Lightning checkpoint to restore from.
-    ckpt_path: Optional[str] = None
-    cell_index_path: Optional[str] = None
+    ckpt_path: str | None = None
+    cell_index_path: str | None = None
     output_dir: str
     steps: list[str] = ["predict", "split", "reduce_dimensionality", "reduce_combined", "plot", "smoothness"]
     predict: PredictStepConfig = PredictStepConfig()
@@ -375,9 +375,9 @@ class EvaluationConfig(BaseModel):
     reduce_combined: ReduceCombinedStepConfig = ReduceCombinedStepConfig()
     smoothness: SmoothnessStepConfig = SmoothnessStepConfig()
     plot: PlotStepConfig = PlotStepConfig()
-    linear_classifiers: Optional[LinearClassifiersStepConfig] = None
-    append_annotations: Optional[AppendAnnotationsStepConfig] = None
-    append_predictions: Optional[AppendPredictionsStepConfig] = None
+    linear_classifiers: LinearClassifiersStepConfig | None = None
+    append_annotations: AppendAnnotationsStepConfig | None = None
+    append_predictions: AppendPredictionsStepConfig | None = None
     mmd: list[MMDStepConfig] = []
 
     @property

--- a/applications/dynaclr/src/dynaclr/evaluation/mmd/config.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/mmd/config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 import numpy as np
 from pydantic import BaseModel, model_validator
 
@@ -52,11 +50,11 @@ class MMDSettings(BaseModel):
     """
 
     n_permutations: int = 1000
-    max_cells: Optional[int] = 2000
+    max_cells: int | None = 2000
     min_cells: int = 20
     seed: int = 42
     balance_samples: bool = False
-    share_bandwidth_from: Optional[str] = None
+    share_bandwidth_from: str | None = None
 
 
 class MAPSettings(BaseModel):
@@ -110,12 +108,12 @@ class _MMDBaseConfig(BaseModel):
 
     output_dir: str
     group_by: str = "perturbation"
-    obs_filter: Optional[dict[str, str]] = None
-    embedding_key: Optional[str] = None
+    obs_filter: dict[str, str] | None = None
+    embedding_key: str | None = None
     mmd: MMDSettings = MMDSettings()
     map_settings: MAPSettings = MAPSettings()
-    temporal_bin_size: Optional[float] = None
-    temporal_bins: Optional[list[float]] = None
+    temporal_bin_size: float | None = None
+    temporal_bins: list[float] | None = None
     save_plots: bool = True
 
     @model_validator(mode="after")
@@ -126,10 +124,10 @@ class _MMDBaseConfig(BaseModel):
 
 
 def _resolve_bin_edges(
-    temporal_bin_size: Optional[float],
-    temporal_bins: Optional[list[float]],
+    temporal_bin_size: float | None,
+    temporal_bins: list[float] | None,
     max_hours: float,
-) -> Optional[list[tuple[float, float]]]:
+) -> list[tuple[float, float]] | None:
     """Return a list of (start, end) bin edge pairs, or None if no temporal binning.
 
     Parameters
@@ -215,7 +213,7 @@ class MMDPooledConfig(_MMDBaseConfig):
 
     input_paths: list[str]
     comparisons: list[ComparisonSpec]
-    condition_aliases: Optional[dict[str, list[str]]] = None
+    condition_aliases: dict[str, list[str]] | None = None
 
     @model_validator(mode="after")
     def _validate(self) -> "MMDPooledConfig":

--- a/applications/dynaclr/src/dynaclr/evaluation/plot_embeddings.py
+++ b/applications/dynaclr/src/dynaclr/evaluation/plot_embeddings.py
@@ -11,7 +11,6 @@ dynaclr plot-embeddings -c plot_config.yaml
 """
 
 from pathlib import Path
-from typing import Optional
 
 import anndata as ad
 import click
@@ -54,8 +53,8 @@ class PlotEmbeddingsConfig(BaseModel):
         instead of pairplot. Default: 4.
     """
 
-    input_path: Optional[str] = None
-    input_paths: Optional[list[str]] = None
+    input_path: str | None = None
+    input_paths: list[str] | None = None
     output_dir: str = Field(...)
     embedding_keys: list[str] = ["X_pca_combined", "X_phate_combined"]
     color_by: list[str] = ["perturbation", "hours_post_perturbation", "experiment", "marker"]

--- a/applications/dynaclr/src/dynaclr/pseudotime/io.py
+++ b/applications/dynaclr/src/dynaclr/pseudotime/io.py
@@ -274,36 +274,35 @@ def save_template_zarr(
         Additional attrs to merge into the store. Useful for
         method-specific metadata not covered by the shared schema.
     """
-    store = zarr.open(str(out_path), mode="w")
+    with zarr.open(str(out_path), mode="w") as store:
+        _save_flavor(store.create_group("raw"), raw_result, "raw")
+        _save_flavor(store.create_group("pca"), pca_result, "pca")
 
-    _save_flavor(store.create_group("raw"), raw_result, "raw")
-    _save_flavor(store.create_group("pca"), pca_result, "pca")
+        if raw_result.zscore_params:
+            zgrp = store.create_group("zscore_params")
+            for ds_id, (mean, std) in raw_result.zscore_params.items():
+                ds_grp = zgrp.create_group(ds_id)
+                ds_grp.create_array("mean", data=mean)
+                ds_grp.create_array("std", data=std)
 
-    if raw_result.zscore_params:
-        zgrp = store.create_group("zscore_params")
-        for ds_id, (mean, std) in raw_result.zscore_params.items():
-            ds_grp = zgrp.create_group(ds_id)
-            ds_grp.create_array("mean", data=mean)
-            ds_grp.create_array("std", data=std)
+        store.create_array("t_key_event", data=np.asarray(t_key_event_per_cell))
 
-    store.create_array("t_key_event", data=np.asarray(t_key_event_per_cell))
+        store.attrs["template_name"] = template_name
+        store.attrs["template_cell_ids"] = [list(c) for c in raw_result.template_cell_ids]
+        store.attrs["anchor_label"] = anchor_label
+        store.attrs["anchor_positive"] = anchor_positive
+        store.attrs["aggregator"] = aggregator
+        store.attrs["template_duration_minutes"] = float(template_duration_minutes)
+        store.attrs["build_frame_intervals_minutes"] = {k: float(v) for k, v in build_frame_intervals_minutes.items()}
+        store.attrs["config_snapshot"] = config_snapshot
 
-    store.attrs["template_name"] = template_name
-    store.attrs["template_cell_ids"] = [list(c) for c in raw_result.template_cell_ids]
-    store.attrs["anchor_label"] = anchor_label
-    store.attrs["anchor_positive"] = anchor_positive
-    store.attrs["aggregator"] = aggregator
-    store.attrs["template_duration_minutes"] = float(template_duration_minutes)
-    store.attrs["build_frame_intervals_minutes"] = {k: float(v) for k, v in build_frame_intervals_minutes.items()}
-    store.attrs["config_snapshot"] = config_snapshot
-
-    versions = get_dynaclr_versions()
-    for k, v in versions.items():
-        store.attrs[k] = v
-
-    if extra_attrs:
-        for k, v in extra_attrs.items():
+        versions = get_dynaclr_versions()
+        for k, v in versions.items():
             store.attrs[k] = v
+
+        if extra_attrs:
+            for k, v in extra_attrs.items():
+                store.attrs[k] = v
 
 
 def load_template_flavor(template_path: str | Path, flavor: str) -> tuple[TemplateResult, dict]:
@@ -330,69 +329,69 @@ def load_template_flavor(template_path: str | Path, flavor: str) -> tuple[Templa
     KeyError
         If the requested flavor is not present in the store.
     """
-    store = zarr.open(str(template_path), mode="r")
-    attrs = dict(store.attrs)
+    with zarr.open(str(template_path), mode="r") as store:
+        attrs = dict(store.attrs)
 
-    if flavor not in ("raw", "pca"):
-        raise ValueError(f"flavor must be 'raw' or 'pca', got {flavor!r}")
-    if flavor not in store:
-        raise KeyError(f"Flavor {flavor!r} not in template zarr {template_path}")
-    grp = store[flavor]
+        if flavor not in ("raw", "pca"):
+            raise ValueError(f"flavor must be 'raw' or 'pca', got {flavor!r}")
+        if flavor not in store:
+            raise KeyError(f"Flavor {flavor!r} not in template zarr {template_path}")
+        grp = store[flavor]
 
-    template = np.asarray(grp["template"])
-    time_calibration = np.asarray(grp["time_calibration"]) if "time_calibration" in grp else None
+        template = np.asarray(grp["template"])
+        time_calibration = np.asarray(grp["time_calibration"]) if "time_calibration" in grp else None
 
-    template_labels: dict[str, dict[str, np.ndarray]] | None = None
-    if "template_labels" in grp:
-        tl_grp = grp["template_labels"]
-        template_labels = {}
-        for col in tl_grp:
-            entry = tl_grp[col]
-            # New schema: per-column subgroup of {class_value: (T,)}.
-            # Legacy: flat array (T,) of the positive-class fraction.
-            if hasattr(entry, "keys") and not hasattr(entry, "shape"):
-                template_labels[col] = {cls: np.asarray(entry[cls]) for cls in entry}
-            else:
-                arr = np.asarray(entry)
-                template_labels[col] = {"positive": arr, "negative": 1.0 - arr}
+        template_labels: dict[str, dict[str, np.ndarray]] | None = None
+        if "template_labels" in grp:
+            tl_grp = grp["template_labels"]
+            template_labels = {}
+            for col in tl_grp:
+                entry = tl_grp[col]
+                # New schema: per-column subgroup of {class_value: (T,)}.
+                # Legacy: flat array (T,) of the positive-class fraction.
+                if hasattr(entry, "keys") and not hasattr(entry, "shape"):
+                    template_labels[col] = {cls: np.asarray(entry[cls]) for cls in entry}
+                else:
+                    arr = np.asarray(entry)
+                    template_labels[col] = {"positive": arr, "negative": 1.0 - arr}
 
-    pca = None
-    if flavor == "pca" and "components" in grp:
-        n_comp = int(grp.attrs["n_components"])
-        pca = PCA(n_components=n_comp)
-        pca.components_ = np.asarray(grp["components"])
-        pca.mean_ = np.asarray(grp["mean"])
-        if "explained_variance" in grp:
-            pca.explained_variance_ = np.asarray(grp["explained_variance"])
-        pca.explained_variance_ratio_ = np.asarray(grp["explained_variance_ratio"])
-        pca.n_components_ = n_comp
-        pca.n_features_in_ = pca.components_.shape[1]
+        pca = None
+        if flavor == "pca" and "components" in grp:
+            n_comp = int(grp.attrs["n_components"])
+            pca = PCA(n_components=n_comp)
+            pca.components_ = np.asarray(grp["components"])
+            pca.mean_ = np.asarray(grp["mean"])
+            if "explained_variance" in grp:
+                pca.explained_variance_ = np.asarray(grp["explained_variance"])
+            pca.explained_variance_ratio_ = np.asarray(grp["explained_variance_ratio"])
+            pca.n_components_ = n_comp
+            pca.n_features_in_ = pca.components_.shape[1]
 
-    zscore_params: dict[str, tuple[np.ndarray, np.ndarray]] = {}
-    if "zscore_params" in store:
-        zgrp = store["zscore_params"]
-        for ds_id in zgrp:
-            zscore_params[ds_id] = (
-                np.asarray(zgrp[ds_id]["mean"]),
-                np.asarray(zgrp[ds_id]["std"]),
-            )
+        zscore_params: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        if "zscore_params" in store:
+            zgrp = store["zscore_params"]
+            for ds_id in zgrp:
+                zscore_params[ds_id] = (
+                    np.asarray(zgrp[ds_id]["mean"]),
+                    np.asarray(zgrp[ds_id]["std"]),
+                )
 
-    template_id = str(grp.attrs.get("template_id", ""))
-    n_input_tracks = int(grp.attrs.get("n_input_tracks", 0))
-    cell_ids = [tuple(c) for c in attrs.get("template_cell_ids", [])]
+        template_id = str(grp.attrs.get("template_id", ""))
+        n_input_tracks = int(grp.attrs.get("n_input_tracks", 0))
+        cell_ids = [tuple(c) for c in attrs.get("template_cell_ids", [])]
 
-    result = TemplateResult(
-        template=template,
-        template_id=template_id,
-        pca=pca,
-        zscore_params=zscore_params,
-        template_cell_ids=cell_ids,
-        n_input_tracks=n_input_tracks,
-        explained_variance=float(grp.attrs.get("explained_variance", 0.0)) or None,
-        template_labels=template_labels,
-        time_calibration=time_calibration,
-    )
-    return result, attrs
+        result = TemplateResult(
+            template=template,
+            template_id=template_id,
+            pca=pca,
+            zscore_params=zscore_params,
+            template_cell_ids=cell_ids,
+            n_input_tracks=n_input_tracks,
+            explained_variance=float(grp.attrs.get("explained_variance", 0.0)) or None,
+            template_labels=template_labels,
+            time_calibration=time_calibration,
+        )
+        return result, attrs
 
 
 def read_template_attrs(template_path: str | Path) -> dict:
@@ -402,7 +401,8 @@ def read_template_attrs(template_path: str | Path) -> dict:
     only needs the metadata (config snapshot, anchor label, version
     stamps) and not the template arrays themselves.
     """
-    return dict(zarr.open(str(template_path), mode="r").attrs)
+    with zarr.open(str(template_path), mode="r") as store:
+        return dict(store.attrs)
 
 
 def read_time_calibration(template_path: str | Path, flavor: str) -> np.ndarray:
@@ -426,10 +426,11 @@ def read_time_calibration(template_path: str | Path, flavor: str) -> np.ndarray:
     """
     if flavor not in ("raw", "pca"):
         raise ValueError(f"flavor must be 'raw' or 'pca', got {flavor!r}")
-    grp = zarr.open(str(template_path), mode="r")[flavor]
-    if "time_calibration" not in grp:
-        raise KeyError(f"time_calibration missing for flavor {flavor!r} in {template_path}")
-    return np.asarray(grp["time_calibration"])
+    with zarr.open(str(template_path), mode="r") as store:
+        grp = store[flavor]
+        if "time_calibration" not in grp:
+            raise KeyError(f"time_calibration missing for flavor {flavor!r} in {template_path}")
+        return np.asarray(grp["time_calibration"])
 
 
 def read_tau_event_band(template_path: str | Path, flavor: str) -> tuple[float, float]:
@@ -449,8 +450,9 @@ def read_tau_event_band(template_path: str | Path, flavor: str) -> tuple[float, 
     """
     if flavor not in ("raw", "pca"):
         raise ValueError(f"flavor must be 'raw' or 'pca', got {flavor!r}")
-    grp = zarr.open(str(template_path), mode="r")[flavor]
-    if "tau_event_band" not in grp:
-        return (0.0, 1.0)
-    band = np.asarray(grp["tau_event_band"])
-    return (float(band[0]), float(band[1]))
+    with zarr.open(str(template_path), mode="r") as store:
+        grp = store[flavor]
+        if "tau_event_band" not in grp:
+            return (0.0, 1.0)
+        band = np.asarray(grp["tau_event_band"])
+        return (float(band[0]), float(band[1]))

--- a/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
+++ b/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
@@ -94,18 +94,27 @@ class CellDinoModel(nn.Module):
             self.model.eval()
         return self
 
-    def preprocess_2d(self, x: Tensor) -> Tensor:
+    def preprocess_2d(self, x: Tensor, normalize: bool = False) -> Tensor:
         """Convert a raw dataloader tensor to CELL-DINO input.
 
-        Squeezes singleton Z (or takes the middle slice if Z>1), resizes to
-        ``self.target_size``, and per-image min/max scales each
-        ``(B*C)`` map to ``[0, 1]``.  No ImageNet mean/std is applied —
-        CELL-DINO uses simple ``[0,1]`` normalization in training.
+        Squeezes singleton Z (or takes the middle slice if Z>1), resizes
+        to ``self.target_size``, and (when ``normalize=True``) per-image
+        min/max scales each ``(B*C)`` map to ``[0, 1]``.
+
+        ``normalize`` defaults to ``False`` because the production path
+        feeds dataloader-normalized input (``NormalizeSampled`` per-FOV
+        stats), and per-image min-max on top of that washes out the cell
+        signal by stretching outliers to ``[0, 1]``.  Set to ``True``
+        only when the caller is feeding raw zarr values without any
+        upstream normalization.
 
         Parameters
         ----------
         x : Tensor
             ``(B, C, D, H, W)`` or ``(B, C, H, W)``.
+        normalize : bool
+            Apply per-image min-max to ``[0, 1]`` before forwarding.
+            Default ``False`` (dataloader is expected to handle this).
 
         Returns
         -------
@@ -122,12 +131,14 @@ class CellDinoModel(nn.Module):
 
         x = F.interpolate(x, size=self.target_size, mode="bilinear", align_corners=False)
 
-        b, c, h, w = x.shape
-        x = x.view(b * c, 1, h, w)
-        x_min = x.amin(dim=(2, 3), keepdim=True)
-        x_max = x.amax(dim=(2, 3), keepdim=True)
-        x = (x - x_min) / (x_max - x_min).clamp(min=1e-8)
-        return x.view(b, c, h, w)
+        if normalize:
+            b, c, h, w = x.shape
+            x = x.view(b * c, 1, h, w)
+            x_min = x.amin(dim=(2, 3), keepdim=True)
+            x_max = x.amax(dim=(2, 3), keepdim=True)
+            x = (x - x_min) / (x_max - x_min).clamp(min=1e-8)
+            x = x.view(b, c, h, w)
+        return x
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         """Run CELL-DINO on an image batch and mean-pool over channels.

--- a/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
+++ b/packages/viscy-models/src/viscy_models/foundation/cell_dino.py
@@ -94,27 +94,26 @@ class CellDinoModel(nn.Module):
             self.model.eval()
         return self
 
-    def preprocess_2d(self, x: Tensor, normalize: bool = False) -> Tensor:
+    def preprocess_2d(self, x: Tensor) -> Tensor:
         """Convert a raw dataloader tensor to CELL-DINO input.
 
         Squeezes singleton Z (or takes the middle slice if Z>1), resizes
-        to ``self.target_size``, and (when ``normalize=True``) per-image
-        min/max scales each ``(B*C)`` map to ``[0, 1]``.
+        to ``self.target_size``, then applies per-image per-channel
+        spatial z-score: for each ``(B, C)`` map, subtract the spatial
+        mean over ``(H, W)`` and divide by the spatial std.
 
-        ``normalize`` defaults to ``False`` because the production path
-        feeds dataloader-normalized input (``NormalizeSampled`` per-FOV
-        stats), and per-image min-max on top of that washes out the cell
-        signal by stretching outliers to ``[0, 1]``.  Set to ``True``
-        only when the caller is feeding raw zarr values without any
-        upstream normalization.
+        This matches the ``self_normalize`` recipe used during CELL-DINO
+        pretraining and recommended by the official inference notebook
+        (``dinov2/notebooks/cell_dino/inference.ipynb``).  Per-image
+        z-score makes the input statistics independent of upstream
+        normalization — whether the dataloader fed raw zarr values or
+        ``NormalizeSampled``-prepped (per-FOV-stat) crops, the final
+        input to the network matches the training distribution.
 
         Parameters
         ----------
         x : Tensor
             ``(B, C, D, H, W)`` or ``(B, C, H, W)``.
-        normalize : bool
-            Apply per-image min-max to ``[0, 1]`` before forwarding.
-            Default ``False`` (dataloader is expected to handle this).
 
         Returns
         -------
@@ -131,14 +130,9 @@ class CellDinoModel(nn.Module):
 
         x = F.interpolate(x, size=self.target_size, mode="bilinear", align_corners=False)
 
-        if normalize:
-            b, c, h, w = x.shape
-            x = x.view(b * c, 1, h, w)
-            x_min = x.amin(dim=(2, 3), keepdim=True)
-            x_max = x.amax(dim=(2, 3), keepdim=True)
-            x = (x - x_min) / (x_max - x_min).clamp(min=1e-8)
-            x = x.view(b, c, h, w)
-        return x
+        m = x.mean(dim=(-2, -1), keepdim=True)
+        s = x.std(dim=(-2, -1), unbiased=False, keepdim=True)
+        return (x - m) / (s + 1e-7)
 
     def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
         """Run CELL-DINO on an image batch and mean-pool over channels.

--- a/packages/viscy-utils/src/viscy_utils/evaluation/linear_classifier.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/linear_classifier.py
@@ -6,7 +6,7 @@ import json
 import logging
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import joblib
 import numpy as np
@@ -31,9 +31,9 @@ class LinearClassifierPipeline:
     ----------
     classifier : LogisticRegression
         Trained logistic regression classifier.
-    scaler : Optional[StandardScaler]
+    scaler : StandardScaler | None
         Fitted StandardScaler, if feature scaling was used.
-    pca : Optional[PCA]
+    pca : PCA | None
         Fitted PCA transformer, if dimensionality reduction was used.
     config : dict
         Configuration used for training.
@@ -44,8 +44,8 @@ class LinearClassifierPipeline:
     def __init__(
         self,
         classifier: LogisticRegression,
-        scaler: Optional[StandardScaler],
-        pca: Optional[PCA],
+        scaler: StandardScaler | None,
+        pca: PCA | None,
         config: dict,
         task: str,
     ):
@@ -199,11 +199,11 @@ def train_linear_classifier(
     task: str,
     use_scaling: bool = True,
     use_pca: bool = False,
-    n_pca_components: Optional[int] = None,
-    classifier_params: Optional[dict[str, Any]] = None,
+    n_pca_components: int | None = None,
+    classifier_params: dict[str, Any] | None = None,
     split_train_data: float = 0.8,
     random_seed: int = 42,
-    groups: Optional[np.ndarray] = None,
+    groups: np.ndarray | None = None,
 ) -> tuple[LinearClassifierPipeline, dict[str, float], dict[str, Any]]:
     """Train a linear classifier on embeddings with preprocessing and evaluation.
 
@@ -217,9 +217,9 @@ def train_linear_classifier(
         Whether to apply StandardScaler normalization.
     use_pca : bool
         Whether to apply PCA dimensionality reduction.
-    n_pca_components : Optional[int]
+    n_pca_components : int | None
         Number of PCA components (required if use_pca=True).
-    classifier_params : Optional[dict]
+    classifier_params : dict | None
         Parameters for LogisticRegression classifier.
     split_train_data : float
         Fraction of data to use for training (rest for validation).
@@ -347,7 +347,7 @@ def train_linear_classifier(
             train_metrics[f"train_{class_name}_support"] = int(train_report[class_name]["support"])
 
     val_metrics = {}
-    y_val_proba: Optional[np.ndarray] = None
+    y_val_proba: np.ndarray | None = None
     if X_val is not None and y_val is not None:
         y_val_pred = classifier.predict(X_val)
         val_report = classification_report(y_val, y_val_pred, digits=3, output_dict=True)
@@ -420,8 +420,8 @@ def predict_with_classifier(
     adata: ad.AnnData,
     pipeline: LinearClassifierPipeline,
     task: str,
-    artifact_metadata: Optional[dict] = None,
-    include_wells: Optional[list[str]] = None,
+    artifact_metadata: dict | None = None,
+    include_wells: list[str] | None = None,
 ) -> ad.AnnData:
     """Apply trained classifier to make predictions on new data.
 
@@ -433,12 +433,12 @@ def predict_with_classifier(
         Trained classifier pipeline with preprocessing.
     task : str
         Name of the classification task (used as column suffix).
-    artifact_metadata : Optional[dict]
+    artifact_metadata : dict | None
         W&B artifact metadata from ``load_pipeline_from_wandb``. When provided,
         provenance keys are stored in ``adata.uns`` under
         ``classifier_{task}_artifact``, ``classifier_{task}_id``, and
         ``classifier_{task}_version``.
-    include_wells : Optional[list[str]]
+    include_wells : list[str] | None
         Well prefixes to restrict prediction to (e.g. ``["A/1", "B/2"]``).
         Cells in other wells will have ``NaN`` for prediction columns.
         When ``None``, all cells are predicted.
@@ -497,8 +497,8 @@ def save_pipeline_to_wandb(
     metrics: dict[str, float],
     config: dict[str, Any],
     wandb_project: str,
-    wandb_entity: Optional[str] = None,
-    tags: Optional[list[str]] = None,
+    wandb_entity: str | None = None,
+    tags: list[str] | None = None,
 ) -> str:
     """Save trained pipeline and metrics to Weights & Biases.
 
@@ -512,9 +512,9 @@ def save_pipeline_to_wandb(
         Full training configuration.
     wandb_project : str
         W&B project name.
-    wandb_entity : Optional[str]
+    wandb_entity : str | None
         W&B entity (username or team).
-    tags : Optional[list[str]]
+    tags : list[str] | None
         Tags to add to the run.
 
     Returns
@@ -602,7 +602,7 @@ def load_pipeline_from_wandb(
     wandb_project: str,
     model_name: str,
     version: str = "latest",
-    wandb_entity: Optional[str] = None,
+    wandb_entity: str | None = None,
 ) -> tuple[LinearClassifierPipeline, dict, dict]:
     """Load trained pipeline and config from Weights & Biases.
 
@@ -614,7 +614,7 @@ def load_pipeline_from_wandb(
         Name of the model artifact.
     version : str
         Version of the artifact (default: 'latest').
-    wandb_entity : Optional[str]
+    wandb_entity : str | None
         W&B entity (username or team).
 
     Returns


### PR DESCRIPTION
## Summary

Five commits stacked on top of the resolved merge commit on `staging/dynacell-dynadtw`. The first restores a regression that my own merge resolution (commit `bcf44d0c`) silently introduced; the next three are cleanup driven by an automated code review of #432; the final commit goes further and aligns `CellDinoModel.preprocess_2d` with Cell-DINO's training-time normalization recipe.

- **`55be1535` fix(viscy-models): restore `normalize=False` gate in `CellDinoModel.preprocess_2d`** — the merge took the modular-viscy-staging side of the add/add conflict on `cell_dino.py`, which silently reverted commit [`240aabd8`](https://github.com/mehta-lab/VisCy/commit/240aabd8) ("foundation: gate per-image min-max with normalize flag"). The companion change to `dinov3.py` was preserved; this re-applies the cell_dino half of that atomic commit verbatim so both foundation extractors share the same preprocess contract.
- **`05651bcc` refactor(dynaclr/pseudotime): wrap `zarr.open` calls in context managers** — 5 sites in `dynaclr/pseudotime/io.py` (1 write + 4 reads) opened zarr stores without `with`, contrary to the project rule that external resources be context-managed.
- **`30949b66` fix(dynaclr/eval): validate per-marker classifier `classes_` in `append_predictions`** — per-task probability columns were sized from the first marker pipeline's `classes_`, then later markers were assigned in without a sanity check; a class-space mismatch would silently misalign columns. Now raises with a clear message.
- **`057df509` style(dynaclr/viscy-utils): replace `Optional[X]` with `X | None`** — ~45 occurrences across 6 eval/config files; CLAUDE.md "Code Style / Modern Python typing" rule.
- **`e648c4ce` fix(viscy-models): match Cell-DINO training distribution with per-image z-score** — supersedes the partial fix in `55be1535`. The `normalize` flag is dropped entirely; `CellDinoModel.preprocess_2d` now applies the official Cell-DINO [`self_normalize`](https://github.com/facebookresearch/dinov2/blob/main/notebooks/cell_dino/inference.ipynb) recipe (per-image per-channel spatial z-score) unconditionally as the final step. Both old branches (skip-norm and per-image min-max) diverged from training; per-image spatial z-score is what `dinov2/data/cell_dino/transforms.py:SelfNormalizeNoDiv` used during pretraining and what the official inference notebook recommends. After this step, upstream pipeline choice (raw zarr, `Div255`, `NormalizeSampled` per-FOV stats, etc.) no longer affects the final input distribution — they all collapse to the per-image z-score the network was trained on. Verified bit-identical to the official `self_normalize` on synthetic inputs.

## Test plan

- [x] `uv sync --all-packages --all-extras` resolves cleanly (same lockfile as #432).
- [x] `uv run pytest -m "not slow"` shows no new regressions beyond the 51 pre-existing failures on `bcf44d0c`.
- [ ] Re-run a CELL-DINO eval (e.g. TOMM20 / SEC61B / CAAX) on top of `e648c4ce` and confirm embeddings/metrics move in the expected direction relative to the regressed `bcf44d0c` baseline (where `CellDinoModel.preprocess_2d` was double-normalizing) and relative to commit `55be1535` (which restored the gate but still didn't match training).
- [x] No `Optional[` or bare `zarr.open(...)` (without `with`) remains in the touched files.
- [x] No remaining `normalize=` callers of `CellDinoModel.preprocess_2d` (the parameter no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)