### PR TITLE
fix(dynacell): a549-mantis caax/h2b spacing to v1-rescaled 0.1494 µm xy

### DIFF
--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-denv/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-denv/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:

--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-mock/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-mock/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:

--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-zikv/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-caax-zikv/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:

--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-denv/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-denv/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:

--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-mock/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-mock/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:

--- a/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-zikv/manifest.yaml
+++ b/applications/dynacell/src/dynacell/_manifests/a549-mantis-h2b-zikv/manifest.yaml
@@ -7,8 +7,8 @@ cell_type: A549
 imaging_modality: mantis-lightsheet
 spacing:
   z: 0.174
-  y: 0.116
-  x: 0.116
+  y: 0.1494
+  x: 0.1494
 channels:
   source: Phase3D
   auxiliary:


### PR DESCRIPTION
## Summary

The caax and h2b A549 mantis manifests carried the **pre-rescale** xy spacing of 0.116 µm, but all 12 \`mantis_v1\` channel zarrs were rescaled to v1 resolution and now share **xy = 0.1494 µm** at the zarr scale level. Update the six caax/h2b condition manifests to match.

## Evidence

Read directly from \`mantis_v1/test/*.ozx\` via \`iohub.open_ome_zarr\`:

| Store | zarr scale (T,C,Z,Y,X) |
|---|---|
| TOMM20_mock.ozx | [1.0, 1.0, 0.174, **0.1494**, **0.1494**] |
| CAAX_mock.ozx   | [1.0, 1.0, 0.174, **0.1494**, **0.1494**] |
| SEC61B_mock.ozx | [1.0, 1.0, 0.174, **0.1494**, **0.1494**] |
| H2B_mock.ozx    | [1.0, 1.0, 0.174, **0.1494**, **0.1494**] |

sec61b and tomm20 manifests were already at 0.1494 (the source resolution rather than the rescale target). Only caax/h2b were stale.

## Why this matters

No code change — manifests only — but spatial-frequency-sensitive metrics that consume the manifest spacing as the \`spacing\` argument (e.g. \`FSC_Resolution\`, \`Spectral_PCC\`) would otherwise be computed on a **22% wrong** xy scale for caax/h2b conditions, biasing absolute resolution estimates and breaking cross-organelle comparability within A549.

## Test plan

- [x] Diff is mechanical: \`y: 0.116 → 0.1494\` and \`x: 0.116 → 0.1494\` in 6 files, no other changes.
- [x] All four A549 channel zarrs at \`mantis_v1/test\` confirmed to carry [Z, Y, X] = [0.174, 0.1494, 0.1494] via direct iohub read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)