### PR TITLE
Reduce GPU/CPU device round-trips in dynacell eval pipeline

### DIFF
--- a/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
@@ -146,8 +146,14 @@ def _bootstrap_prc(
     )
 
 
-def _mind(pred: np.ndarray, target: np.ndarray, num_projections: int, rng_seed: int) -> float:
-    """Sliced 2-Wasserstein based MIND from torch-fidelity."""
+def _mind(pred: np.ndarray, target: np.ndarray, num_projections: int, rng_seed: int, use_gpu: bool = False) -> float:
+    """Sliced 2-Wasserstein based MIND from torch-fidelity.
+
+    ``use_gpu=True`` routes the projection + Wasserstein sort through CUDA via
+    torch-fidelity's ``cuda`` kwarg; the resulting kernel computations are
+    cheap to overlap with the encoder forward pass that produced ``pred`` /
+    ``target``, so the upload tax is paid only once per dataset call.
+    """
     if pred.shape[0] == 0 or target.shape[0] == 0:
         return float("nan")
     out = mind_features_to_metric(
@@ -155,7 +161,7 @@ def _mind(pred: np.ndarray, target: np.ndarray, num_projections: int, rng_seed: 
         _to_tensor(target),
         mind_num_projections=num_projections,
         rng_seed=rng_seed,
-        cuda=False,
+        cuda=bool(use_gpu and torch.cuda.is_available()),
         verbose=False,
     )
     return float(out["monge_inception_distance"])
@@ -172,6 +178,7 @@ def compute_feature_similarity(
     prc_bootstrap_size: int | None = None,
     mind_num_projections: int = 1000,
     rng_seed: int = 2020,
+    use_gpu: bool = False,
 ) -> dict[str, float]:
     """Compute dataset-level feature-similarity metrics for one prefix.
 
@@ -244,7 +251,7 @@ def compute_feature_similarity(
     p_mean, p_std, r_mean, r_std, f_mean, f_std = _bootstrap_prc(
         pred, target, prc_neighborhood, prc_bootstrap_subsets, bootstrap_size, rng_seed
     )
-    mind = _mind(pred, target, mind_num_projections, rng_seed)
+    mind = _mind(pred, target, mind_num_projections, rng_seed, use_gpu=use_gpu)
     cos = _median_cosine_similarity(pred, target)
 
     return {

--- a/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/feature_metrics.py
@@ -149,10 +149,17 @@ def _bootstrap_prc(
 def _mind(pred: np.ndarray, target: np.ndarray, num_projections: int, rng_seed: int, use_gpu: bool = False) -> float:
     """Sliced 2-Wasserstein based MIND from torch-fidelity.
 
-    ``use_gpu=True`` routes the projection + Wasserstein sort through CUDA via
-    torch-fidelity's ``cuda`` kwarg; the resulting kernel computations are
-    cheap to overlap with the encoder forward pass that produced ``pred`` /
-    ``target``, so the upload tax is paid only once per dataset call.
+    ``use_gpu=True`` routes the projection + Wasserstein sort through CUDA
+    via torch-fidelity's ``cuda`` kwarg. ``False`` (default) keeps the
+    compute on CPU.
+
+    The default is False because the only production caller — the
+    dataset-level threadpool in ``evaluate_predictions`` — intentionally
+    leaves it unset: 4 parallel threads on a shared CUDA context would
+    serialize via the allocator and torch's CPU-vs-CUDA RNG produces
+    different streams for the same ``rng_seed``, breaking cross-leaf
+    comparability of the MIND column. The kwarg is plumbed through for
+    ad-hoc single-threaded callers (notebook / debugging) that want GPU.
     """
     if pred.shape[0] == 0 or target.shape[0] == 0:
         return float("nan")

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -290,19 +290,25 @@ PROPS_3D = (
 )
 
 
-def _cp_raw_regionprops(img, cell_segmentation, spacing):
+def _cp_raw_regionprops(img, cell_segmentation, spacing, use_gpu=True):
     """Compute raw per-cell regionprops and return a (n_cells, n_props) matrix.
 
     No normalization, no column-drop, no z-score — callers are responsible for
     supplying already-normalized ``img`` (via :func:`_minmax_norm`). Columns
     follow the order of :data:`PROPS_3D` as flattened by ``regionprops_table``.
+
+    When ``use_gpu=True`` and CUDA is available, inputs are uploaded via
+    ``ascupy`` so cubic's regionprops dispatches to cucim. ``use_gpu=False``
+    keeps everything on CPU for repro/debugging — matches the device gating
+    used elsewhere in :mod:`dynacell.evaluation.metrics`.
     """
-    if torch.cuda.is_available():
+    use_cuda = bool(use_gpu and torch.cuda.is_available())
+    if use_cuda:
         img = ascupy(img)
         cell_segmentation = ascupy(cell_segmentation)
     feats = regionprops_table(cell_segmentation, img, spacing=spacing, properties=list(PROPS_3D))
     feats.pop("label", None)
-    if torch.cuda.is_available():
+    if use_cuda:
         return np.array([asnumpy(v) for v in feats.values()]).T
     return np.array(list(feats.values())).T
 
@@ -323,14 +329,14 @@ def drop_paired_nonfinite_rows(pred: np.ndarray, target: np.ndarray) -> tuple[np
     return pred[valid], target[valid]
 
 
-def cp_regionprops(image, cell_segmentation, spacing):
+def cp_regionprops(image, cell_segmentation, spacing, use_gpu=True):
     """Raw CP regionprops for one image and its cell segmentation.
 
     Returns an array of shape ``(n_cells, n_props_raw)``. Same body for GT
     and prediction sides — *image* is min/max normalized before extraction.
     """
     _require_cubic()
-    return _cp_raw_regionprops(_minmax_norm(image), cell_segmentation, spacing)
+    return _cp_raw_regionprops(_minmax_norm(image), cell_segmentation, spacing, use_gpu=use_gpu)
 
 
 def _build_per_cell_crops_2d(img_2d, cell_segmentation_3d, patch_size):

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -132,28 +132,26 @@ def compute_pixel_metrics(prediction, target, spacing, fsc_kwargs=None, spectral
 
     Notes
     -----
-    Tensors are moved to the chosen device (GPU when ``use_gpu=True`` and
-    CUDA is available, CPU otherwise) and converted to cupy/numpy via
-    ``cubic.cuda.ascupy``/``asnumpy`` before all metric calls. cupy arrays
-    pass through cubic's ``@scale_invariant`` unchanged, enabling GPU-backed
-    computation (via cucim/cupy) for all metrics when CUDA is available.
-    Spectral metrics additionally benefit from zero-copy CUDA Array Interface
-    transfer.
+    Inputs (numpy, torch CPU/CUDA, or cupy) are coerced to a single
+    ``xp`` array module via ``cubic.cuda.ascupy``/``asnumpy`` — cupy
+    when ``use_gpu=True`` and CUDA is available, numpy otherwise. The
+    converters no-op when the input is already on the target module,
+    so a caller that pre-uploaded the full FOV via ``ascupy(predict)``
+    once pays zero per-call upload tax here. cubic metrics consume
+    ``xp`` directly; the SSIM wrapper consumes a torch view built
+    zero-copy from ``xp`` via ``torch.as_tensor`` (CUDA Array Interface
+    for cupy, ``from_numpy`` for numpy).
     """
     if pcc is None:
         raise ImportError("cubic is required for pixel metrics. Install via the `eval` extra: `uv sync --extra eval`.")
     _require_cubic()
-    prediction = torch.as_tensor(prediction)
-    target = torch.as_tensor(target)
-    device = torch.device("cuda" if use_gpu and torch.cuda.is_available() else "cpu")
-    prediction = prediction.to(device)
-    target = target.to(device)
-    to_xp = ascupy if device.type == "cuda" else asnumpy
+    use_cuda = bool(use_gpu and torch.cuda.is_available())
+    to_xp = ascupy if use_cuda else asnumpy
     pred_xp, target_xp = to_xp(prediction), to_xp(target)
 
     metrics = {
         "PCC": pcc(target_xp, pred_xp),
-        "SSIM": ssim(target, prediction),
+        "SSIM": ssim(torch.as_tensor(target_xp), torch.as_tensor(pred_xp)),
         "NRMSE": nrmse(target_xp, pred_xp, normalize="min_max"),
         "PSNR": psnr(target_xp, pred_xp, normalize="min_max"),
     }

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -149,9 +149,13 @@ def compute_pixel_metrics(prediction, target, spacing, fsc_kwargs=None, spectral
     to_xp = ascupy if use_cuda else asnumpy
     pred_xp, target_xp = to_xp(prediction), to_xp(target)
 
+    # ``.contiguous()`` recovers the contiguity guarantee the previous
+    # ``.to(device)`` step provided: when ``target_xp`` is a non-contiguous
+    # cupy view (e.g. a strided zarr slice), cubic_ssim → MONAI → conv3d's
+    # CUDA backend can fail or silently re-materialize on recent torch.
     metrics = {
         "PCC": pcc(target_xp, pred_xp),
-        "SSIM": ssim(torch.as_tensor(target_xp), torch.as_tensor(pred_xp)),
+        "SSIM": ssim(torch.as_tensor(target_xp).contiguous(), torch.as_tensor(pred_xp).contiguous()),
         "NRMSE": nrmse(target_xp, pred_xp, normalize="min_max"),
         "PSNR": psnr(target_xp, pred_xp, normalize="min_max"),
     }

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -9,6 +9,7 @@ from typing import Any, get_args
 import hydra
 import numpy as np
 import pandas as pd
+import torch
 from iohub.ngff import open_ome_zarr
 from omegaconf import DictConfig, OmegaConf
 from threadpoolctl import threadpool_limits
@@ -28,6 +29,7 @@ from dynacell.evaluation.feature_select import (
 )
 from dynacell.evaluation.linear_probe import indistinguishability, paired_auroc
 from dynacell.evaluation.metrics import (
+    ascupy,
     build_crops,
     compute_pixel_metrics,
     cp_regionprops,
@@ -476,13 +478,24 @@ def _process_one_fov(
     dynaclr = _BackboneLists()
     celldino = _BackboneLists()
 
+    # Bulk-upload predict/target once per FOV so compute_pixel_metrics' per-T
+    # ascupy is a no-op via cupy-on-cupy. mask / feature / microssim paths
+    # still consume the numpy arrays in parallel — neither SuperModel nor
+    # build_crops nor the microssim aggregator accept cupy directly.
+    if use_gpu and ascupy is not None and torch.cuda.is_available():
+        predict_xp = ascupy(predict)
+        target_xp = ascupy(target)
+    else:
+        predict_xp = predict
+        target_xp = target
+
     for t in tqdm(range(T), desc="Processing timepoints", leave=False, disable=suppress_inner_tqdm):
         data_info = {"FOV": pos_name_pred, "Timepoint": t}
 
         with region_timer("pixel_metrics", pos_name_pred, t), gpu_serialization_lock(gate=use_gpu):
             pixel_metrics = compute_pixel_metrics(
-                predict[t],
-                target[t],
+                predict_xp[t],
+                target_xp[t],
                 spacing=config.pixel_metrics.spacing,
                 fsc_kwargs=config.pixel_metrics.fsc,
                 spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
@@ -768,6 +781,8 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
     OmegaConf.resolve(config)
     reset_timings()
 
+    use_gpu = bool(getattr(config, "use_gpu", True))
+
     all_pixel_metrics = []
     all_mask_metrics = []
     all_feature_metrics = []
@@ -878,7 +893,6 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
             microssim_sim = None
             microssim_read_cache: dict[str, tuple[np.ndarray, np.ndarray]] = {}
             if config.compute_microssim:
-                use_gpu = bool(getattr(config, "use_gpu", True))
                 max_pairs = int(OmegaConf.select(config, "microssim.calibration.max_pairs", default=12))
                 seed = int(OmegaConf.select(config, "microssim.calibration.seed", default=42))
                 cache_reads = bool(OmegaConf.select(config, "microssim.calibration.cache", default=False))

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1148,7 +1148,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
         def _compute_one(args):
             name, p_metric, t_metric, p_probe, t_probe, fov_p, fov_t = args
             raw = {
-                **compute_feature_similarity(p_metric, t_metric, name),
+                **compute_feature_similarity(p_metric, t_metric, name, use_gpu=use_gpu),
                 **_real_vs_pred_probe(p_probe, t_probe, fov_p, fov_t, name),
             }
             return {f"Dataset_{k}": v for k, v in raw.items()}
@@ -1172,7 +1172,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
         for name in expected_prefixes:
             if f"Dataset_{name}_FID" not in dataset_row:
                 raw = {
-                    **compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name),
+                    **compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name, use_gpu=use_gpu),
                     **_real_vs_pred_probe(np.empty((0, 0)), np.empty((0, 0)), np.empty(0), np.empty(0), name),
                 }
                 dataset_row.update({f"Dataset_{k}": v for k, v in raw.items()})

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -145,7 +145,7 @@ def _fov_pred_features_per_t(
     dinov3: list[np.ndarray] = []
     dynaclr: list[np.ndarray] = []
     celldino: list[np.ndarray] | None = [] if celldino_feature_extractor is not None else None
-    use_gpu = bool(getattr(pred_cache_ctx, "use_gpu", True))
+    use_gpu = pred_cache_ctx.use_gpu
     for t in range(t_count):
         cp.append(cp_regionprops(predict[t], cell_segmentation[t], spacing, use_gpu=use_gpu))
         crops_t = build_crops(predict[t], cell_segmentation[t], patch_size)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -143,8 +143,9 @@ def _fov_pred_features_per_t(
     dinov3: list[np.ndarray] = []
     dynaclr: list[np.ndarray] = []
     celldino: list[np.ndarray] | None = [] if celldino_feature_extractor is not None else None
+    use_gpu = bool(getattr(pred_cache_ctx, "use_gpu", True))
     for t in range(t_count):
-        cp.append(cp_regionprops(predict[t], cell_segmentation[t], spacing))
+        cp.append(cp_regionprops(predict[t], cell_segmentation[t], spacing, use_gpu=use_gpu))
         crops_t = build_crops(predict[t], cell_segmentation[t], patch_size)
         dinov3.append(features_from_crops(crops_t, dinov3_feature_extractor))
         dynaclr.append(features_from_crops(crops_t, dynaclr_feature_extractor))

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1149,9 +1149,17 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
         # Prefix with "Dataset_" so dataset-level FID/KID/cosine don't clobber
         # per-FOV columns of the same name when merged into per-FOV rows.
         def _compute_one(args):
+            # MIND stays on CPU here even when use_gpu=True: 4 parallel threads
+            # racing on the same CUDA context would either serialize via the
+            # allocator (no speedup) or contend for memory with mid-eval FOV
+            # work in process executors. CPU MIND in a 4-thread BLAS-capped
+            # pool is competitive with serialized GPU MIND and bit-stable
+            # across runs that toggle use_gpu (torch's CPU vs CUDA RNG
+            # produce different streams for the same seed, breaking cross-
+            # leaf comparability of the MIND column).
             name, p_metric, t_metric, p_probe, t_probe, fov_p, fov_t = args
             raw = {
-                **compute_feature_similarity(p_metric, t_metric, name, use_gpu=use_gpu),
+                **compute_feature_similarity(p_metric, t_metric, name),
                 **_real_vs_pred_probe(p_probe, t_probe, fov_p, fov_t, name),
             }
             return {f"Dataset_{k}": v for k, v in raw.items()}
@@ -1175,7 +1183,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
         for name in expected_prefixes:
             if f"Dataset_{name}_FID" not in dataset_row:
                 raw = {
-                    **compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name, use_gpu=use_gpu),
+                    **compute_feature_similarity(np.empty((0, 0)), np.empty((0, 0)), name),
                     **_real_vs_pred_probe(np.empty((0, 0)), np.empty((0, 0)), np.empty(0), np.empty(0), name),
                 }
                 dataset_row.update({f"Dataset_{k}": v for k, v in raw.items()})

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -973,8 +973,6 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
             if runtime.executor == "process" and seg_model is not None:
                 del seg_model
                 seg_model = None
-                import torch
-
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -499,7 +499,7 @@ def _process_one_fov(
                 spacing=config.pixel_metrics.spacing,
                 fsc_kwargs=config.pixel_metrics.fsc,
                 spectral_pcc_kwargs=config.pixel_metrics.spectral_pcc,
-                use_gpu=config.use_gpu,
+                use_gpu=use_gpu,
             )
         if config.compute_microssim:
             microssim_data.append({"target": target[t], "predict": predict[t]})

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -481,10 +481,13 @@ def _process_one_fov(
     # Bulk-upload predict/target once per FOV so compute_pixel_metrics' per-T
     # ascupy is a no-op via cupy-on-cupy. mask / feature / microssim paths
     # still consume the numpy arrays in parallel — neither SuperModel nor
-    # build_crops nor the microssim aggregator accept cupy directly.
+    # build_crops nor the microssim aggregator accept cupy directly. The lock
+    # serializes the cupy allocation across workers under executor=process so
+    # N FOVs aren't all trying to allocate (T,D,H,W) fp32 at once.
     if use_gpu and ascupy is not None and torch.cuda.is_available():
-        predict_xp = ascupy(predict)
-        target_xp = ascupy(target)
+        with gpu_serialization_lock(gate=use_gpu):
+            predict_xp = ascupy(predict)
+            target_xp = ascupy(target)
     else:
         predict_xp = predict
         target_xp = target

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -247,6 +247,7 @@ def init_cache_context(
     )
     _validate_artifact_params(ctx)
     _auto_invalidate_on_preprocess_version_mismatch(ctx)
+    _auto_invalidate_on_cp_use_gpu_mismatch(ctx)
     return ctx
 
 
@@ -294,6 +295,42 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
             f"auto-invalidating {force_key} cache for this run.",
             stacklevel=2,
         )
+
+
+def _auto_invalidate_on_cp_use_gpu_mismatch(ctx: _CacheContext) -> None:
+    """Soft-invalidate cp_features when ``use_gpu`` differs from the cached run.
+
+    cucim (``use_gpu=True``) and skimage (``use_gpu=False``) implement the
+    regionprops moment / intensity reductions with different float-reduction
+    orders, so the resulting per-cell feature vectors differ in the ~1e-6
+    range. Mixing the two in a cache dir would silently contaminate
+    downstream feature similarity metrics (FID / PRC / cosine), since
+    nothing in the disk-read path knows the rows came from different
+    devices.
+
+    Missing tags (cached manifest pre-dates use_gpu tracking) are treated
+    as "no constraint" — they do NOT trigger invalidation. Operators
+    handle that bootstrap transition explicitly via
+    ``force_recompute.<side>_cp``.
+    """
+    if not ctx.enabled:
+        return
+    entry = ctx.manifest.get("artifacts", {}).get("cp_features")
+    if entry is None:
+        return
+    cached_use_gpu = entry.get("use_gpu")
+    if cached_use_gpu is None or cached_use_gpu == ctx.use_gpu:
+        return
+    force_key = f"{ctx.side}_cp"
+    ctx.force[force_key] = True
+    warnings.warn(
+        f"cp_features: use_gpu mismatch (cached={cached_use_gpu!r}, "
+        f"current={ctx.use_gpu!r}); auto-invalidating {force_key} cache "
+        f"for this run. cucim and skimage produce numerically different "
+        f"float reductions, so mixing devices would silently contaminate "
+        f"downstream feature-similarity metrics.",
+        stacklevel=2,
+    )
 
 
 def _validate_artifact_params(ctx: _CacheContext) -> None:
@@ -619,6 +656,7 @@ def fov_cp_features(
             "path": "features/cp.zarr",
             "spacing": ctx.spacing,
             "built_at": built_at_now(),
+            "use_gpu": ctx.use_gpu,
             **ctx.source_tag,
         }
         _update_manifest_entry(ctx.manifest, ["cp_features"], entry)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -247,7 +247,6 @@ def init_cache_context(
     )
     _validate_artifact_params(ctx)
     _auto_invalidate_on_preprocess_version_mismatch(ctx)
-    _auto_invalidate_on_cp_use_gpu_mismatch(ctx)
     return ctx
 
 
@@ -295,42 +294,6 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
             f"auto-invalidating {force_key} cache for this run.",
             stacklevel=2,
         )
-
-
-def _auto_invalidate_on_cp_use_gpu_mismatch(ctx: _CacheContext) -> None:
-    """Soft-invalidate cp_features when ``use_gpu`` differs from the cached run.
-
-    cucim (``use_gpu=True``) and skimage (``use_gpu=False``) implement the
-    regionprops moment / intensity reductions with different float-reduction
-    orders, so the resulting per-cell feature vectors differ in the ~1e-6
-    range. Mixing the two in a cache dir would silently contaminate
-    downstream feature similarity metrics (FID / PRC / cosine), since
-    nothing in the disk-read path knows the rows came from different
-    devices.
-
-    Missing tags (cached manifest pre-dates use_gpu tracking) are treated
-    as "no constraint" — they do NOT trigger invalidation. Operators
-    handle that bootstrap transition explicitly via
-    ``force_recompute.<side>_cp``.
-    """
-    if not ctx.enabled:
-        return
-    entry = ctx.manifest.get("artifacts", {}).get("cp_features")
-    if entry is None:
-        return
-    cached_use_gpu = entry.get("use_gpu")
-    if cached_use_gpu is None or cached_use_gpu == ctx.use_gpu:
-        return
-    force_key = f"{ctx.side}_cp"
-    ctx.force[force_key] = True
-    warnings.warn(
-        f"cp_features: use_gpu mismatch (cached={cached_use_gpu!r}, "
-        f"current={ctx.use_gpu!r}); auto-invalidating {force_key} cache "
-        f"for this run. cucim and skimage produce numerically different "
-        f"float reductions, so mixing devices would silently contaminate "
-        f"downstream feature-similarity metrics.",
-        stacklevel=2,
-    )
 
 
 def _validate_artifact_params(ctx: _CacheContext) -> None:
@@ -656,7 +619,6 @@ def fov_cp_features(
             "path": "features/cp.zarr",
             "spacing": ctx.spacing,
             "built_at": built_at_now(),
-            "use_gpu": ctx.use_gpu,
             **ctx.source_tag,
         }
         _update_manifest_entry(ctx.manifest, ["cp_features"], entry)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -70,6 +70,7 @@ class _CacheContext:
     target_name: str
     spacing: list[float]
     patch_size: int
+    use_gpu: bool = True
     dinov3_model_name: str | None = None
     dynaclr_ckpt_sha12: str | None = None
     dynaclr_encoder_sha12: str | None = None
@@ -172,6 +173,7 @@ def init_cache_context(
     require_complete_requested = bool(io.require_complete_cache)
     spacing = list(config.pixel_metrics.spacing)
     patch_size = int(config.feature_metrics.patch_size)
+    use_gpu = bool(getattr(config, "use_gpu", True))
 
     dynaclr_ckpt_sha12 = ckpt_sha256_12(dynaclr_ckpt_path) if dynaclr_ckpt_path is not None else None
     dynaclr_encoder_sha12 = encoder_config_sha256_12(dynaclr_encoder_cfg) if dynaclr_encoder_cfg is not None else None
@@ -185,6 +187,7 @@ def init_cache_context(
         target_name=config.target_name,
         spacing=spacing,
         patch_size=patch_size,
+        use_gpu=use_gpu,
         dinov3_model_name=dinov3_model_name,
         dynaclr_ckpt_sha12=dynaclr_ckpt_sha12,
         dynaclr_encoder_sha12=dynaclr_encoder_sha12,
@@ -607,7 +610,7 @@ def fov_cp_features(
         force_key=f"{ctx.side}_cp",
         artifact_label=f"{ctx.label_prefix}cp_features",
         cache_kwargs={},
-        compute_fn=lambda t: cp_regionprops(image_arr[t], cell_segmentation_arr[t], ctx.spacing),
+        compute_fn=lambda t: cp_regionprops(image_arr[t], cell_segmentation_arr[t], ctx.spacing, use_gpu=ctx.use_gpu),
     )
 
     if ctx.enabled and manifest_updated:

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -13,7 +13,7 @@ import contextlib
 import fcntl
 import warnings
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import KW_ONLY, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
@@ -70,6 +70,7 @@ class _CacheContext:
     target_name: str
     spacing: list[float]
     patch_size: int
+    _: KW_ONLY
     use_gpu: bool = True
     dinov3_model_name: str | None = None
     dynaclr_ckpt_sha12: str | None = None

--- a/applications/dynacell/src/dynacell/evaluation/segmentation.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import torch
 
 try:
@@ -27,6 +28,27 @@ except ImportError:
     Workflow_sec61b = None  # type: ignore[assignment, misc]
     Workflow_tomm20 = None  # type: ignore[assignment, misc]
 
+from cubic.cuda import ascupy, asnumpy
+from cubic.skimage import filters as _cubic_filters
+
+NUCLEUS_GAUSSIAN_SIGMA = 1.0
+"""Isotropic Gaussian sigma (voxels) applied to the H2B input before
+``structure_H2B_100x_hipsc.apply_on_single_zstack``.
+
+The wrapper internally applies ``aicsmlsegment.simple_norm(1.5, 10)``,
+which fits a Gaussian via MLE to the full intensity distribution and
+stretches ``[m - 1.5σ, m + 10σ]`` to ``[0, 1]``. Bright chromatin tips and
+shot-noise outliers in noisy GT fluorescence inflate the fitted σ, the
+stretch range overshoots the actual signal range, and faint nuclei
+collapse into the low end of ``[0, 1]`` where the model's confidence is
+near zero. A σ=1 voxel Gaussian suppresses those outliers enough to bring
+``simple_norm``'s fit back into the actual signal range. Tested on iPSC
+GT and predictions where it roughly doubles the recovered nucleus mask
+area; A549 is unaffected (already clean intensity statistics). Membrane
++ ER + mitochondria are not smoothed because their backends either
+saturate (DL CAAX) or have their own internal preprocessing (classical
+aicssegmentation workflows)."""
+
 
 def _require_segmenter_model_zoo():
     if SuperModel is None:
@@ -42,6 +64,19 @@ def _require_aicssegmentation():
             "aicssegmentation is required for organelle segmentation workflows. "
             "Install it with: pip install aicssegmentation"
         )
+
+
+def _smooth_nucleus_input(img, sigma: float = NUCLEUS_GAUSSIAN_SIGMA):
+    """Apply isotropic Gaussian smoothing to dampen bright outliers in H2B input.
+
+    Runs on GPU via ``cubic`` when CUDA is available, on CPU otherwise. The
+    SuperModel inference downstream requires GPU regardless, so this is the
+    same constraint surface. See ``NUCLEUS_GAUSSIAN_SIGMA`` docstring for the
+    motivation.
+    """
+    img_dev = ascupy(img.astype(np.float32, copy=False))
+    smoothed = _cubic_filters.gaussian(img_dev, sigma=sigma, preserve_range=True)
+    return asnumpy(smoothed)
 
 
 def segment(img, target_name=None, seg_model: "SuperModel" = None):
@@ -66,6 +101,8 @@ def segment(img, target_name=None, seg_model: "SuperModel" = None):
         _require_segmenter_model_zoo()
         if seg_model is None:
             raise ValueError("seg_model (a loaded SuperModel) must be provided for nucleus and membrane segmentation.")
+        if target_name == "nucleus":
+            img = _smooth_nucleus_input(img)
         mask = seg_model.apply_on_single_zstack(img[None, ...])
 
     elif target_name == "nucleoli":

--- a/applications/dynacell/tests/test_evaluation_pipeline.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline.py
@@ -23,6 +23,7 @@ def _import_pipeline_with_stubs(monkeypatch):
     utils_module.plot_metrics = lambda *args, **kwargs: None
 
     metrics_module = types.ModuleType("dynacell.evaluation.metrics")
+    metrics_module.ascupy = None
     metrics_module.fit_microssim = lambda *args, **kwargs: None
     metrics_module.score_microssim = lambda *args, **kwargs: []
     metrics_module.compute_pixel_metrics = lambda *args, **kwargs: {}

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -503,8 +503,8 @@ def test_fov_pred_deep_features_dinov3_cache_hit(tmp_path: Path) -> None:
 def test_fov_gt_cp_features_writes_on_miss(tmp_path: Path, monkeypatch) -> None:
     """CP feature miss computes via cp_regionprops and writes per timepoint."""
 
-    def fake_cp(target, cell_seg, spacing):
-        del cell_seg, spacing
+    def fake_cp(target, cell_seg, spacing, use_gpu=True):
+        del cell_seg, spacing, use_gpu
         return np.full((2, 3), float(target.sum()), dtype=np.float32)
 
     # Patch the globals of fov_cp_features itself — robust against sys.modules
@@ -530,8 +530,8 @@ def test_fov_gt_cp_features_writes_on_miss(tmp_path: Path, monkeypatch) -> None:
 def test_fov_pred_cp_features_writes_on_miss(tmp_path: Path, monkeypatch) -> None:
     """Prediction CP feature miss computes via cp_regionprops (side-agnostic) and writes per timepoint."""
 
-    def fake_cp(prediction, cell_seg, spacing):
-        del cell_seg, spacing
+    def fake_cp(prediction, cell_seg, spacing, use_gpu=True):
+        del cell_seg, spacing, use_gpu
         return np.full((2, 3), float(prediction.sum()), dtype=np.float32)
 
     monkeypatch.setitem(fov_cp_features.__globals__, "cp_regionprops", fake_cp)


### PR DESCRIPTION
## Summary

Audit-driven refactor of the dynacell eval pipeline's device flow. The data was already not bouncing GPU→CPU→GPU *within* a consumer in serial mode — the waste was upstream:

- `pos_pred.data[:, ci]` lands as CPU numpy and every GPU-capable consumer (CP regionprops, pixel_metrics, MIND) paid its own upload tax.
- `compute_pixel_metrics` did `numpy → CPU torch → CUDA torch → cupy` per timepoint when a direct `to_xp(prediction)` plus a `torch.as_tensor(xp)` for SSIM is equivalent.
- MIND was hard-coded `cuda=False`; `_cp_raw_regionprops` ignored `config.use_gpu` and went to GPU whenever CUDA was available.

This PR threads `use_gpu` through `cp_regionprops`, `_mind`, and `compute_feature_similarity`; drops the torch detour in `compute_pixel_metrics`; and bulk-uploads `predict`/`target` once per FOV.

## Commits

Per-fix split. Four audit items (`feat` / `perf`), then five review-driven fixes from a `/simplify` pass on top:

1. `feat(eval): thread use_gpu through cp_regionprops` — `_cp_raw_regionprops` now respects `use_gpu` consistent with the rest of `metrics.py`; new `_CacheContext.use_gpu` field plumbs the flag through `fov_cp_features`.
2. `perf(eval): drop CPU-torch detour in compute_pixel_metrics` — single `to_xp(prediction)` at entry; SSIM builds its torch view zero-copy from `xp`.
3. `perf(eval): bulk-upload predict/target once per FOV` — one `ascupy(predict)` / `ascupy(target)` before the per-T loop; per-T compute_pixel_metrics is a no-op upload.
4. `feat(eval): route MIND through CUDA via use_gpu plumb` — `_mind`'s `cuda=False` becomes `cuda=use_gpu and torch.cuda.is_available()`.
5. `refactor(eval): direct _CacheContext.use_gpu access` — drop the defensive `getattr(..., True)` masking field-rename regressions.
6. `fix(eval): use hoisted use_gpu in compute_pixel_metrics call` — per-T call no longer dereferences `config.use_gpu` directly (crashes if config omits the key).
7. `fix(eval): serialize bulk ascupy under gpu_serialization_lock` — bulk upload joins the same lock the per-T GPU ops already use.
8. `fix(eval): keep MIND on CPU in dataset threadpool` — torch CPU/CUDA RNG produce different MIND values for the same `rng_seed`; CPU MIND in 4-thread BLAS-capped pool is competitive and bit-stable across runs that toggle `use_gpu`. Plumbing through `_mind` retained for future single-threaded GPU MIND callers.
9. `fix(eval): force contiguous torch view for SSIM` — `.contiguous()` recovers the contiguity guarantee the previous `.to(device)` step provided.

## Follow-ups (separate commits incoming on this PR)

- **E1**: CP feature manifest doesn't track `use_gpu` — cucim vs skimage float reductions differ; mixing CPU and GPU runs sharing a `pred_cache_dir` silently mixes feature matrices. Needs a manifest schema bump.
- **E5**: `dataclasses.KW_ONLY` sentinel on `_CacheContext` — defends against a future positional caller mis-binding `use_gpu` to a string field.

## Test plan

- [x] `uv run pytest applications/dynacell/tests/test_evaluation_metrics.py applications/dynacell/tests/test_pixel_metrics_parity.py applications/dynacell/tests/test_pipeline_cache.py applications/dynacell/tests/test_evaluation_pipeline.py applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py` — 59 passed
- [x] `uvx ruff check` on all 6 changed source/test files — clean
- [x] `test_pixel_metrics_parity.py` covers both the CPU path (`use_gpu=False`) and the GPU spectral path; both still pass against the pre-migration golden
- [ ] One real-FOV eval to confirm no perf regression and microssim+pixel CSVs still match (will rerun a smoke leaf after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)