### PR TITLE
fix(dynacell/eval): soft-invalidate per-artifact cache on stale params

### DIFF
--- a/applications/dynacell/src/dynacell/evaluation/README.md
+++ b/applications/dynacell/src/dynacell/evaluation/README.md
@@ -129,7 +129,14 @@ GT caches are reusable across model checkpoints for the same `(gt_path, gt_chann
   features/celldino/{weights_sha12}.zarr # one plate per CELL-DINO weights
 ```
 
-Identity: `(cache_schema_version, plate_path, channel_name, cell_segmentation_path)`. Mismatch raises `StaleCacheError`. The DynaCLR `ckpt_sha256_12` is memoized to a `<ckpt>.sha256` sidecar; touch or replace the checkpoint and the hash recomputes.
+Identity: `(cache_schema_version, plate_path, channel_name, cell_segmentation_path)`. Identity mismatches raise `StaleCacheError` — the cache directory must be wiped and re-primed. The DynaCLR `ckpt_sha256_12` is memoized to a `<ckpt>.sha256` sidecar; touch or replace the checkpoint and the hash recomputes.
+
+Per-artifact params (`cp_features.spacing`, `dinov3_features.patch_size`, `dynaclr_features.{checkpoint_sha256_12, encoder_config_sha256_12, patch_size}`, `celldino_features.{weights_sha256_12, patch_size}`, `organelle_masks.target_name`, plus per-extractor `preprocess_version`) are softer: a mismatch emits a warning and sets the matching `force_recompute.<side>_<kind>=True` so the artifact is recomputed and the manifest entry is rewritten with the current values. This self-heal path runs at `init_cache_context` time and covers the common "I bumped spacing / patch_size / preprocess recipe" workflow without forcing operators to wipe each cache by hand.
+
+Two strict-mode escape hatches keep the soft path from corrupting partially-walked or fast-path runs:
+
+- `io.require_complete_cache=true` (cache-only mode): a known mismatch raises instead of warning. The user opted out of recompute; a stale manifest is fatal.
+- `limit_positions=N` (smoke / iteration): a known mismatch raises instead of warning. Partial walks can't safely self-heal — the manifest entry would be rewritten globally while only the first N FOVs' on-disk chunks get recomputed, leaving the rest stale under a manifest that claims the new params. Clear the cache or drop `limit_positions` to recover.
 
 ### Priming with `precompute-gt`
 
@@ -161,6 +168,7 @@ With both caches warm, this flag puts `dynacell evaluate` in cache-only mode:
 
 - No model loads (~30-90 s cold-start skipped). The upfront `precompute_deep_features` pass is also skipped.
 - Cache misses raise `StaleCacheError` immediately — fail-loud instead of opportunistic rebuild.
+- Per-artifact param mismatches (e.g. stale `spacing` or `patch_size`) also raise instead of soft-invalidating; the soft path would silently trigger compute the user opted out of.
 - Pixel + mask metrics still run on the original image volumes; deep features served from disk.
 
 Use case: parallel sweeps, downstream metric iteration, crash recovery.
@@ -195,7 +203,13 @@ Without `io.gt_cache_dir` / `io.pred_cache_dir`, only `force_recompute.{final_me
 
 ### Invalidation
 
-We deliberately do **not** fingerprint zarr contents. If you modify them in place, either bump `cache_schema_version` in `cache.py`, set the right `force_recompute.*`, or delete the affected cache dir.
+Three paths invalidate cached artifacts:
+
+1. **Soft auto-invalidate (default)** — bumping a tracked per-artifact param (spacing, patch_size, preprocess_version, etc.) on a normal full-walk run. `init_cache_context` warns, sets the matching `force_recompute.<side>_<kind>`, and the next FOV pass recomputes and rewrites the manifest entry. Identity mismatches (plate_path, channel_name, cell_segmentation_path, cache_schema_version) still hard-raise.
+2. **Manual `force_recompute.<side>_<kind>`** — bypass cache for a specific family without touching the manifest's recorded params.
+3. **Cache-dir wipe** — required when running with `limit_positions=N` or `io.require_complete_cache=true` and you need to change a tracked param, OR when zarr contents have been modified in place (no content fingerprinting).
+
+Bumping `cache_schema_version` in `cache.py` forces a wipe on every existing cache.
 
 ## Scaling
 

--- a/applications/dynacell/src/dynacell/evaluation/cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/cache.py
@@ -180,31 +180,35 @@ def seed_cache_identity(
         manifest["cell_segmentation"] = {"plate_path": cell_segmentation_path}
 
 
-def check_artifact_params(
+def diff_artifact_params(
     entry: dict[str, Any] | None,
     current: dict[str, Any],
     *,
-    artifact_label: str,
     numeric_keys: tuple[str, ...] = (),
-) -> None:
-    """Raise if a per-artifact manifest entry disagrees with *current* params.
+) -> list[tuple[str, Any, Any]]:
+    """Return per-key mismatches between a manifest entry and current params.
 
     Parameters
     ----------
     entry
         Manifest entry for the artifact, or ``None`` if no entry exists yet
-        (in which case this function is a no-op — the caller decides whether
-        to treat absence as miss or miss+error).
+        (returns an empty list — the caller decides whether to treat
+        absence as miss).
     current
         Current-config values keyed by the same names as in *entry*.
-    artifact_label
-        Human-readable label for the error message (e.g. ``"cp_features"``).
     numeric_keys
         Keys in *current* whose values should be compared with
         :func:`numpy.allclose` instead of ``==``.
+
+    Returns
+    -------
+    list of tuple
+        ``(key, cached_value, current_value)`` for every disagreement;
+        empty when *entry* is ``None`` or every key matches.
     """
     if entry is None:
-        return
+        return []
+    mismatches: list[tuple[str, Any, Any]] = []
     for key, value in current.items():
         cached_value = entry.get(key)
         if key in numeric_keys:
@@ -214,9 +218,10 @@ def check_artifact_params(
                 rtol=1e-9,
                 atol=0.0,
             ):
-                raise StaleCacheError(f"{artifact_label}: {key} mismatch: cached={cached_value!r}, current={value!r}")
+                mismatches.append((key, cached_value, value))
         elif cached_value != value:
-            raise StaleCacheError(f"{artifact_label}: {key} mismatch: cached={cached_value!r}, current={value!r}")
+            mismatches.append((key, cached_value, value))
+    return mismatches
 
 
 def built_at_now() -> str:

--- a/applications/dynacell/src/dynacell/evaluation/cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/cache.py
@@ -208,6 +208,12 @@ def diff_artifact_params(
     """
     if entry is None:
         return []
+    if not isinstance(entry, dict):
+        # A malformed manifest entry (string/list/scalar where a mapping is
+        # expected — hand-edit or partial-write corruption) must surface as
+        # mismatches so the caller can soft-invalidate, not as an
+        # AttributeError escaping through `entry.get(...)`.
+        return [(key, entry, value) for key, value in current.items()]
     mismatches: list[tuple[str, Any, Any]] = []
     for key, value in current.items():
         cached_value = entry.get(key)

--- a/applications/dynacell/src/dynacell/evaluation/cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/cache.py
@@ -212,12 +212,19 @@ def diff_artifact_params(
     for key, value in current.items():
         cached_value = entry.get(key)
         if key in numeric_keys:
-            if cached_value is None or not np.allclose(
-                np.asarray(cached_value, dtype=float),
-                np.asarray(value, dtype=float),
-                rtol=1e-9,
-                atol=0.0,
-            ):
+            # A malformed cached value (None, wrong dtype, wrong length) must
+            # surface as a mismatch so the caller can soft-invalidate, not as
+            # a TypeError/ValueError that escapes through diff_artifact_params.
+            try:
+                close = cached_value is not None and np.allclose(
+                    np.asarray(cached_value, dtype=float),
+                    np.asarray(value, dtype=float),
+                    rtol=1e-9,
+                    atol=0.0,
+                )
+            except (TypeError, ValueError):
+                close = False
+            if not close:
                 mismatches.append((key, cached_value, value))
         elif cached_value != value:
             mismatches.append((key, cached_value, value))

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -26,9 +26,9 @@ from dynacell.evaluation.cache import (
     StaleCacheError,
     built_at_now,
     cache_paths,
-    check_artifact_params,
     check_cache_identity,
     ckpt_sha256_12,
+    diff_artifact_params,
     encoder_config_sha256_12,
     feature_slug,
     load_manifest,
@@ -245,7 +245,7 @@ def init_cache_context(
         side=side,
         **base_kwargs,
     )
-    _validate_artifact_params(ctx)
+    _auto_invalidate_on_artifact_param_mismatch(ctx)
     _auto_invalidate_on_preprocess_version_mismatch(ctx)
     return ctx
 
@@ -296,51 +296,83 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
         )
 
 
-def _validate_artifact_params(ctx: _CacheContext) -> None:
-    """Raise if any existing per-artifact manifest entry disagrees with ctx params."""
+def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
+    """Soft-invalidate per-artifact cache when current params disagree with manifest.
+
+    Mirrors :func:`_auto_invalidate_on_preprocess_version_mismatch` but
+    keys off per-artifact identity params recorded in the manifest
+    (e.g. ``cp_features.spacing``, ``dinov3_features.patch_size``,
+    ``organelle_masks.target_name``). On any mismatch the corresponding
+    ``ctx.force[<side>_<kind>]`` flag is set so the artifact is recomputed
+    and the manifest entry is rewritten with the new values.
+
+    Missing entries are a no-op — there is nothing to invalidate yet.
+    """
+    if not ctx.enabled:
+        return
     artifacts = ctx.manifest.get("artifacts", {})
 
-    masks_section = artifacts.get("organelle_masks", {})
-    check_artifact_params(
-        masks_section.get(ctx.target_name),
-        {"target_name": ctx.target_name, **ctx.source_tag},
-        artifact_label=f"organelle_masks[{ctx.target_name}]",
-    )
-    check_artifact_params(
-        artifacts.get("cp_features"),
-        {"spacing": ctx.spacing, **ctx.source_tag},
-        artifact_label=f"{ctx.label_prefix}cp_features",
-        numeric_keys=("spacing",),
-    )
+    checks: list[tuple[str, dict[str, Any] | None, dict[str, Any], tuple[str, ...]]] = [
+        (
+            "masks",
+            artifacts.get("organelle_masks", {}).get(ctx.target_name),
+            {"target_name": ctx.target_name, **ctx.source_tag},
+            (),
+        ),
+        (
+            "cp",
+            artifacts.get("cp_features"),
+            {"spacing": ctx.spacing, **ctx.source_tag},
+            ("spacing",),
+        ),
+    ]
     if ctx.dinov3_model_name is not None:
-        dinov3_section = artifacts.get("dinov3_features", {})
-        check_artifact_params(
-            dinov3_section.get(feature_slug(ctx.dinov3_model_name)),
-            {"model_name": ctx.dinov3_model_name, "patch_size": ctx.patch_size, **ctx.source_tag},
-            artifact_label=f"dinov3_features[{ctx.dinov3_model_name}]",
+        checks.append(
+            (
+                "dinov3",
+                artifacts.get("dinov3_features", {}).get(feature_slug(ctx.dinov3_model_name)),
+                {"model_name": ctx.dinov3_model_name, "patch_size": ctx.patch_size, **ctx.source_tag},
+                (),
+            )
         )
     if ctx.dynaclr_ckpt_sha12 is not None:
-        dynaclr_section = artifacts.get("dynaclr_features", {})
-        check_artifact_params(
-            dynaclr_section.get(ctx.dynaclr_ckpt_sha12),
-            {
-                "checkpoint_sha256_12": ctx.dynaclr_ckpt_sha12,
-                "encoder_config_sha256_12": ctx.dynaclr_encoder_sha12,
-                "patch_size": ctx.patch_size,
-                **ctx.source_tag,
-            },
-            artifact_label=f"dynaclr_features[{ctx.dynaclr_ckpt_sha12}]",
+        checks.append(
+            (
+                "dynaclr",
+                artifacts.get("dynaclr_features", {}).get(ctx.dynaclr_ckpt_sha12),
+                {
+                    "checkpoint_sha256_12": ctx.dynaclr_ckpt_sha12,
+                    "encoder_config_sha256_12": ctx.dynaclr_encoder_sha12,
+                    "patch_size": ctx.patch_size,
+                    **ctx.source_tag,
+                },
+                (),
+            )
         )
     if ctx.celldino_weights_sha12 is not None:
-        celldino_section = artifacts.get("celldino_features", {})
-        check_artifact_params(
-            celldino_section.get(ctx.celldino_weights_sha12),
-            {
-                "weights_sha256_12": ctx.celldino_weights_sha12,
-                "patch_size": ctx.patch_size,
-                **ctx.source_tag,
-            },
-            artifact_label=f"celldino_features[{ctx.celldino_weights_sha12}]",
+        checks.append(
+            (
+                "celldino",
+                artifacts.get("celldino_features", {}).get(ctx.celldino_weights_sha12),
+                {
+                    "weights_sha256_12": ctx.celldino_weights_sha12,
+                    "patch_size": ctx.patch_size,
+                    **ctx.source_tag,
+                },
+                (),
+            )
+        )
+
+    for kind, entry, current, numeric_keys in checks:
+        mismatches = diff_artifact_params(entry, current, numeric_keys=numeric_keys)
+        if not mismatches:
+            continue
+        force_key = f"{ctx.side}_{kind}"
+        ctx.force[force_key] = True
+        details = ", ".join(f"{key}: cached={cached!r}, current={cur!r}" for key, cached, cur in mismatches)
+        warnings.warn(
+            f"{force_key}: artifact param mismatch ({details}); auto-invalidating {force_key} cache for this run.",
+            stacklevel=2,
         )
 
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -263,6 +263,11 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
     isn't loaded for this run) are treated as "no constraint" — they do
     NOT trigger invalidation. Operators handle that bootstrap transition
     explicitly via ``force_recompute.<side>_<kind>``.
+
+    Under ``io.require_complete_cache=true`` a known mismatch is escalated
+    to a hard :class:`StaleCacheError` — the user opted out of recompute,
+    so a stale-version manifest is an unambiguous failure rather than a
+    signal to rebuild.
     """
     if not ctx.enabled:
         return
@@ -286,6 +291,12 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
         cached_version = entry.get("preprocess_version")
         if cached_version is None or cached_version == current_version:
             continue
+        if ctx.require_complete:
+            raise StaleCacheError(
+                f"{section_key}[{sub_key}]: preprocess_version mismatch "
+                f"(cached={cached_version!r}, current={current_version!r}) and "
+                f"io.require_complete_cache=true"
+            )
         force_key = f"{ctx.side}_{kind}"
         ctx.force[force_key] = True
         warnings.warn(
@@ -307,6 +318,11 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
     and the manifest entry is rewritten with the new values.
 
     Missing entries are a no-op — there is nothing to invalidate yet.
+
+    Under ``io.require_complete_cache=true`` the soft path is escalated to
+    a hard :class:`StaleCacheError` — the user opted out of recompute, so a
+    stale-param manifest is an unambiguous failure rather than a signal to
+    rebuild.
     """
     if not ctx.enabled:
         return
@@ -367,9 +383,13 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         mismatches = diff_artifact_params(entry, current, numeric_keys=numeric_keys)
         if not mismatches:
             continue
+        details = ", ".join(f"{key}: cached={cached!r}, current={cur!r}" for key, cached, cur in mismatches)
+        if ctx.require_complete:
+            raise StaleCacheError(
+                f"{ctx.side}_{kind}: artifact param mismatch ({details}) and io.require_complete_cache=true"
+            )
         force_key = f"{ctx.side}_{kind}"
         ctx.force[force_key] = True
-        details = ", ".join(f"{key}: cached={cached!r}, current={cur!r}" for key, cached, cur in mismatches)
         warnings.warn(
             f"{force_key}: artifact param mismatch ({details}); auto-invalidating {force_key} cache for this run.",
             stacklevel=2,

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -328,15 +328,17 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         return
     artifacts = ctx.manifest.get("artifacts", {})
 
-    checks: list[tuple[str, dict[str, Any] | None, dict[str, Any], tuple[str, ...]]] = [
+    checks: list[tuple[str, str, dict[str, Any] | None, dict[str, Any], tuple[str, ...]]] = [
         (
             "masks",
+            f"{ctx.label_prefix}organelle_masks[{ctx.target_name}]",
             artifacts.get("organelle_masks", {}).get(ctx.target_name),
             {"target_name": ctx.target_name, **ctx.source_tag},
             (),
         ),
         (
             "cp",
+            f"{ctx.label_prefix}cp_features",
             artifacts.get("cp_features"),
             {"spacing": ctx.spacing, **ctx.source_tag},
             ("spacing",),
@@ -346,6 +348,7 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         checks.append(
             (
                 "dinov3",
+                f"{ctx.label_prefix}dinov3_features[{ctx.dinov3_model_name}]",
                 artifacts.get("dinov3_features", {}).get(feature_slug(ctx.dinov3_model_name)),
                 {"model_name": ctx.dinov3_model_name, "patch_size": ctx.patch_size, **ctx.source_tag},
                 (),
@@ -355,6 +358,7 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         checks.append(
             (
                 "dynaclr",
+                f"{ctx.label_prefix}dynaclr_features[{ctx.dynaclr_ckpt_sha12}]",
                 artifacts.get("dynaclr_features", {}).get(ctx.dynaclr_ckpt_sha12),
                 {
                     "checkpoint_sha256_12": ctx.dynaclr_ckpt_sha12,
@@ -369,6 +373,7 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         checks.append(
             (
                 "celldino",
+                f"{ctx.label_prefix}celldino_features[{ctx.celldino_weights_sha12}]",
                 artifacts.get("celldino_features", {}).get(ctx.celldino_weights_sha12),
                 {
                     "weights_sha256_12": ctx.celldino_weights_sha12,
@@ -379,19 +384,19 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
             )
         )
 
-    for kind, entry, current, numeric_keys in checks:
+    for kind, artifact_label, entry, current, numeric_keys in checks:
         mismatches = diff_artifact_params(entry, current, numeric_keys=numeric_keys)
         if not mismatches:
             continue
         details = ", ".join(f"{key}: cached={cached!r}, current={cur!r}" for key, cached, cur in mismatches)
         if ctx.require_complete:
             raise StaleCacheError(
-                f"{ctx.side}_{kind}: artifact param mismatch ({details}) and io.require_complete_cache=true"
+                f"{artifact_label}: artifact param mismatch ({details}) and io.require_complete_cache=true"
             )
         force_key = f"{ctx.side}_{kind}"
         ctx.force[force_key] = True
         warnings.warn(
-            f"{force_key}: artifact param mismatch ({details}); auto-invalidating {force_key} cache for this run.",
+            f"{artifact_label}: artifact param mismatch ({details}); auto-invalidating {force_key} cache for this run.",
             stacklevel=2,
         )
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -71,6 +71,7 @@ class _CacheContext:
     spacing: list[float]
     patch_size: int
     _: KW_ONLY
+    partial_walk: bool = False
     use_gpu: bool = True
     dinov3_model_name: str | None = None
     dynaclr_ckpt_sha12: str | None = None
@@ -175,6 +176,7 @@ def init_cache_context(
     spacing = list(config.pixel_metrics.spacing)
     patch_size = int(config.feature_metrics.patch_size)
     use_gpu = bool(getattr(config, "use_gpu", True))
+    partial_walk = OmegaConf.select(config, "limit_positions", default=None) is not None
 
     dynaclr_ckpt_sha12 = ckpt_sha256_12(dynaclr_ckpt_path) if dynaclr_ckpt_path is not None else None
     dynaclr_encoder_sha12 = encoder_config_sha256_12(dynaclr_encoder_cfg) if dynaclr_encoder_cfg is not None else None
@@ -188,6 +190,7 @@ def init_cache_context(
         target_name=config.target_name,
         spacing=spacing,
         patch_size=patch_size,
+        partial_walk=partial_walk,
         use_gpu=use_gpu,
         dinov3_model_name=dinov3_model_name,
         dynaclr_ckpt_sha12=dynaclr_ckpt_sha12,
@@ -268,6 +271,14 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
     to a hard :class:`StaleCacheError` — the user opted out of recompute,
     so a stale-version manifest is an unambiguous failure rather than a
     signal to rebuild.
+
+    Under ``limit_positions`` (smoke / iteration mode that walks only the
+    first ``N`` FOVs) the soft path is also escalated: rewriting the
+    manifest's per-extractor entry to the new version while only the
+    visited FOVs' on-disk features get recomputed would leave the
+    unvisited FOVs with stale-version data under a manifest that lies
+    about it. The operator must clear the cache and rerun, OR drop
+    ``limit_positions`` so every FOV is recomputed.
     """
     if not ctx.enabled:
         return
@@ -297,6 +308,13 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
                 f"(cached={cached_version!r}, current={current_version!r}) and "
                 f"io.require_complete_cache=true"
             )
+        if ctx.partial_walk:
+            raise StaleCacheError(
+                f"{section_key}[{sub_key}]: preprocess_version mismatch "
+                f"(cached={cached_version!r}, current={current_version!r}) and "
+                f"limit_positions is set (partial walk cannot safely auto-invalidate; "
+                f"clear the cache or drop limit_positions)"
+            )
         force_key = f"{ctx.side}_{kind}"
         ctx.force[force_key] = True
         warnings.warn(
@@ -323,6 +341,14 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
     a hard :class:`StaleCacheError` — the user opted out of recompute, so a
     stale-param manifest is an unambiguous failure rather than a signal to
     rebuild.
+
+    Under ``limit_positions`` (smoke / iteration mode that walks only the
+    first ``N`` FOVs) the soft path is also escalated: rewriting the
+    manifest's per-artifact entry to the new params while only the visited
+    FOVs' on-disk features get recomputed would leave the unvisited FOVs
+    with stale-param data under a manifest that lies about it. The
+    operator must clear the cache and rerun, OR drop ``limit_positions``
+    so every FOV is recomputed.
     """
     if not ctx.enabled:
         return
@@ -392,6 +418,11 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
         if ctx.require_complete:
             raise StaleCacheError(
                 f"{artifact_label}: artifact param mismatch ({details}) and io.require_complete_cache=true"
+            )
+        if ctx.partial_walk:
+            raise StaleCacheError(
+                f"{artifact_label}: artifact param mismatch ({details}) and limit_positions is set "
+                f"(partial walk cannot safely auto-invalidate; clear the cache or drop limit_positions)"
             )
         force_key = f"{ctx.side}_{kind}"
         ctx.force[force_key] = True

--- a/applications/dynacell/tests/test_evaluation_cache.py
+++ b/applications/dynacell/tests/test_evaluation_cache.py
@@ -15,9 +15,9 @@ from dynacell.evaluation.cache import (  # noqa: E402
     CACHE_SCHEMA_VERSION,
     StaleCacheError,
     cache_paths,
-    check_artifact_params,
     check_cache_identity,
     ckpt_sha256_12,
+    diff_artifact_params,
     encoder_config_sha256_12,
     load_manifest,
     read_features,
@@ -244,43 +244,40 @@ def test_seed_cache_identity_preserves_existing() -> None:
     assert manifest["cell_segmentation"]["plate_path"] == "/orig_seg.zarr"
 
 
-def test_check_artifact_params_none_entry_is_noop() -> None:
-    """No manifest entry means no comparison to do; check returns silently."""
-    check_artifact_params(None, {"spacing": [1.0, 1.0, 1.0]}, artifact_label="cp_features")
+def test_diff_artifact_params_none_entry_returns_empty() -> None:
+    """No manifest entry means no comparison to do; diff returns empty list."""
+    assert diff_artifact_params(None, {"spacing": [1.0, 1.0, 1.0]}) == []
 
 
-def test_check_artifact_params_numeric_allclose_passes() -> None:
+def test_diff_artifact_params_numeric_allclose_returns_empty() -> None:
     """Near-identical floats pass the numeric comparison via np.allclose."""
     entry = {"spacing": [0.29, 0.108, 0.108]}
-    check_artifact_params(
-        entry,
-        {"spacing": [0.29, 0.10800000000001, 0.108]},
-        artifact_label="cp_features",
-        numeric_keys=("spacing",),
+    assert (
+        diff_artifact_params(
+            entry,
+            {"spacing": [0.29, 0.10800000000001, 0.108]},
+            numeric_keys=("spacing",),
+        )
+        == []
     )
 
 
-def test_check_artifact_params_numeric_mismatch_raises() -> None:
-    """Materially different spacing values raise StaleCacheError."""
+def test_diff_artifact_params_numeric_mismatch_lists_key() -> None:
+    """Materially different spacing values surface as a mismatch tuple."""
     entry = {"spacing": [0.29, 0.108, 0.108]}
-    with pytest.raises(StaleCacheError, match="spacing mismatch"):
-        check_artifact_params(
-            entry,
-            {"spacing": [0.3, 0.108, 0.108]},
-            artifact_label="cp_features",
-            numeric_keys=("spacing",),
-        )
+    mismatches = diff_artifact_params(
+        entry,
+        {"spacing": [0.3, 0.108, 0.108]},
+        numeric_keys=("spacing",),
+    )
+    assert mismatches == [("spacing", [0.29, 0.108, 0.108], [0.3, 0.108, 0.108])]
 
 
-def test_check_artifact_params_scalar_mismatch_raises() -> None:
-    """Non-numeric scalar mismatches raise with the param name."""
+def test_diff_artifact_params_scalar_mismatch_lists_key() -> None:
+    """Non-numeric scalar mismatches surface with the param name."""
     entry = {"patch_size": 256, "model_name": "foo"}
-    with pytest.raises(StaleCacheError, match="patch_size mismatch"):
-        check_artifact_params(
-            entry,
-            {"patch_size": 128, "model_name": "foo"},
-            artifact_label="dinov3_features",
-        )
+    mismatches = diff_artifact_params(entry, {"patch_size": 128, "model_name": "foo"})
+    assert mismatches == [("patch_size", 256, 128)]
 
 
 def test_write_and_read_mask_roundtrip(tmp_path: Path) -> None:

--- a/applications/dynacell/tests/test_evaluation_cache.py
+++ b/applications/dynacell/tests/test_evaluation_cache.py
@@ -280,6 +280,38 @@ def test_diff_artifact_params_scalar_mismatch_lists_key() -> None:
     assert mismatches == [("patch_size", 256, 128)]
 
 
+def test_diff_artifact_params_numeric_length_mismatch_lists_key() -> None:
+    """A malformed numeric cached value (wrong length) surfaces as a mismatch.
+
+    np.allclose raises ValueError on incompatible broadcast shapes; the
+    helper must catch that so the caller can soft-invalidate rather than
+    crash inside init_cache_context.
+    """
+    entry = {"spacing": [0.29, 0.108]}
+    mismatches = diff_artifact_params(
+        entry,
+        {"spacing": [0.29, 0.108, 0.108]},
+        numeric_keys=("spacing",),
+    )
+    assert mismatches == [("spacing", [0.29, 0.108], [0.29, 0.108, 0.108])]
+
+
+def test_diff_artifact_params_numeric_nonconvertible_lists_key() -> None:
+    """A numeric cached value that isn't array-castable surfaces as a mismatch.
+
+    np.asarray(..., dtype=float) raises TypeError on non-numeric input
+    (e.g. a hand-edited manifest with a string sentinel); the helper must
+    catch that so a malformed manifest does not bypass soft-invalidation.
+    """
+    entry = {"spacing": "unknown"}
+    mismatches = diff_artifact_params(
+        entry,
+        {"spacing": [0.29, 0.108, 0.108]},
+        numeric_keys=("spacing",),
+    )
+    assert mismatches == [("spacing", "unknown", [0.29, 0.108, 0.108])]
+
+
 def test_write_and_read_mask_roundtrip(tmp_path: Path) -> None:
     """Masks written for one position are readable back as a bool array."""
     paths = cache_paths(tmp_path)

--- a/applications/dynacell/tests/test_evaluation_cache.py
+++ b/applications/dynacell/tests/test_evaluation_cache.py
@@ -312,6 +312,26 @@ def test_diff_artifact_params_numeric_nonconvertible_lists_key() -> None:
     assert mismatches == [("spacing", "unknown", [0.29, 0.108, 0.108])]
 
 
+def test_diff_artifact_params_non_dict_entry_lists_all_keys() -> None:
+    """A non-mapping manifest entry surfaces every current key as a mismatch.
+
+    Hand-edited or partially-written manifest YAML can put a string,
+    list, or scalar where an artifact dict is expected; `entry.get(key)`
+    would raise AttributeError and crash init_cache_context. The helper
+    must treat the malformed entry as "no usable cached params" so the
+    caller can soft-invalidate.
+    """
+    mismatches = diff_artifact_params(
+        "corrupted-string-instead-of-dict",  # type: ignore[arg-type]
+        {"spacing": [0.29, 0.108, 0.108], "patch_size": 4},
+        numeric_keys=("spacing",),
+    )
+    assert mismatches == [
+        ("spacing", "corrupted-string-instead-of-dict", [0.29, 0.108, 0.108]),
+        ("patch_size", "corrupted-string-instead-of-dict", 4),
+    ]
+
+
 def test_write_and_read_mask_roundtrip(tmp_path: Path) -> None:
     """Masks written for one position are readable back as a bool array."""
     paths = cache_paths(tmp_path)

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -276,6 +276,32 @@ def test_init_cache_spacing_mismatch_auto_invalidates(tmp_path: Path) -> None:
     )
 
 
+def test_init_cache_spacing_mismatch_raises_under_require_complete(tmp_path: Path) -> None:
+    """Stale spacing under ``require_complete_cache=true`` is fatal, not soft-recomputed.
+
+    The fast-path mode promises no model loads and no opportunistic
+    rebuilds; auto-invalidation here would silently violate that contract
+    and trigger compute the operator explicitly opted out of.
+    """
+    paths = cache_paths(tmp_path)
+    from dynacell.evaluation.cache import save_manifest
+
+    save_manifest(
+        paths,
+        {
+            "cache_schema_version": 1,
+            "gt": {"plate_path": "/tmp/gt.zarr", "channel_name": "target"},
+            "cell_segmentation": {"plate_path": "/tmp/seg.zarr"},
+            "artifacts": {"cp_features": {"spacing": [0.3, 0.108, 0.108]}},
+        },
+    )
+    with pytest.raises(StaleCacheError, match="gt_cp.*spacing.*require_complete_cache=true"):
+        init_cache_context(
+            _make_config(**{"io.gt_cache_dir": str(tmp_path), "io.require_complete_cache": True}),
+            side="gt",
+        )
+
+
 def test_fov_gt_masks_cache_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:
     """First call computes masks via segment() and writes them to cache."""
     import dynacell.evaluation.segmentation as segmentation

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -295,7 +295,7 @@ def test_init_cache_spacing_mismatch_raises_under_require_complete(tmp_path: Pat
             "artifacts": {"cp_features": {"spacing": [0.3, 0.108, 0.108]}},
         },
     )
-    with pytest.raises(StaleCacheError, match="gt_cp.*spacing.*require_complete_cache=true"):
+    with pytest.raises(StaleCacheError, match="cp_features.*spacing.*require_complete_cache=true"):
         init_cache_context(
             _make_config(**{"io.gt_cache_dir": str(tmp_path), "io.require_complete_cache": True}),
             side="gt",

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -244,8 +244,15 @@ def test_init_pred_cache_channel_name_mismatch_raises(tmp_path: Path) -> None:
         )
 
 
-def test_init_cache_spacing_mismatch_raises(tmp_path: Path) -> None:
-    """An existing cp_features entry with a different spacing value raises."""
+def test_init_cache_spacing_mismatch_auto_invalidates(tmp_path: Path) -> None:
+    """A cp_features entry with a stale spacing flips force_recompute, not raises.
+
+    Pre-existing manifest has ``spacing=[0.3, 0.108, 0.108]`` but the current
+    config advertises ``[0.29, 0.108, 0.108]``. The validator must warn and
+    set ``force["gt_cp"] = True`` so the regionprops cache is recomputed
+    with the current spacing, then the manifest entry is rewritten — letting
+    spacing bumps self-heal across runs.
+    """
     paths = cache_paths(tmp_path)
     from dynacell.evaluation.cache import save_manifest
 
@@ -258,8 +265,15 @@ def test_init_cache_spacing_mismatch_raises(tmp_path: Path) -> None:
             "artifacts": {"cp_features": {"spacing": [0.3, 0.108, 0.108]}},
         },
     )
-    with pytest.raises(StaleCacheError, match="spacing mismatch"):
-        init_cache_context(_make_config(**{"io.gt_cache_dir": str(tmp_path)}), side="gt")
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        ctx = init_cache_context(_make_config(**{"io.gt_cache_dir": str(tmp_path)}), side="gt")
+    assert ctx.force["gt_cp"] is True
+    assert any("artifact param mismatch" in str(w.message) and "spacing" in str(w.message) for w in caught), (
+        f"expected spacing mismatch warning; got {[str(w.message) for w in caught]}"
+    )
 
 
 def test_fov_gt_masks_cache_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -302,6 +302,36 @@ def test_init_cache_spacing_mismatch_raises_under_require_complete(tmp_path: Pat
         )
 
 
+def test_init_cache_spacing_mismatch_raises_under_limit_positions(tmp_path: Path) -> None:
+    """Stale spacing under ``limit_positions`` is fatal, not soft-recomputed.
+
+    Partial-walk runs (smoke / iteration with `limit_positions=N`) visit
+    only the first N FOVs. Soft-invalidate would rewrite the manifest's
+    flat `cp_features.spacing` to the new value while only those N FOVs
+    get their on-disk regionprops recomputed — leaving unvisited FOVs'
+    chunks tagged with the new spacing in the manifest but holding
+    old-spacing data on disk. The operator must clear the cache or drop
+    `limit_positions`.
+    """
+    paths = cache_paths(tmp_path)
+    from dynacell.evaluation.cache import save_manifest
+
+    save_manifest(
+        paths,
+        {
+            "cache_schema_version": 1,
+            "gt": {"plate_path": "/tmp/gt.zarr", "channel_name": "target"},
+            "cell_segmentation": {"plate_path": "/tmp/seg.zarr"},
+            "artifacts": {"cp_features": {"spacing": [0.3, 0.108, 0.108]}},
+        },
+    )
+    with pytest.raises(StaleCacheError, match="cp_features.*spacing.*limit_positions"):
+        init_cache_context(
+            _make_config(**{"io.gt_cache_dir": str(tmp_path), "limit_positions": 4}),
+            side="gt",
+        )
+
+
 def test_fov_gt_masks_cache_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:
     """First call computes masks via segment() and writes them to cache."""
     import dynacell.evaluation.segmentation as segmentation


### PR DESCRIPTION
## Summary

- Convert `_validate_artifact_params` from hard-raise to warn-and-flip `force_recompute.<side>_<kind>`, mirroring `_auto_invalidate_on_preprocess_version_mismatch`. A spacing bump (PR #439, 0.116 → 0.1494 µm) made every cached cp_features entry start raising `StaleCacheError` at cache init — operators had to wipe each cache to recover. Stale params now self-heal.
- Preserve fail-loud under `io.require_complete_cache=true`: both `_auto_invalidate_*` helpers raise instead of soft-invalidating when the user opted out of recompute (model loads are skipped on that path, so soft-invalidate would enter the recompute branch in `_fov_masks` / `_load_or_compute_feature_timepoints` and silently violate the documented contract).
- Treat malformed cached numeric params (None, string sentinel, length-mismatched spacing) as mismatches rather than letting `np.asarray` / `np.allclose` exceptions escape and crash `init_cache_context`.
- Include the manifest sub-key (e.g. `dinov3_features[<model>]`, `cp_features`, `organelle_masks[<target>]`) in soft-invalidate warnings and require_complete raises so operators can grep logs by specific model / target.

## Commits (atomic, one per simplify finding)

1. `028764d2` refactor: base soft-invalidate (rename `check_artifact_params` → `diff_artifact_params`, replace `_validate_artifact_params` with `_auto_invalidate_on_artifact_param_mismatch`)
2. `b7644c38` fix: hard-raise under `require_complete_cache=true` (escape hatch on both `_auto_invalidate_*` helpers)
3. `50dc4ae4` fix: malformed cached numeric values surface as mismatches, not crashes
4. `168fafbf` fix: include artifact sub-key in warning / raise messages

## Out of scope (known limitations matching the existing preprocess_version pattern)

- **Partial-recompute under shared zarrs:** `cp_features.zarr` and the feature-family zarrs are keyed per-FOV, but the manifest entry is rewritten globally. FOVs not visited in the soft-invalidate run keep stale on-disk values while the manifest claims the new params. This is the same limitation that `_auto_invalidate_on_preprocess_version_mismatch` accepts; addressing it would diverge unilaterally.
- **Cross-side `source_tag` contamination:** `check_cache_identity` catches the gross case (a pred manifest reused as gt). A hand-edited manifest with a flipped per-artifact `source` field would now soft-invalidate instead of raise — judged contrived and out of scope.

## Test plan

- [x] `uv run pytest applications/dynacell/tests/test_evaluation_cache.py applications/dynacell/tests/test_pipeline_cache.py` — 73 pass
- [x] `uvx prek run --files <edited>` clean (ruff check + format)
- [x] New tests: `test_diff_artifact_params_numeric_length_mismatch_lists_key`, `test_diff_artifact_params_numeric_nonconvertible_lists_key`, `test_init_cache_spacing_mismatch_auto_invalidates`, `test_init_cache_spacing_mismatch_raises_under_require_complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)