### PR TITLE
feat(dynacell/eval): Cellpose nucleus + watershed whole-cell instance AP

### DIFF
--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = [ "version" ]
 dependencies = [
   "lightning>=2.3",
   "monai",
+  "nvidia-cublas-cu12>=12.9.2.10",
   "omegaconf",
   "pydantic>=2",
   "viscy-data[mmap]",
@@ -43,7 +44,7 @@ optional-dependencies.eval = [
   "aicsmlsegment",
   "aicssegmentation",
   "cellpose",
-  "cubic==0.7.0a8",
+  "cubic==0.7.0a9",
   "dynaclr",
   "hydra-core>=1.2",
   "iohub",

--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -31,7 +31,6 @@ dynamic = [ "version" ]
 dependencies = [
   "lightning>=2.3",
   "monai",
-  "nvidia-cublas-cu12>=12.9.2.10",
   "omegaconf",
   "pydantic>=2",
   "viscy-data[mmap]",
@@ -66,11 +65,12 @@ optional-dependencies.eval = [
 optional-dependencies.eval_gpu = [
   "cucim-cu12",
   "cupy-cuda12x",
-  # cupy-cuda12x needs libcufft.so.11 (CUDA 12 cuFFT ABI). Torch 2.12 +cu130
-  # pulls in nvidia-cufft (12.0.0.61, libcufft.so.12) but not the cu12
-  # variant, so we pin nvidia-cufft-cu12 explicitly to bring back
-  # libcufft.so.11. Both sonames coexist; cupy picks .11 via cuda-pathfinder,
-  # torch picks .12 via its own dlopen tree.
+  # cupy-cuda12x is CUDA-12 only and finds its CUDA libs through
+  # cuda-pathfinder. torch is pinned to a CUDA-12 build (see the root
+  # pyproject's pytorch-cu128 index) so the whole venv is CUDA-12-consistent
+  # and pathfinder resolves cupy's cublas/cufft to the cu12 wheels; nvidia-
+  # cufft-cu12 is declared explicitly so cupy's cuFFT is present regardless of
+  # torch's cuda-toolkit extras.
   "nvidia-cufft-cu12",
 ]
 optional-dependencies.preprocess = [

--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -63,15 +63,13 @@ optional-dependencies.eval = [
   "transformers",
 ]
 optional-dependencies.eval_gpu = [
-  "cucim-cu12",
-  "cupy-cuda12x",
-  # cupy-cuda12x is CUDA-12 only and finds its CUDA libs through
-  # cuda-pathfinder. torch is pinned to a CUDA-12 build (see the root
-  # pyproject's pytorch-cu128 index) so the whole venv is CUDA-12-consistent
-  # and pathfinder resolves cupy's cublas/cufft to the cu12 wheels; nvidia-
-  # cufft-cu12 is declared explicitly so cupy's cuFFT is present regardless of
-  # torch's cuda-toolkit extras.
-  "nvidia-cufft-cu12",
+  # CUDA-13 builds so cupy/cucim match torch's CUDA-13 stack (PyPI torch 2.12 is
+  # cu13, and the HPC GPU driver is CUDA 13). cupy/cucim find their CUDA libs via
+  # cuda-pathfinder, which resolves to the cu13 nvidia wheels torch already pulls
+  # -- a consistent single-CUDA-major venv, so cupy works with no LD_LIBRARY_PATH.
+  # (cupy-cuda12x on a cu13 torch breaks: pathfinder hands it libcublas.so.13.)
+  "cucim-cu13",
+  "cupy-cuda13x",
 ]
 optional-dependencies.preprocess = [
   "iohub",

--- a/applications/dynacell/src/dynacell/evaluation/CLAUDE.md
+++ b/applications/dynacell/src/dynacell/evaluation/CLAUDE.md
@@ -5,8 +5,15 @@ computing) for any GPU-accelerated numerical work — image preprocessing
 before / after model inference, metric calculations, cropping/resizing,
 percentile clips, Gaussian filters, etc. Cubic is a hard runtime
 dependency of the eval extras (`applications/dynacell/pyproject.toml`
-pins `cubic==0.7.0a6`). Do not gate cubic imports behind `try/except`
+pins `cubic==0.7.0a9`). Do not gate cubic imports behind `try/except`
 or fall back to scipy/skimage paths.
+
+The GPU-resident Cellpose-SAM entry point is
+`cubic.segmentation.segment_cpsam` (single host→device upload, masks
+returned to host; GPU-only by contract). The marker-controlled watershed
+helper `segment_watershed` is **not** re-exported from
+`cubic.segmentation` — import it from
+`cubic.segmentation.segment_utils`.
 
 Below is the same guidance the upstream cubic repository ships in its
 `AGENTS.md`, condensed and adapted for this module. **Read it before

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -18,6 +18,44 @@ defaults:
 benchmark: null
 
 target_name: ???
+
+# Nucleus/membrane organelle-mask segmenter. `supermodel` = segmenter-model-zoo
+# SuperModel (default, unchanged behavior). `cellpose` = GPU Cellpose-SAM + fnet
+# pre/post (nucleus only). `cellpose_watershed` = whole-cell (membrane only):
+# GPU Cellpose-SAM nuclei seeds + membrane EDT watershed. The cellpose /
+# cellpose_watershed backends with compute_instance_ap=true add instance mAP
+# (cubic average_precision) to mask_metrics; labels cache under
+# instance_masks/<target>__<backend>.zarr.
+segmentation:
+  backend: supermodel  # supermodel | cellpose (nucleus) | cellpose_watershed (whole-cell)
+  dimension: 2d        # 2d | 3d — instance backends only (3d = full-volume do_3D)
+  slice_selection: frac    # frac | sharpest — picks the 2d plane (dimension=2d)
+  slice_fraction: 0.30     # fractional Z depth when slice_selection=frac
+  nuclei_channel_name: null  # GT-plate channel for watershed seeds (cellpose_watershed only)
+  # Nucleus Cellpose-SAM params (the cellpose path + the cellpose_watershed seeds).
+  cellpose:
+    target_voxel_um: 0.58  # isotropic grid the nuclei are segmented on (always)
+    cellprob_threshold: 0.0
+    flow_threshold: 0.4
+    min_obj_size: 30       # drop nuclei < N px/vox at target_voxel_um; 2D default — raise (~500) for dimension=3d
+  # Whole-cell watershed stage (cellpose_watershed only). Physical-um params,
+  # converted to working-grid pixels per cell_voxel_um (so they are grid-independent).
+  watershed:
+    cell_voxel_um: 0.3     # isotropic cell-stage grid (null = native resolution)
+    close_um: 2.5          # grayscale-closing disk radius
+    wall_sigma_um: 0.35    # gaussian sigma before wall thresholding
+    wall_min_um: 1.0       # drop membrane-wall specks (um^ndim)
+    hole_um: 3.0           # fill cell-mask holes (um^ndim)
+    min_cell_um: 15.0      # drop cells below this (2D um^2 default; set ~50 um^3 for dimension=3d)
+    memb_clahe: true       # CLAHE the membrane channel
+    subtract_nuclei: true  # carve nuclei out -> cytoplasmic-shape-only metrics
+
+# Whole-cell / nucleus instance average-precision. Requires an instance backend:
+# (cellpose_watershed, membrane) or (cellpose, nucleus).
+compute_instance_ap: false
+instance_metrics:
+  iou_thresholds: [0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95]
+
 io:
   pred_path: ???
   gt_path: ???
@@ -110,6 +148,8 @@ force_recompute:
   pred_dinov3: false
   pred_dynaclr: false
   pred_celldino: false
+  gt_instances: false
+  pred_instances: false
   final_metrics: false
 
 save:

--- a/applications/dynacell/src/dynacell/evaluation/cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/cache.py
@@ -45,10 +45,28 @@ class CachePaths:
     manifest: Path
     masks_dir: Path
     features_dir: Path
+    instance_masks_dir: Path
 
-    def mask_plate(self, target_name: str) -> Path:
-        """Return the HCS OME-Zarr plate for masks of *target_name*."""
-        return self.masks_dir / f"{target_name}.zarr"
+    def mask_plate(self, target_name: str, backend: str = "supermodel") -> Path:
+        """Return the HCS OME-Zarr plate for masks of *target_name*.
+
+        Non-default segmentation backends get a ``__{backend}`` filename infix so
+        masks from different segmenters never collide in one cache dir; the
+        default ``supermodel`` keeps the bare ``{target_name}.zarr`` path so
+        pre-existing caches are unaffected.
+        """
+        stem = target_name if backend == "supermodel" else f"{target_name}__{backend}"
+        return self.masks_dir / f"{stem}.zarr"
+
+    def instance_mask_plate(self, target_name: str, backend: str) -> Path:
+        """Return the HCS OME-Zarr plate for instance (uint16) labels.
+
+        Instance-label caches always carry a ``__{backend}`` infix
+        (``nucleus__cellpose.zarr`` / ``membrane__cellpose_watershed.zarr``) and
+        live under a separate directory from the binary ``organelle_masks`` so
+        the two never collide.
+        """
+        return self.instance_masks_dir / f"{target_name}__{backend}.zarr"
 
     def cp_features(self) -> Path:
         """Return the zarr group path for CP regionprops features."""
@@ -75,6 +93,7 @@ def cache_paths(cache_dir: Path | str) -> CachePaths:
         manifest=root / "manifest.yaml",
         masks_dir=root / "organelle_masks",
         features_dir=root / "features",
+        instance_masks_dir=root / "instance_masks",
     )
 
 
@@ -242,7 +261,7 @@ def built_at_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def read_mask(paths: CachePaths, target_name: str, pos_name: str) -> np.ndarray | None:
+def read_mask(paths: CachePaths, target_name: str, pos_name: str, backend: str = "supermodel") -> np.ndarray | None:
     """Read cached organelle masks for a single position.
 
     Returns
@@ -251,7 +270,7 @@ def read_mask(paths: CachePaths, target_name: str, pos_name: str) -> np.ndarray 
         Bool array of shape ``(T, D, H, W)``, or ``None`` if the plate or
         position is absent.
     """
-    plate_path = paths.mask_plate(target_name)
+    plate_path = paths.mask_plate(target_name, backend)
     if not plate_path.exists():
         return None
     with open_ome_zarr(plate_path, mode="r") as plate:
@@ -297,6 +316,7 @@ def write_mask(
     masks: np.ndarray,
     *,
     channel_name: str = _MASK_CHANNEL,
+    backend: str = "supermodel",
 ) -> None:
     """Append masks for a single position to the ``{target_name}.zarr`` plate.
 
@@ -315,9 +335,89 @@ def write_mask(
     """
     if masks.ndim != 4:
         raise ValueError(f"masks must be 4-D (T, D, H, W); got shape {masks.shape}")
-    plate_path = paths.mask_plate(target_name)
+    plate_path = paths.mask_plate(target_name, backend)
     plate_path.parent.mkdir(parents=True, exist_ok=True)
     data = masks.astype(bool)[:, None]  # (T, 1, D, H, W)
+    if plate_path.exists() and _is_position_malformed(plate_path, pos_name):
+        _rewrite_inner_array(plate_path / pos_name, data)
+        return
+    mode = "r+" if plate_path.exists() else "w"
+    with open_ome_zarr(
+        plate_path,
+        mode=mode,
+        layout="hcs",
+        channel_names=[channel_name],
+        version="0.5",
+    ) as plate:
+        row, col, fov = pos_name.split("/")
+        try:
+            position = plate[pos_name]
+        except KeyError:
+            position = plate.create_position(row, col, fov)
+        try:
+            del position["0"]
+        except KeyError:
+            pass
+        position.create_image("0", data)
+
+
+_INSTANCE_MASK_CHANNEL = "instance_seg"
+
+
+def read_instance_mask(paths: CachePaths, target_name: str, pos_name: str, backend: str) -> np.ndarray | None:
+    """Read cached instance labels for a single position.
+
+    Returns
+    -------
+    numpy.ndarray | None
+        uint16 array of shape ``(T, D, H, W)`` (2-D runs are stored with
+        ``D=1``), or ``None`` if the plate or position is absent.
+    """
+    plate_path = paths.instance_mask_plate(target_name, backend)
+    if not plate_path.exists():
+        return None
+    with open_ome_zarr(plate_path, mode="r") as plate:
+        try:
+            position = plate[pos_name]
+        except KeyError:
+            return None
+        data = np.asarray(position.data[:, 0]).astype(np.uint16)
+    return data
+
+
+def write_instance_mask(
+    paths: CachePaths,
+    target_name: str,
+    pos_name: str,
+    labels: np.ndarray,
+    *,
+    channel_name: str = _INSTANCE_MASK_CHANNEL,
+    backend: str,
+) -> None:
+    """Append uint16 instance labels for a single position to the instance plate.
+
+    Mirrors :func:`write_mask` but preserves integer labels (no bool coercion).
+
+    Parameters
+    ----------
+    paths
+        Cache paths.
+    target_name
+        Organelle name (mask plate filename stem, with the ``__{backend}`` infix).
+    pos_name
+        HCS position name in ``row/col/fov`` form.
+    labels
+        uint16 array of shape ``(T, D, H, W)`` (2-D runs use ``D=1``).
+    channel_name
+        OME-Zarr channel label to write for this instance plate.
+    backend
+        Segmentation backend (selects the plate filename infix).
+    """
+    if labels.ndim != 4:
+        raise ValueError(f"labels must be 4-D (T, D, H, W); got shape {labels.shape}")
+    plate_path = paths.instance_mask_plate(target_name, backend)
+    plate_path.parent.mkdir(parents=True, exist_ok=True)
+    data = labels.astype(np.uint16)[:, None]  # (T, 1, D, H, W)
     if plate_path.exists() and _is_position_malformed(plate_path, pos_name):
         _rewrite_inner_array(plate_path / pos_name, data)
         return

--- a/applications/dynacell/src/dynacell/evaluation/instance_metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/instance_metrics.py
@@ -1,0 +1,87 @@
+"""Instance-segmentation average-precision metrics (Cellpose-style).
+
+Thin numpy wrapper over :func:`cubic.metrics.average_precision` (TP / (TP + FP +
+FN) per IoU threshold, the Cellpose definition). Used for both the nucleus and
+whole-cell instance-AP eval paths. The returned dict merges directly into the
+per-(FOV, t) mask-metric rows, so every per-threshold AP becomes its own
+``mask_metrics.csv`` column / ``.npy`` key.
+"""
+
+import numpy as np
+from cubic.metrics import average_precision
+
+DEFAULT_IOU_THRESHOLDS = (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95)
+"""IoU thresholds for the AP sweep (Cellpose / StarDist standard 0.50..0.95)."""
+
+_PRIMARY_THRESHOLD = 0.50
+"""IoU threshold whose TP/FP/FN counts are persisted (the standard 0.50 operating
+point); stored under ``instance_{TP,FP,FN}@0.50`` so the threshold is explicit."""
+
+
+def _relabel_sequential(labels: np.ndarray) -> np.ndarray:
+    """Relabel an integer label image to a dense ``0, 1..K`` (background stays 0).
+
+    ``cubic.average_precision`` derives object counts from ``labels.max()``, so
+    labels must be gap-free for FP/FN to be correct. Uses ``np.unique`` with
+    ``return_inverse`` (not connected-component relabeling — disjoint pieces that
+    share an id stay one object).
+    """
+    labels = np.asarray(labels)
+    uniq, inv = np.unique(labels, return_inverse=True)
+    inv = inv.reshape(labels.shape)
+    # uniq is sorted ascending; if a 0 background exists it maps to 0, real ids to
+    # 1..K. If no 0 is present (no background), shift so ids become 1..K.
+    return inv if uniq[0] == 0 else inv + 1
+
+
+def instance_average_precision(
+    labels_pred: np.ndarray,
+    labels_gt: np.ndarray,
+    iou_thresholds=DEFAULT_IOU_THRESHOLDS,
+) -> dict:
+    """Average precision of predicted vs ground-truth instance labels.
+
+    Parameters
+    ----------
+    labels_pred, labels_gt : numpy.ndarray
+        Predicted and ground-truth integer instance-label images (same shape).
+    iou_thresholds : sequence of float
+        IoU thresholds for the AP sweep.
+
+    Returns
+    -------
+    dict
+        ``AP_<th>`` (one per threshold), ``mAP`` (their mean), ``n_gt``,
+        ``n_pred``, and ``instance_{TP,FP,FN}@0.50``. Both sides empty → all-NaN
+        AP/mAP; exactly one side empty → AP/mAP 0.0.
+    """
+    thresholds = [float(t) for t in iou_thresholds]
+    pred = _relabel_sequential(labels_pred)
+    gt = _relabel_sequential(labels_gt)
+    n_pred = int(pred.max())
+    n_gt = int(gt.max())
+
+    # cubic.average_precision returns 0 (not NaN) on empty inputs, so pre-check the
+    # degenerate cases here and call it only when both sides have objects.
+    if n_gt == 0 and n_pred == 0:
+        ap_vals = [float("nan")] * len(thresholds)
+        tp = fp = fn = float("nan")
+    elif n_gt == 0 or n_pred == 0:
+        ap_vals = [0.0] * len(thresholds)
+        tp, fp, fn = 0.0, float(n_pred), float(n_gt)
+    else:
+        ap, tp_arr, fp_arr, fn_arr = average_precision(gt, pred, thresholds)
+        ap_vals = [float(a) for a in np.atleast_1d(ap)]
+        idx = thresholds.index(_PRIMARY_THRESHOLD) if _PRIMARY_THRESHOLD in thresholds else 0
+        tp = float(np.atleast_1d(tp_arr)[idx])
+        fp = float(np.atleast_1d(fp_arr)[idx])
+        fn = float(np.atleast_1d(fn_arr)[idx])
+
+    result = {"n_gt": n_gt, "n_pred": n_pred}
+    for th, a in zip(thresholds, ap_vals):
+        result[f"AP_{th:.2f}"] = a
+    result["mAP"] = float(np.mean(ap_vals))
+    result[f"instance_TP@{_PRIMARY_THRESHOLD:.2f}"] = tp
+    result[f"instance_FP@{_PRIMARY_THRESHOLD:.2f}"] = fp
+    result[f"instance_FN@{_PRIMARY_THRESHOLD:.2f}"] = fn
+    return result

--- a/applications/dynacell/src/dynacell/evaluation/instance_metrics_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/instance_metrics_test.py
@@ -1,0 +1,95 @@
+"""Tests for the instance average-precision wrapper (real cubic, CPU)."""
+
+import numpy as np
+
+from dynacell.evaluation.instance_metrics import (
+    DEFAULT_IOU_THRESHOLDS,
+    _relabel_sequential,
+    instance_average_precision,
+)
+
+
+def _two_squares(shape=(16, 16)) -> np.ndarray:
+    """A label image with two well-separated square instances (ids 1, 2)."""
+    lab = np.zeros(shape, dtype=np.uint16)
+    lab[2:6, 2:6] = 1
+    lab[10:14, 10:14] = 2
+    return lab
+
+
+def test_identical_labels_map_one():
+    """Identical label images score mAP 1.0 and AP 1.0 at every threshold."""
+    gt = _two_squares()
+    result = instance_average_precision(gt.copy(), gt)
+    assert result["mAP"] == 1.0
+    assert result["n_gt"] == 2 and result["n_pred"] == 2
+    for th in DEFAULT_IOU_THRESHOLDS:
+        assert result[f"AP_{th:.2f}"] == 1.0
+    assert result["instance_TP@0.50"] == 2.0
+    assert result["instance_FP@0.50"] == 0.0
+    assert result["instance_FN@0.50"] == 0.0
+
+
+def test_disjoint_labels_map_zero():
+    """Predicting objects nowhere near the GT scores mAP 0.0."""
+    gt = _two_squares()
+    pred = np.zeros_like(gt)
+    pred[2:6, 10:14] = 1  # overlaps neither GT square
+    result = instance_average_precision(pred, gt)
+    assert result["mAP"] == 0.0
+
+
+def test_one_side_empty_is_zero():
+    """One empty side → AP 0.0 (not NaN); FP/FN reflect the non-empty side."""
+    gt = _two_squares()
+    empty = np.zeros_like(gt)
+    miss = instance_average_precision(empty, gt)
+    assert miss["mAP"] == 0.0
+    assert miss["instance_FN@0.50"] == 2.0
+    assert miss["instance_FP@0.50"] == 0.0
+    extra = instance_average_precision(gt.copy(), empty)
+    assert extra["mAP"] == 0.0
+    assert extra["instance_FP@0.50"] == 2.0
+    assert extra["instance_FN@0.50"] == 0.0
+
+
+def test_both_empty_is_nan():
+    """Both sides empty → AP undefined (NaN), not a spurious 0.0."""
+    empty = np.zeros((16, 16), dtype=np.uint16)
+    result = instance_average_precision(empty, empty)
+    assert np.isnan(result["mAP"])
+    assert result["n_gt"] == 0 and result["n_pred"] == 0
+    for th in DEFAULT_IOU_THRESHOLDS:
+        assert np.isnan(result[f"AP_{th:.2f}"])
+
+
+def test_arg_swap_moves_fp_fn_not_map():
+    """Swapping pred/gt leaves mAP unchanged but swaps FP and FN."""
+    gt = _two_squares()
+    pred = gt.copy()
+    pred[10:14, 10:14] = 0  # pred has only 1 of the 2 objects
+    a = instance_average_precision(pred, gt)  # 1 pred, 2 gt -> 1 FN
+    b = instance_average_precision(gt, pred)  # 2 pred, 1 gt -> 1 FP
+    assert a["mAP"] == b["mAP"]
+    assert a["instance_FN@0.50"] == b["instance_FP@0.50"] == 1.0
+    assert a["instance_FP@0.50"] == b["instance_FN@0.50"] == 0.0
+
+
+def test_gapped_relabel_no_merge():
+    """``_relabel_sequential`` densifies ids without merging disjoint objects."""
+    lab = np.zeros((8, 8), dtype=np.uint16)
+    lab[0:2, 0:2] = 5
+    lab[5:7, 5:7] = 9  # gap in ids (5, 9) -> should become (1, 2)
+    out = _relabel_sequential(lab)
+    assert sorted(np.unique(out).tolist()) == [0, 1, 2]
+    # the two original objects stay distinct (no merge)
+    assert out[0, 0] != out[5, 5]
+
+
+def test_relabel_preserves_object_count_for_ap():
+    """AP object counts come from labels.max(); relabel keeps n correct."""
+    lab = np.zeros((8, 8), dtype=np.uint16)
+    lab[0:2, 0:2] = 7  # single object with a non-1 id
+    result = instance_average_precision(lab.copy(), lab)
+    assert result["n_gt"] == 1 and result["n_pred"] == 1
+    assert result["mAP"] == 1.0

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
 from dynacell.evaluation.cache import FeatureKind
+from dynacell.evaluation.cross_condition_probe import run_for_group as _cross_condition_run_for_group
 from dynacell.evaluation.feature_metrics import (
     compute_feature_similarity,
     compute_feature_similarity_pairwise,
@@ -45,6 +46,9 @@ from dynacell.evaluation.pipeline_cache import (
     fov_cp_features,
     fov_deep_features,
     fov_masks,
+    fov_nucleus_instances,
+    fov_whole_cell_instances,
+    instance_cache_hit,
     precompute_deep_features,
 )
 from dynacell.evaluation.runtime import (
@@ -369,6 +373,46 @@ def _calibrate_microssim(
     return sim, read_cache
 
 
+def _validate_instance_ap_config(config: DictConfig) -> None:
+    """Validate the instance-AP backend / target / toggle combination.
+
+    Bidirectional guard (raises ``ValueError`` on any invalid pairing):
+
+    - ``backend='cellpose_watershed'`` requires ``target_name='membrane'``, a
+      non-null ``segmentation.nuclei_channel_name`` (the GT watershed seeds), and
+      ``compute_instance_ap=true`` (whole-cell AP is the backend's sole purpose).
+    - ``compute_instance_ap=true`` requires an instance-producing pair:
+      ``(cellpose_watershed, membrane)`` or ``(cellpose, nucleus)``.
+    """
+    backend = OmegaConf.select(config, "segmentation.backend", default="supermodel")
+    compute_instance_ap = bool(getattr(config, "compute_instance_ap", False))
+    target_name = config.target_name
+    nuclei_channel = OmegaConf.select(config, "segmentation.nuclei_channel_name", default=None)
+
+    if backend == "cellpose_watershed":
+        if target_name != "membrane":
+            raise ValueError("segmentation.backend='cellpose_watershed' requires target_name='membrane'")
+        if nuclei_channel is None:
+            raise ValueError(
+                "segmentation.backend='cellpose_watershed' requires segmentation.nuclei_channel_name "
+                "(the GT-plate channel for the watershed seeds)"
+            )
+        if not compute_instance_ap:
+            raise ValueError("segmentation.backend='cellpose_watershed' requires compute_instance_ap=true")
+
+    if compute_instance_ap:
+        valid = (backend == "cellpose_watershed" and target_name == "membrane") or (
+            backend == "cellpose" and target_name == "nucleus"
+        )
+        if not valid:
+            raise ValueError(
+                "compute_instance_ap=true requires an instance-producing backend/target: "
+                "(backend='cellpose_watershed', target_name='membrane') or "
+                "(backend='cellpose', target_name='nucleus'); "
+                f"got backend={backend!r}, target_name={target_name!r}"
+            )
+
+
 def _process_one_fov(
     config: DictConfig,
     cuda_empty_cache_every_n_timepoints: int,
@@ -394,7 +438,10 @@ def _process_one_fov(
     ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
     paths in ``evaluate_predictions``.
     """
+    from dynacell.evaluation.instance_metrics import instance_average_precision
     from dynacell.evaluation.segmentation import segment
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
+    from dynacell.evaluation.segmentation_whole_cell import slice_index
 
     timings_start = len(get_timings())
     # Inner per-T tqdm is noise when N workers each emit it to the shared
@@ -421,13 +468,67 @@ def _process_one_fov(
 
     T = predict.shape[0]
 
-    with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
-        gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
-    if pred_cache_ctx.enabled:
-        with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
-            pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
+    # Mask path: when compute_instance_ap is set, the binary fov_masks path is
+    # replaced by an instance-label path (nucleus or whole-cell). gt_cells /
+    # pred_cells are (T, D, H, W) uint16 instance labels; the binary mask metrics
+    # are derived from labels>0 in the per-T loop. Otherwise the legacy binary
+    # path runs byte-identically.
+    instance_mode = bool(getattr(config, "compute_instance_ap", False))
+    backend = OmegaConf.select(config, "segmentation.backend", default="supermodel")
+    gt_cells = pred_cells = None
+    gt_mask_stack = pred_mask_stack = None
+    if instance_mode:
+        is3d = OmegaConf.select(config, "segmentation.dimension", default="2d") == "3d"
+        # Separate working arrays — never rebind predict/target (the 3D pixel
+        # metrics + MicroMS3IM below keep using the full native arrays).
+        if is3d:
+            target_cells, predict_cells = target, predict
+        else:
+            sel = OmegaConf.select(config, "segmentation.slice_selection", default="frac")
+            frac = float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30))
+            z_idx = [slice_index(target[t], selection=sel, fraction=frac) for t in range(T)]
+            target_cells = np.stack([target[t, z_idx[t]] for t in range(T)])  # (T, Y, X)
+            predict_cells = np.stack([predict[t, z_idx[t]] for t in range(T)])
+        if backend == "cellpose_watershed":
+            nuclei_channel = OmegaConf.select(config, "segmentation.nuclei_channel_name", default=None)
+            nuclei = np.asarray(pos_gt.data[:, pos_gt.get_channel_index(nuclei_channel)])  # (T, Z, Y, X)
+            nuclei_cells = nuclei if is3d else np.stack([nuclei[t, z_idx[t]] for t in range(T)])
+            # Seed preflight: compute GT-nuclei watershed seeds only when at least
+            # one side will actually run segment_whole_cell (a disabled cache or a
+            # manifest-invalidated/forced slot counts as a miss).
+            gt_will_compute = not cache_ctx.enabled or not instance_cache_hit(cache_ctx, pos_name_pred)
+            pred_will_compute = not pred_cache_ctx.enabled or not instance_cache_hit(pred_cache_ctx, pos_name_pred)
+            seed_stack = None
+            if gt_will_compute or pred_will_compute:
+                seg_spacing = tuple(config.pixel_metrics.spacing) if is3d else tuple(config.pixel_metrics.spacing[-2:])
+                with region_timer("nucleus_seeds", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                    seed_stack = np.stack(
+                        [
+                            segment_nucleus_instances(
+                                nuclei_cells[t], seg_spacing, seg_model, do_3d=is3d, **cache_ctx.cellpose_params
+                            )
+                            for t in range(T)
+                        ]
+                    )
+            with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                gt_cells = fov_whole_cell_instances(cache_ctx, pos_name_pred, target_cells, nuclei_cells, seed_stack)
+            with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                pred_cells = fov_whole_cell_instances(
+                    pred_cache_ctx, pos_name_pred, predict_cells, nuclei_cells, seed_stack
+                )
+        else:  # backend == "cellpose": independent per-side nucleus instances
+            with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                gt_cells = fov_nucleus_instances(cache_ctx, pos_name_pred, target_cells, seg_model)
+            with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                pred_cells = fov_nucleus_instances(pred_cache_ctx, pos_name_pred, predict_cells, seg_model)
     else:
-        pred_mask_stack = None
+        with region_timer("mask_gt", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+            gt_mask_stack = fov_masks(cache_ctx, pos_name_pred, target, seg_model)
+        if pred_cache_ctx.enabled:
+            with region_timer("mask_pred", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
+                pred_mask_stack = fov_masks(pred_cache_ctx, pos_name_pred, predict, seg_model)
+        else:
+            pred_mask_stack = None
 
     gt_cp_per_t = None
     gt_dinov3_per_t = None
@@ -509,15 +610,32 @@ def _process_one_fov(
         fov_pixel_metrics.append({**data_info, **pixel_metrics})
 
         with region_timer("mask_metrics", pos_name_pred, t):
-            segmented_target = gt_mask_stack[t]
-            if pred_mask_stack is not None:
-                segmented_predict = pred_mask_stack[t]
+            if instance_mode:
+                gt_lab = gt_cells[t]
+                pred_lab = pred_cells[t]
+                segmented_target = gt_lab > 0
+                segmented_predict = pred_lab > 0
+                with region_timer("instance_ap", pos_name_pred, t):
+                    ap_metrics = instance_average_precision(pred_lab, gt_lab, cache_ctx.iou_thresholds)
+                fov_mask_metrics.append(
+                    {**data_info, **evaluate_segmentations(segmented_predict, segmented_target), **ap_metrics}
+                )
             else:
-                with gpu_serialization_lock(gate=use_gpu):
-                    segmented_predict = np.asarray(segment(predict[t], config.target_name, seg_model=seg_model)).astype(
-                        bool
-                    )
-            fov_mask_metrics.append({**data_info, **evaluate_segmentations(segmented_predict, segmented_target)})
+                segmented_target = gt_mask_stack[t]
+                if pred_mask_stack is not None:
+                    segmented_predict = pred_mask_stack[t]
+                else:
+                    with gpu_serialization_lock(gate=use_gpu):
+                        segmented_predict = np.asarray(
+                            segment(
+                                predict[t],
+                                config.target_name,
+                                seg_model=seg_model,
+                                backend=OmegaConf.select(config, "segmentation.backend", default="supermodel"),
+                                spacing_zyx=tuple(config.pixel_metrics.spacing),
+                            )
+                        ).astype(bool)
+                fov_mask_metrics.append({**data_info, **evaluate_segmentations(segmented_predict, segmented_target)})
             segmentations.append(np.stack([segmented_predict, segmented_target], axis=0))
 
         if config.compute_feature_metrics:
@@ -783,6 +901,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
     # so this is safe under feature-metrics-disabled runs.
     OmegaConf.resolve(config)
     reset_timings()
+    _validate_instance_ap_config(config)
 
     use_gpu = bool(getattr(config, "use_gpu", True))
 
@@ -1230,8 +1349,15 @@ def _final_metrics_cache_valid(config: DictConfig) -> bool:
         return False
     save_dir = Path(config.save.save_dir)
     pixel_ok = (save_dir / config.save.pixel_metrics_filename).exists()
-    mask_ok = (save_dir / config.save.mask_metrics_filename).exists()
+    mask_path = save_dir / config.save.mask_metrics_filename
+    mask_ok = mask_path.exists()
     feature_ok = (save_dir / config.save.feature_metrics_filename).exists() if config.compute_feature_metrics else True
+    # A prior AP-less run's mask cache must not suppress newly-requested instance
+    # AP: require the AP columns to be present in the cached rows.
+    if mask_ok and bool(getattr(config, "compute_instance_ap", False)):
+        rows = np.load(mask_path, allow_pickle=True).tolist()
+        if not rows or "mAP" not in rows[0]:
+            return False
     return pixel_ok and mask_ok and feature_ok
 
 
@@ -1252,12 +1378,29 @@ _MODEL_LOADING_FIELDS: tuple[str, ...] = (
     "feature_extractor",
     "compute_feature_metrics",
     "use_gpu",
+    # segmentation.backend selects SuperModel vs Cellpose-SAM in
+    # ``prepare_segmentation_model`` and the mask cache path — a per-condition
+    # override would load the wrong segmenter for the shared bundle and mix
+    # backends across the grouped run's mask caches.
+    "segmentation.backend",
     # require_complete_cache flips ``prepare_segmentation_model`` between
     # "load real SuperModel" and "return None" — letting a condition
     # override it would mean the shared seg_model bundle is wrong for that
     # condition (None when cache-miss expects a real model, or loaded but
     # never used). Treat as a grouped invariant.
     "io.require_complete_cache",
+    # The instance-AP toggles gate the segmentation behavior and the shared
+    # instance-label cache identity. A per-condition override would change the
+    # seg backend, the sliced plane, the seed params, or the AP thresholds for
+    # one condition while sharing the bundle + caches with the others.
+    "compute_instance_ap",
+    "segmentation.dimension",
+    "segmentation.slice_selection",
+    "segmentation.slice_fraction",
+    "segmentation.nuclei_channel_name",
+    "segmentation.cellpose",
+    "segmentation.watershed",
+    "instance_metrics.iou_thresholds",
 )
 
 
@@ -1456,6 +1599,7 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
         return models
 
     results: list[tuple[str, tuple]] = []
+    condition_save_dirs: list[Path] = []
     for idx, cond in enumerate(conditions):
         name = (
             cond.get("name", str(idx)) if isinstance(cond, dict) else OmegaConf.select(cond, "name", default=str(idx))
@@ -1477,6 +1621,30 @@ def evaluate_predictions_grouped(config: DictConfig) -> list[tuple[str, tuple]]:
                 feature_metrics=feature_metrics,
             )
         results.append((name, (pixel_metrics, mask_metrics, feature_metrics)))
+        condition_save_dirs.append(Path(merged.save.save_dir))
+
+    # Cross-condition infection probe: once every condition in the group has
+    # its single-cell embeddings on disk, classify each infected condition vs
+    # mock (FOV-stratified logistic probe, per feature space, GT and pred).
+    # Default-on whenever feature metrics were computed (the probe consumes the
+    # embeddings those produce) and a mock + >=1 infected condition are present.
+    # Gated by ``cross_condition_probe.enabled``; never fails the eval.
+    probe_enabled = bool(
+        OmegaConf.select(
+            config,
+            "cross_condition_probe.enabled",
+            default=bool(OmegaConf.select(config, "compute_feature_metrics", default=True)),
+        )
+    )
+    if probe_enabled:
+        n_splits = int(OmegaConf.select(config, "cross_condition_probe.n_splits", default=5))
+        rng_seed = int(OmegaConf.select(config, "cross_condition_probe.rng_seed", default=2020))
+        try:
+            written = _cross_condition_run_for_group(condition_save_dirs, n_splits=n_splits, rng_seed=rng_seed)
+            if written:
+                print(f"[grouped] cross-condition probe wrote {len(written)} CSV(s): {[str(p) for p in written]}")
+        except Exception as e:  # noqa: BLE001 -- diagnostic add-on must not fail the eval
+            print(f"[grouped] cross-condition probe skipped: {type(e).__name__}: {e}")
 
     return results
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -34,12 +34,15 @@ from dynacell.evaluation.cache import (
     load_manifest,
     open_features_group,
     read_features_from_group,
+    read_instance_mask,
     read_mask,
     save_manifest,
     seed_cache_identity,
     write_features_to_group,
+    write_instance_mask,
     write_mask,
 )
+from dynacell.evaluation.instance_metrics import DEFAULT_IOU_THRESHOLDS
 from dynacell.evaluation.metrics import (
     build_crops,
     cp_regionprops,
@@ -73,6 +76,16 @@ class _CacheContext:
     _: KW_ONLY
     partial_walk: bool = False
     use_gpu: bool = True
+    backend: str = "supermodel"
+    compute_instance_ap: bool = False
+    dimension: str = "2d"
+    slice_selection: str = "frac"
+    slice_fraction: float = 0.30
+    nuclei_channel_name: str | None = None
+    nuclei_plate_path: str | None = None
+    iou_thresholds: list[float] = field(default_factory=lambda: list(DEFAULT_IOU_THRESHOLDS))
+    cellpose_params: dict[str, Any] = field(default_factory=dict)
+    watershed_params: dict[str, Any] = field(default_factory=dict)
     dinov3_model_name: str | None = None
     dynaclr_ckpt_sha12: str | None = None
     dynaclr_encoder_sha12: str | None = None
@@ -123,6 +136,8 @@ def _resolve_force(force: DictConfig) -> dict[str, bool]:
         "pred_dinov3": all_flag or bool(force.pred_dinov3),
         "pred_dynaclr": all_flag or bool(force.pred_dynaclr),
         "pred_celldino": all_flag or bool(force.pred_celldino),
+        "gt_instances": all_flag or bool(OmegaConf.select(force, "gt_instances", default=False)),
+        "pred_instances": all_flag or bool(OmegaConf.select(force, "pred_instances", default=False)),
         "final_metrics": all_flag or bool(force.final_metrics),
     }
 
@@ -185,6 +200,10 @@ def init_cache_context(
     cache_dir_key, plate_key, channel_key = _SIDE_IO_KEYS[side]
     cache_dir = OmegaConf.select(config, f"io.{cache_dir_key}", default=None)
 
+    cellpose_cfg = OmegaConf.select(config, "segmentation.cellpose", default=None)
+    watershed_cfg = OmegaConf.select(config, "segmentation.watershed", default=None)
+    nuclei_plate_path = OmegaConf.select(config, "io.gt_path", default=None)
+
     base_kwargs: dict[str, Any] = dict(
         force=force,
         target_name=config.target_name,
@@ -192,6 +211,18 @@ def init_cache_context(
         patch_size=patch_size,
         partial_walk=partial_walk,
         use_gpu=use_gpu,
+        backend=OmegaConf.select(config, "segmentation.backend", default="supermodel"),
+        compute_instance_ap=bool(OmegaConf.select(config, "compute_instance_ap", default=False)),
+        dimension=OmegaConf.select(config, "segmentation.dimension", default="2d"),
+        slice_selection=OmegaConf.select(config, "segmentation.slice_selection", default="frac"),
+        slice_fraction=float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30)),
+        nuclei_channel_name=OmegaConf.select(config, "segmentation.nuclei_channel_name", default=None),
+        nuclei_plate_path=str(nuclei_plate_path) if nuclei_plate_path is not None else None,
+        iou_thresholds=list(
+            OmegaConf.select(config, "instance_metrics.iou_thresholds", default=DEFAULT_IOU_THRESHOLDS)
+        ),
+        cellpose_params=(OmegaConf.to_container(cellpose_cfg, resolve=True) if cellpose_cfg is not None else {}),
+        watershed_params=(OmegaConf.to_container(watershed_cfg, resolve=True) if watershed_cfg is not None else {}),
         dinov3_model_name=dinov3_model_name,
         dynaclr_ckpt_sha12=dynaclr_ckpt_sha12,
         dynaclr_encoder_sha12=dynaclr_encoder_sha12,
@@ -370,6 +401,17 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
             ("spacing",),
         ),
     ]
+    if ctx.compute_instance_ap:
+        stem = f"{ctx.target_name}__{ctx.backend}"
+        checks.append(
+            (
+                "instances",
+                f"{ctx.label_prefix}instance_masks[{stem}]",
+                artifacts.get("instance_masks", {}).get(stem),
+                _instance_identity(ctx),
+                (),
+            )
+        )
     if ctx.dinov3_model_name is not None:
         checks.append(
             (
@@ -510,9 +552,11 @@ def fov_masks(
     from it. When caching is disabled (``ctx.enabled == False``), the masks
     are computed fresh from *image_arr* without any cache interaction.
     """
+    mask_stem = ctx.target_name if ctx.backend == "supermodel" else f"{ctx.target_name}__{ctx.backend}"
     manifest_entry: dict[str, Any] = {
-        "path": f"organelle_masks/{ctx.target_name}.zarr",
+        "path": f"organelle_masks/{mask_stem}.zarr",
         "target_name": ctx.target_name,
+        "backend": ctx.backend,
         "built_at": built_at_now(),
         **ctx.source_tag,
     }
@@ -546,7 +590,15 @@ def _fov_masks(
     def _compute_masks() -> np.ndarray:
         return np.stack(
             [
-                np.asarray(segment(image_arr[t], ctx.target_name, seg_model=seg_model)).astype(bool)
+                np.asarray(
+                    segment(
+                        image_arr[t],
+                        ctx.target_name,
+                        seg_model=seg_model,
+                        backend=ctx.backend,
+                        spacing_zyx=tuple(ctx.spacing),
+                    )
+                ).astype(bool)
                 for t in range(t_count)
             ]
         )
@@ -568,7 +620,7 @@ def _fov_masks(
         ctx.mark_manifest_dirty()
 
     def _write_masks(masks: np.ndarray) -> None:
-        write_mask(ctx.paths, ctx.target_name, pos_name, masks, channel_name=channel_name)
+        write_mask(ctx.paths, ctx.target_name, pos_name, masks, channel_name=channel_name, backend=ctx.backend)
 
     # Cache disabled — compute fresh, no locking, no caching.
     if not ctx.enabled:
@@ -584,7 +636,7 @@ def _fov_masks(
         return masks
 
     # Fast-path: cache hit without taking a lock.
-    cached = read_mask(ctx.paths, ctx.target_name, pos_name)
+    cached = read_mask(ctx.paths, ctx.target_name, pos_name, backend=ctx.backend)
     if cached is not None:
         return _validate_cached_shape(cached)
 
@@ -592,7 +644,7 @@ def _fov_masks(
     # may have populated the slot between our fast-path read and the lock
     # acquisition; if so, the re-read returns a hit and we skip recomputation.
     with _pos_write_lock(ctx, f"{ctx.side}_masks_{ctx.target_name}", pos_name):
-        cached = read_mask(ctx.paths, ctx.target_name, pos_name)
+        cached = read_mask(ctx.paths, ctx.target_name, pos_name, backend=ctx.backend)
         if cached is not None:
             return _validate_cached_shape(cached)
         _raise_if_require_complete(ctx, artifact_label, pos_name)
@@ -600,6 +652,177 @@ def _fov_masks(
         _write_masks(masks)
         _record_write()
     return masks
+
+
+def _instance_identity(ctx: _CacheContext) -> dict[str, Any]:
+    """Return the cache-identity dict for a side's instance-label artifact."""
+    identity: dict[str, Any] = {
+        **ctx.cellpose_params,
+        "dimension": ctx.dimension,
+        "slice_selection": ctx.slice_selection,
+        "slice_fraction": ctx.slice_fraction,
+        **ctx.source_tag,
+    }
+    if ctx.backend == "cellpose_watershed":
+        # Whole-cell labels also depend on the watershed params and the GT nuclei
+        # seeds; record the GT nuclei (path, channel) so a pred-side identity
+        # captures that cross-side dependency (source_tag alone does not).
+        identity = {
+            **identity,
+            **ctx.watershed_params,
+            "nuclei_channel": ctx.nuclei_channel_name,
+            "nuclei_path": ctx.nuclei_plate_path,
+        }
+    return identity
+
+
+def _fov_instances(
+    ctx: _CacheContext,
+    *,
+    pos_name: str,
+    ref_stack: np.ndarray,
+    compute_t,
+) -> np.ndarray:
+    """Shared load-or-compute for one side's instance labels (position stack).
+
+    Mirrors :func:`_fov_masks` but reads/writes the whole ``(T, D, H, W)``
+    position once (the instance cache API is whole-stack) and preserves uint16
+    labels. ``compute_t(t)`` returns native labels for timepoint *t*: ``(Y, X)``
+    in 2-D or ``(Z, Y, X)`` in 3-D. A 2-D run is stored with a singleton ``D=1``.
+    The manifest entry/identity is derived from ``ctx`` (target + backend).
+    """
+    t_count = ref_stack.shape[0]
+    force_key = f"{ctx.side}_instances"
+    stem = f"{ctx.target_name}__{ctx.backend}"
+    manifest_keys = ["instance_masks", stem]
+    artifact_label = f"{ctx.label_prefix}instance_masks[{stem}]"
+    manifest_entry = {
+        "path": f"instance_masks/{stem}.zarr",
+        "target_name": ctx.target_name,
+        "backend": ctx.backend,
+        "built_at": built_at_now(),
+        **_instance_identity(ctx),
+    }
+
+    def _compute() -> np.ndarray:
+        stacked = np.stack([np.asarray(compute_t(t)) for t in range(t_count)])
+        if stacked.ndim == 3:  # 2D (T, Y, X) -> (T, 1, Y, X)
+            stacked = stacked[:, None]
+        return stacked.astype(np.uint16)
+
+    def _validate_cached_shape(arr: np.ndarray) -> np.ndarray:
+        if arr.shape[0] != t_count:
+            raise StaleCacheError(
+                f"Cached instance timepoint count mismatch for {pos_name}: cached={arr.shape[0]} vs current={t_count}"
+            )
+        ref_spatial = ref_stack.shape[1:]
+        expected = (1, *ref_spatial) if len(ref_spatial) == 2 else ref_spatial
+        if tuple(arr.shape[1:]) != tuple(expected):
+            raise StaleCacheError(
+                f"Cached instance spatial shape mismatch for {pos_name}: "
+                f"cached={tuple(arr.shape[1:])} vs current={tuple(expected)}"
+            )
+        return arr
+
+    def _write(labels: np.ndarray) -> None:
+        write_instance_mask(ctx.paths, ctx.target_name, pos_name, labels, backend=ctx.backend)
+
+    def _record_write() -> None:
+        _update_manifest_entry(ctx.manifest, manifest_keys, manifest_entry)
+        _add_position(ctx.manifest, manifest_keys, pos_name)
+        ctx.mark_manifest_dirty()
+
+    if not ctx.enabled:
+        return _compute()
+
+    lock_tag = f"{ctx.side}_instances_{ctx.target_name}"
+    if ctx.force[force_key]:
+        with _pos_write_lock(ctx, lock_tag, pos_name):
+            labels = _compute()
+            _write(labels)
+            _record_write()
+        return labels
+
+    cached = read_instance_mask(ctx.paths, ctx.target_name, pos_name, backend=ctx.backend)
+    if cached is not None:
+        return _validate_cached_shape(cached)
+
+    with _pos_write_lock(ctx, lock_tag, pos_name):
+        cached = read_instance_mask(ctx.paths, ctx.target_name, pos_name, backend=ctx.backend)
+        if cached is not None:
+            return _validate_cached_shape(cached)
+        _raise_if_require_complete(ctx, artifact_label, pos_name)
+        labels = _compute()
+        _write(labels)
+        _record_write()
+    return labels
+
+
+def instance_cache_hit(ctx: _CacheContext, pos_name: str) -> bool:
+    """Whether *pos_name*'s instance labels are present and valid (no compute needed).
+
+    A disabled cache (``not ctx.enabled``) or a set ``{side}_instances`` force
+    flag (manifest identity mismatch at init, or an explicit force) counts as a
+    miss. Used by the whole-cell seed preflight to skip seed computation only
+    when both sides already hit.
+    """
+    if not ctx.enabled or ctx.force[f"{ctx.side}_instances"]:
+        return False
+    return read_instance_mask(ctx.paths, ctx.target_name, pos_name, backend=ctx.backend) is not None
+
+
+def _seg_spacing(ctx: _CacheContext) -> tuple[float, ...]:
+    """Spacing tuple for the segmentation call: ``(z, y, x)`` in 3-D, ``(y, x)`` in 2-D."""
+    return tuple(ctx.spacing) if ctx.dimension == "3d" else tuple(ctx.spacing[-2:])
+
+
+def fov_nucleus_instances(
+    ctx: _CacheContext,
+    pos_name: str,
+    nuc_stack: np.ndarray,
+    model,
+) -> np.ndarray:
+    """Return cached/computed nucleus instance labels for one FOV (``backend=cellpose``).
+
+    *nuc_stack* is the per-side nucleus stack — ``(T, Y, X)`` in 2-D (already
+    sliced) or ``(T, Z, Y, X)`` in 3-D. Each timepoint is segmented independently
+    with :func:`segment_nucleus_instances`. Returns ``(T, D, H, W)`` uint16.
+    """
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
+
+    is3d = ctx.dimension == "3d"
+    spacing = _seg_spacing(ctx)
+
+    def compute_t(t: int) -> np.ndarray:
+        return segment_nucleus_instances(nuc_stack[t], spacing, model, do_3d=is3d, **ctx.cellpose_params)
+
+    return _fov_instances(ctx, pos_name=pos_name, ref_stack=nuc_stack, compute_t=compute_t)
+
+
+def fov_whole_cell_instances(
+    ctx: _CacheContext,
+    pos_name: str,
+    memb_stack: np.ndarray,
+    nuc_stack: np.ndarray,
+    seed_stack: np.ndarray,
+) -> np.ndarray:
+    """Return cached/computed whole-cell instance labels (``backend=cellpose_watershed``).
+
+    *memb_stack* / *nuc_stack* are the membrane / GT-nuclei fluorescence stacks
+    and *seed_stack* the GT-nuclei instance labels (watershed markers) — all
+    ``(T, Y, X)`` in 2-D or ``(T, Z, Y, X)`` in 3-D. Each timepoint runs
+    :func:`segment_whole_cell` (cytoplasm-only labels). Returns ``(T, D, H, W)``
+    uint16. *seed_stack* is only read on the compute path; pass ``None`` only
+    when the cache is guaranteed to hit (see :func:`instance_cache_hit`).
+    """
+    from dynacell.evaluation.segmentation_whole_cell import segment_whole_cell
+
+    spacing = _seg_spacing(ctx)
+
+    def compute_t(t: int) -> np.ndarray:
+        return segment_whole_cell(memb_stack[t], nuc_stack[t], seed_stack[t], spacing, **ctx.watershed_params)
+
+    return _fov_instances(ctx, pos_name=pos_name, ref_stack=memb_stack, compute_t=compute_t)
 
 
 def _kind_cache_kwargs(ctx: _CacheContext, kind: FeatureKind) -> dict[str, Any]:

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -110,6 +110,19 @@ class _CacheContext:
         """Manifest-entry tag distinguishing prediction artifacts; empty for GT."""
         return {"source": "prediction"} if self.side == "pred" else {}
 
+    @property
+    def mask_stem(self) -> str:
+        """Filename/manifest stem for this run's binary organelle masks.
+
+        Mirrors :meth:`CachePaths.mask_plate`: the default ``supermodel`` backend
+        keeps the bare ``{target_name}`` stem (pre-existing caches unaffected),
+        while other backends get a ``{target_name}__{backend}`` infix. The
+        manifest entry must be keyed by this stem (not by ``target_name`` alone)
+        so masks from different backends don't clobber each other's manifest
+        ``path`` / ``positions`` in a shared cache dir.
+        """
+        return self.target_name if self.backend == "supermodel" else f"{self.target_name}__{self.backend}"
+
     def mark_manifest_dirty(self) -> None:
         """Record that the manifest has unsaved changes (next flush will persist them)."""
         self._manifest_dirty = True
@@ -387,9 +400,18 @@ def _auto_invalidate_on_artifact_param_mismatch(ctx: _CacheContext) -> None:
 
     checks: list[tuple[str, str, dict[str, Any] | None, dict[str, Any], tuple[str, ...]]] = [
         (
+            # Key by ``mask_stem`` (= ``{target}__{backend}`` for non-default
+            # backends), the same stem as the cache plate path, so masks from
+            # different backends get separate manifest entries instead of
+            # clobbering one ``organelle_masks[target_name]`` slot. ``backend`` is
+            # encoded in the stem itself, so it is intentionally NOT a param in
+            # the identity dict below (a backend switch lands on a different
+            # entry/plate — there is nothing stale to invalidate, and adding it
+            # would spuriously invalidate pre-existing caches that predate the
+            # field).
             "masks",
-            f"{ctx.label_prefix}organelle_masks[{ctx.target_name}]",
-            artifacts.get("organelle_masks", {}).get(ctx.target_name),
+            f"{ctx.label_prefix}organelle_masks[{ctx.mask_stem}]",
+            artifacts.get("organelle_masks", {}).get(ctx.mask_stem),
             {"target_name": ctx.target_name, **ctx.source_tag},
             (),
         ),
@@ -552,7 +574,7 @@ def fov_masks(
     from it. When caching is disabled (``ctx.enabled == False``), the masks
     are computed fresh from *image_arr* without any cache interaction.
     """
-    mask_stem = ctx.target_name if ctx.backend == "supermodel" else f"{ctx.target_name}__{ctx.backend}"
+    mask_stem = ctx.mask_stem
     manifest_entry: dict[str, Any] = {
         "path": f"organelle_masks/{mask_stem}.zarr",
         "target_name": ctx.target_name,
@@ -566,7 +588,8 @@ def fov_masks(
         image_arr=image_arr,
         seg_model=seg_model,
         force_key=f"{ctx.side}_masks",
-        artifact_label=f"{ctx.label_prefix}organelle_masks[{ctx.target_name}]",
+        manifest_key=mask_stem,
+        artifact_label=f"{ctx.label_prefix}organelle_masks[{mask_stem}]",
         manifest_entry=manifest_entry,
     )
 
@@ -578,6 +601,7 @@ def _fov_masks(
     image_arr: np.ndarray,
     seg_model,
     force_key: str,
+    manifest_key: str,
     artifact_label: str,
     manifest_entry: dict[str, Any],
 ) -> np.ndarray:
@@ -613,10 +637,10 @@ def _fov_masks(
     def _record_write() -> None:
         _update_manifest_entry(
             ctx.manifest,
-            ["organelle_masks", ctx.target_name],
+            ["organelle_masks", manifest_key],
             manifest_entry,
         )
-        _add_position(ctx.manifest, ["organelle_masks", ctx.target_name], pos_name)
+        _add_position(ctx.manifest, ["organelle_masks", manifest_key], pos_name)
         ctx.mark_manifest_dirty()
 
     def _write_masks(masks: np.ndarray) -> None:

--- a/applications/dynacell/src/dynacell/evaluation/segmentation.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation.py
@@ -31,6 +31,8 @@ except ImportError:
 from cubic.cuda import ascupy, asnumpy
 from cubic.skimage import filters as _cubic_filters
 
+from dynacell.evaluation.segmentation_cellpose import load_cellpose_model, segment_nucleus
+
 NUCLEUS_GAUSSIAN_SIGMA = 1.0
 """Isotropic Gaussian sigma (voxels) applied to the H2B input before
 ``structure_H2B_100x_hipsc.apply_on_single_zstack``.
@@ -79,7 +81,7 @@ def _smooth_nucleus_input(img, sigma: float = NUCLEUS_GAUSSIAN_SIGMA):
     return asnumpy(smoothed)
 
 
-def segment(img, target_name=None, seg_model: "SuperModel" = None):
+def segment(img, target_name=None, seg_model=None, *, backend="supermodel", spacing_zyx=None):
     """Run the organelle-specific segmentation workflow on a single z-stack.
 
     Parameters
@@ -90,7 +92,14 @@ def segment(img, target_name=None, seg_model: "SuperModel" = None):
         Organelle name: one of ``nucleus``, ``membrane``, ``nucleoli``,
         ``lysosomes``, ``er``, ``mitochondria``.
     seg_model :
-        Pre-loaded ``SuperModel`` required for nucleus/membrane segmentation.
+        Pre-loaded segmenter. A ``SuperModel`` for ``backend="supermodel"``
+        nucleus/membrane, or a ``CellposeModel`` for ``backend="cellpose"``.
+    backend :
+        Nucleus/membrane segmenter selector: ``"supermodel"`` (segmenter-model-zoo,
+        default) or ``"cellpose"`` (GPU Cellpose-SAM + fnet pre/post, nucleus only).
+        Ignored for classical (ER/mito/nucleoli/lysosomes) targets.
+    spacing_zyx :
+        Physical voxel size ``(z, y, x)`` µm; required for ``backend="cellpose"``.
 
     Returns
     -------
@@ -98,6 +107,12 @@ def segment(img, target_name=None, seg_model: "SuperModel" = None):
         Boolean mask with the same spatial shape as *img*.
     """
     if target_name in ["nucleus", "membrane"]:
+        if backend == "cellpose":
+            if target_name != "nucleus":
+                raise NotImplementedError("segmentation backend='cellpose' supports nucleus only")
+            if seg_model is None or spacing_zyx is None:
+                raise ValueError("cellpose nucleus segmentation requires seg_model (CellposeModel) and spacing_zyx.")
+            return segment_nucleus(img, tuple(spacing_zyx), seg_model).astype(bool)
         _require_segmenter_model_zoo()
         if seg_model is None:
             raise ValueError("seg_model (a loaded SuperModel) must be provided for nucleus and membrane segmentation.")
@@ -139,6 +154,12 @@ def prepare_segmentation_model(config):
     mask cache is disabled (``io.pred_cache_dir=None``); in that case we
     must still load SuperModel even under ``require_complete_cache=true``
     or the fallback raises ``ValueError`` mid-loop.
+
+    The instance-AP backends (``cellpose``/``cellpose_watershed`` with
+    ``compute_instance_ap=true``) populate a separate instance-label cache
+    lazily, so the (cheap) CellposeModel is still required on any
+    instance-cache miss even when the pred mask cache is enabled — the
+    ``require_complete_cache`` short-circuit is therefore suppressed for them.
     """
     require_complete = bool(getattr(config.io, "require_complete_cache", False))
     if config.target_name not in [
@@ -150,11 +171,20 @@ def prepare_segmentation_model(config):
         "mitochondria",
     ]:
         raise ValueError(f"Invalid target_name in config: {config.target_name!r}")
-    if require_complete:
+    compute_instance_ap = bool(getattr(config, "compute_instance_ap", False))
+    if require_complete and not compute_instance_ap:
         pred_cache_dir = getattr(config.io, "pred_cache_dir", None)
         if config.target_name not in ("nucleus", "membrane") or pred_cache_dir is not None:
             return None
     if config.target_name in ["nucleus", "membrane"]:
+        seg_cfg = getattr(config, "segmentation", None)
+        backend = getattr(seg_cfg, "backend", "supermodel") if seg_cfg is not None else "supermodel"
+        if backend in ("cellpose", "cellpose_watershed"):
+            if backend == "cellpose" and config.target_name != "nucleus":
+                raise NotImplementedError("segmentation.backend='cellpose' supports nucleus only")
+            if backend == "cellpose_watershed" and config.target_name != "membrane":
+                raise NotImplementedError("segmentation.backend='cellpose_watershed' supports membrane only")
+            return load_cellpose_model(use_gpu=getattr(config, "use_gpu", True))
         _require_segmenter_model_zoo()
         if config.target_name == "nucleus":
             checkpoint_name = "structure_H2B_100x_hipsc"

--- a/applications/dynacell/src/dynacell/evaluation/segmentation.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation.py
@@ -184,7 +184,20 @@ def prepare_segmentation_model(config):
                 raise NotImplementedError("segmentation.backend='cellpose' supports nucleus only")
             if backend == "cellpose_watershed" and config.target_name != "membrane":
                 raise NotImplementedError("segmentation.backend='cellpose_watershed' supports membrane only")
-            return load_cellpose_model(use_gpu=getattr(config, "use_gpu", True))
+            use_gpu = bool(getattr(config, "use_gpu", True))
+            if not (use_gpu and torch.cuda.is_available()):
+                # The cellpose backends run inference through
+                # ``cubic.segmentation.segment_cpsam``, which is GPU-only by
+                # contract (raises in its CUDA precondition). Fail here with a
+                # clear message instead of building a CPU CellposeModel that
+                # would die deeper in the per-FOV segmentation loop.
+                raise RuntimeError(
+                    f"segmentation.backend={backend!r} requires CUDA (cubic.segment_cpsam "
+                    f"is GPU-only), but use_gpu={use_gpu} and "
+                    f"torch.cuda.is_available()={torch.cuda.is_available()}. "
+                    "Run on a CUDA device with use_gpu=true."
+                )
+            return load_cellpose_model(use_gpu=use_gpu)
         _require_segmenter_model_zoo()
         if config.target_name == "nucleus":
             checkpoint_name = "structure_H2B_100x_hipsc"

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
@@ -102,7 +102,16 @@ def _robust_clahe(img: np.ndarray, use_clahe: bool = True):
     """
     img_dev = ascupy(img.astype(np.float32, copy=False))
     lo, hi = np.percentile(img_dev, (ROBUST_PERCENTILE, 100.0 - ROBUST_PERCENTILE))
-    img_dev = np.clip((img_dev - lo) / (hi - lo), 0.0, 1.0)
+    if float(hi - lo) <= 0.0:
+        # Constant (or near-constant) input: no contrast to stretch. Map to an
+        # all-zero image rather than dividing by zero, which would yield NaNs
+        # that propagate through CLAHE into Cellpose inference. Empty / flat-field
+        # FOVs are legitimate inputs the pipeline handles downstream (the
+        # segmenters return all-zero labels on them), so this is the correct
+        # normalization of a constant image, not error-hiding.
+        img_dev = np.zeros_like(img_dev)
+    else:
+        img_dev = np.clip((img_dev - lo) / (hi - lo), 0.0, 1.0)
     if use_clahe:
         divisor = CLAHE_KERNEL_DIVISOR if img_dev.ndim == 3 else CLAHE_KERNEL_DIVISOR_2D
         kernel = tuple(int(s // d) for s, d in zip(img_dev.shape, divisor))

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
@@ -1,0 +1,260 @@
+"""GPU-resident Cellpose-SAM nucleus segmentation with fnet_astr_vpa-style pre/post.
+
+All preprocessing (robust percentile clip, CLAHE, isotropic downscale) and
+postprocessing (size filter, sequential relabel, upsample to native) run on GPU
+through ``cubic``. The Cellpose-SAM inference itself runs through
+``cubic.segmentation.segment_cpsam``, which uploads the downscaled volume to the
+device exactly once and returns only the integer mask to the host — keeping the
+flow field and intermediate buffers GPU-resident (vs ``CellposeModel.eval``,
+which re-uploads tiles host-side).
+
+Recipe adapted from ``fnet_astr_vpa`` (Allen iPSC nucleus segmentation):
+robust(0.1) -> CLAHE(kernel=shape//(2,3,5) in 3D, shape//(3,5) in 2D, clip=0.015)
+-> isotropic downscale, then Cellpose-SAM (``do_3D`` for volumes, 2D for single
+slices), then an on-device size filter + sequential relabel. The isotropic
+downscale makes the volume isotropic at ``target_voxel_um`` so we pass
+``anisotropy=1.0`` (3D) and Cellpose performs no internal resize
+(``image_scaling=1`` via ``diameter=None``).
+
+Both a single 3-D ``(Z, Y, X)`` volume (``do_3d=True``) and a single 2-D
+``(Y, X)`` slice (``do_3d=False``) are supported; ``return_labels`` selects
+between an integer instance-label image (uint16) and the binary footprint.
+"""
+
+import numpy as np
+from cellpose import models
+from cubic.cuda import ascupy, asnumpy, get_array_module
+from cubic.image_utils import rescale_isotropic, rescale_xy
+from cubic.segmentation import segment_cpsam
+from cubic.skimage import exposure as _cubic_exposure
+from cubic.skimage import transform as _cubic_transform
+
+ROBUST_PERCENTILE = 0.1
+"""Lower percentile for robust min/max rescale; upper is ``100 - this``.
+Clips bright outliers before CLAHE so the [0, 1] stretch tracks signal, not
+shot-noise tips (fnet ``preprocessing.yaml``)."""
+
+CLAHE_KERNEL_DIVISOR = (2, 3, 5)
+"""Per-axis (Z, Y, X) divisor for the 3D CLAHE contextual kernel:
+``kernel = image.shape // divisor`` (fnet ``clahe``)."""
+
+CLAHE_KERNEL_DIVISOR_2D = (3, 5)
+"""Per-axis (Y, X) divisor for the CLAHE contextual kernel on a single 2D slice."""
+
+CLAHE_CLIP_LIMIT = 0.015
+CLAHE_NBINS = 256
+
+TARGET_VOXEL_UM = 0.58
+"""Isotropic voxel size (um) the volume is downscaled to before Cellpose.
+Matches the grid fnet's cellpose ran on (Allen iPSC ~0.58 um isotropic). At
+512x512 FOVs this yields lateral <= 256 (iPSC ~99, A549 ~128) so Cellpose runs
+single-tile; larger FOVs tile on host automatically."""
+
+CELLPROB_THRESHOLD = 0.0
+FLOW_THRESHOLD = 0.4
+
+MIN_OBJECT_SIZE = 500
+"""Drop Cellpose instances smaller than this many voxels (at the downscaled
+isotropic grid) as spurious — the one cleanup step we keep from fnet's
+``postprocessing.yaml``.
+
+We deliberately do **not** call ``cubic.cleanup_segmentation``: its
+``clear_xy_borders`` uses ``np.in1d`` (removed in numpy>=2.2) and its
+``remove_large_objects`` asserts a non-constant label image mid-pipeline, which
+crashes on empty/near-empty FOVs. fnet's ``max_obj_size=7500`` /
+``max_hole_size=50`` filters are also dropped for now: those thresholds were
+tuned for fnet's legacy ``nuclei`` model on its grid and would wrongly remove
+real whole nuclei at Cellpose-SAM's ``TARGET_VOXEL_UM`` resolution — re-tune in
+Phase 0 before reinstating. Border-touching nuclei are kept (consistent on GT
+and prediction sides for binary Dice)."""
+
+
+def load_cellpose_model(use_gpu: bool = True) -> "models.CellposeModel":
+    """Load the Cellpose-SAM model.
+
+    Parameters
+    ----------
+    use_gpu : bool
+        Place the network on GPU. Defaults to True.
+
+    Returns
+    -------
+    cellpose.models.CellposeModel
+        The Cellpose-SAM model (``cpsam``).
+    """
+    model = models.CellposeModel(gpu=use_gpu)
+    # cellpose 4.1.x's CellposeModel no longer exposes a ``backbone`` attribute,
+    # which ``cubic.segmentation.segment_cpsam`` requires (it reads it only to
+    # pick the tile size: "sam_vitl" -> 256). Cellpose-SAM is the ViT-L backbone,
+    # so set it explicitly to keep the GPU-resident path's precondition satisfied.
+    if not hasattr(model, "backbone"):
+        model.backbone = "sam_vitl"
+    return model
+
+
+def _robust_clahe(img: np.ndarray, use_clahe: bool = True):
+    """Robust percentile clip to ~[0, 1] then (optional) CLAHE, on GPU.
+
+    Shared preprocessing front-end for the nucleus (this module) and whole-cell
+    (:mod:`dynacell.evaluation.segmentation_whole_cell`) pipelines. The CLAHE
+    contextual kernel divisor is selected by ``img.ndim`` (3-D vs 2-D). Returns a
+    CuPy array with the same shape as *img*, float32 in ~[0, 1].
+    """
+    img_dev = ascupy(img.astype(np.float32, copy=False))
+    lo, hi = np.percentile(img_dev, (ROBUST_PERCENTILE, 100.0 - ROBUST_PERCENTILE))
+    img_dev = np.clip((img_dev - lo) / (hi - lo), 0.0, 1.0)
+    if use_clahe:
+        divisor = CLAHE_KERNEL_DIVISOR if img_dev.ndim == 3 else CLAHE_KERNEL_DIVISOR_2D
+        kernel = tuple(int(s // d) for s, d in zip(img_dev.shape, divisor))
+        img_dev = _cubic_exposure.equalize_adapthist(
+            img_dev, kernel_size=kernel, clip_limit=CLAHE_CLIP_LIMIT, nbins=CLAHE_NBINS
+        )
+    return img_dev
+
+
+def _preprocess_gpu(
+    img: np.ndarray,
+    spacing: tuple[float, ...],
+    target_voxel_um: float,
+    use_clahe: bool = True,
+):
+    """Robust clip -> (optional) CLAHE -> isotropic downscale, all on GPU.
+
+    Supports a 3-D ``(Z, Y, X)`` volume (3-tuple *spacing*, downscaled to an
+    isotropic ``target_voxel_um`` grid) and a 2-D ``(Y, X)`` slice (2-tuple
+    *spacing*, XY downscaled to ``target_voxel_um``). The branch is selected by
+    ``img.ndim``.
+
+    Parameters
+    ----------
+    img : numpy.ndarray
+        3-D ``(Z, Y, X)`` image or 2-D ``(Y, X)`` slice.
+    spacing : tuple of float
+        Physical voxel size in micrometers: ``(z, y, x)`` for 3-D, ``(y, x)``
+        for 2-D.
+    target_voxel_um : float
+        Isotropic voxel size (um) to downscale to.
+    use_clahe : bool
+        Apply CLAHE after the robust clip. Defaults to True.
+
+    Returns
+    -------
+    cupy.ndarray
+        Preprocessed downscaled image on GPU, float32 in ~[0, 1].
+    """
+    img_dev = _robust_clahe(img, use_clahe=use_clahe)
+    if img_dev.ndim == 3:
+        return rescale_isotropic(
+            img_dev,
+            spacing,
+            downscale_xy=True,
+            order=3,
+            target_z_voxel_size=target_voxel_um,
+        )
+    return rescale_xy(
+        img_dev,
+        scale=spacing[-1] / target_voxel_um,
+        order=3,
+        anti_aliasing=True,
+        preserve_range=True,
+    )
+
+
+def segment_nucleus(
+    img: np.ndarray,
+    spacing: tuple[float, ...],
+    model: "models.CellposeModel",
+    *,
+    target_voxel_um: float = TARGET_VOXEL_UM,
+    cellprob_threshold: float = CELLPROB_THRESHOLD,
+    flow_threshold: float = FLOW_THRESHOLD,
+    min_obj_size: int = MIN_OBJECT_SIZE,
+    use_clahe: bool = True,
+    do_3d: bool = True,
+    return_labels: bool = False,
+) -> np.ndarray:
+    """Segment nuclei in a single z-stack or slice with GPU Cellpose-SAM.
+
+    Parameters
+    ----------
+    img : numpy.ndarray
+        3-D ``(Z, Y, X)`` volume (``do_3d=True``) or 2-D ``(Y, X)`` slice
+        (``do_3d=False``) fluorescence image.
+    spacing : tuple of float
+        Physical voxel size in micrometers: ``(z, y, x)`` for 3-D, ``(y, x)``
+        for 2-D (from ``config.pixel_metrics.spacing``).
+    model : cellpose.models.CellposeModel
+        Pre-loaded Cellpose-SAM model (on CUDA — ``segment_cpsam`` is GPU-only).
+    target_voxel_um : float
+        Isotropic voxel size (um) to downscale to before inference.
+    cellprob_threshold, flow_threshold : float
+        Cellpose mask thresholds (``flow_threshold`` is ignored by Cellpose in 3D).
+    min_obj_size : int
+        Remove instances smaller than this many voxels/pixels at the downscaled
+        grid. The default is tuned for the 3-D volume path; lower it for 2-D
+        slices (areas are far smaller than volumes at the same voxel size).
+    use_clahe : bool
+        Apply CLAHE during preprocessing. Defaults to True.
+    do_3d : bool
+        Run volumetric Cellpose-SAM (``do_3D``) on a ``(Z, Y, X)`` volume. When
+        False, run 2-D Cellpose-SAM on a ``(Y, X)`` slice.
+    return_labels : bool
+        When True, return the uint16 instance-label image; otherwise return the
+        binary footprint (``labels > 0``).
+
+    Returns
+    -------
+    numpy.ndarray
+        Instance labels (uint16) or boolean footprint with the same spatial
+        shape as *img* (native resolution).
+    """
+    native_shape = img.shape
+    down = _preprocess_gpu(img, spacing, target_voxel_um, use_clahe=use_clahe)
+    # channel-first 3 identical channels: (3, Zd, Yd, Xd) for 3D, (3, Yd, Xd) for 2D
+    down_3ch = np.repeat(asnumpy(down)[np.newaxis], 3, axis=0)
+
+    masks, _, _ = segment_cpsam(
+        model,
+        down_3ch,
+        channel_axis=0,
+        z_axis=1 if do_3d else None,
+        do_3D=do_3d,
+        anisotropy=1.0 if do_3d else None,
+        diameter=None,
+        normalize=False,
+        cellprob_threshold=cellprob_threshold,
+        flow_threshold=flow_threshold,
+    )
+
+    # GPU size-filter + sequential relabel: keep instances >= min_obj_size, remap
+    # surviving ids to 1..K via an on-device gather LUT (np.unique dispatches to
+    # CuPy on the device array, so this stays GPU-resident).
+    labels_dev = ascupy(masks)
+    xp = get_array_module(labels_dev)
+    ids, counts = np.unique(labels_dev, return_counts=True)
+    keep = ids[(ids != 0) & (counts >= min_obj_size)]
+    if int(keep.size) == 0:
+        dtype = np.uint16 if return_labels else bool
+        return np.zeros(native_shape, dtype=dtype)
+    remap = xp.zeros(int(ids.max()) + 1, dtype=xp.uint16)
+    remap[keep] = xp.arange(1, int(keep.size) + 1, dtype=xp.uint16)
+    relabeled = remap[labels_dev]
+    native = _cubic_transform.resize(relabeled, native_shape, order=0, anti_aliasing=False, preserve_range=True)
+    if return_labels:
+        return asnumpy(native).astype(np.uint16)
+    return asnumpy(native) > 0
+
+
+def segment_nucleus_instances(
+    img: np.ndarray,
+    spacing: tuple[float, ...],
+    model: "models.CellposeModel",
+    **kwargs,
+) -> np.ndarray:
+    """Segment nuclei and return uint16 instance labels (native resolution).
+
+    Thin alias for :func:`segment_nucleus` with ``return_labels=True``. Used both
+    as the per-slice/volume label generator for the nucleus instance-AP path and
+    as the watershed seed generator for the whole-cell path.
+    """
+    return segment_nucleus(img, spacing, model, return_labels=True, **kwargs)

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose.py
@@ -210,8 +210,12 @@ def segment_nucleus(
     """
     native_shape = img.shape
     down = _preprocess_gpu(img, spacing, target_voxel_um, use_clahe=use_clahe)
-    # channel-first 3 identical channels: (3, Zd, Yd, Xd) for 3D, (3, Yd, Xd) for 2D
-    down_3ch = np.repeat(asnumpy(down)[np.newaxis], 3, axis=0)
+    # channel-first 3 identical channels, built on-device: (3, Zd, Yd, Xd) for 3D,
+    # (3, Yd, Xd) for 2D. segment_cpsam uploads its input to the GPU exactly once,
+    # so handing it a device array makes that upload a no-op and avoids a
+    # GPU->host->GPU round-trip of the downscaled volume.
+    xp = get_array_module(down)
+    down_3ch = xp.repeat(down[xp.newaxis], 3, axis=0)
 
     masks, _, _ = segment_cpsam(
         model,

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose_test.py
@@ -93,6 +93,28 @@ def test_segment_cellpose_membrane_not_implemented():
         segmentation.segment(img, "membrane", seg_model=object(), backend="cellpose", spacing_zyx=_SPACING)
 
 
+def test_prepare_segmentation_model_cellpose_requires_cuda():
+    """Cellpose backends fail fast (clear error) when run without CUDA.
+
+    ``segment_cpsam`` is GPU-only; building a CPU CellposeModel would only crash
+    deeper in the per-FOV loop. ``use_gpu=False`` trips the guard regardless of
+    whether the test host has a GPU.
+    """
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.create(
+        {
+            "target_name": "nucleus",
+            "use_gpu": False,
+            "compute_instance_ap": True,
+            "segmentation": {"backend": "cellpose"},
+            "io": {"require_complete_cache": False},
+        }
+    )
+    with pytest.raises(RuntimeError, match="requires CUDA"):
+        segmentation.prepare_segmentation_model(cfg)
+
+
 def test_segment_nucleus_return_labels(cellpose_model):
     """return_labels=True yields native-shape uint16 instances relabeled 1..K."""
     from dynacell.evaluation.segmentation_cellpose import segment_nucleus

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_cellpose_test.py
@@ -1,0 +1,139 @@
+"""Tests for the GPU Cellpose-SAM nucleus segmentation backend."""
+
+import numpy as np
+import pytest
+import torch
+
+from dynacell.evaluation import segmentation
+from dynacell.evaluation.cache import cache_paths
+
+_HAS_CUDA = torch.cuda.is_available()
+_SPACING = (0.30, 0.11, 0.11)
+
+
+def test_mask_plate_backend_routing(tmp_path):
+    """Default backend keeps the bare path; cellpose gets a ``__cellpose`` infix."""
+    paths = cache_paths(tmp_path)
+    assert paths.mask_plate("nucleus").name == "nucleus.zarr"
+    assert paths.mask_plate("nucleus", "supermodel").name == "nucleus.zarr"
+    assert paths.mask_plate("nucleus", "cellpose").name == "nucleus__cellpose.zarr"
+
+
+def test_instance_mask_plate_routing(tmp_path):
+    """Instance plates live under instance_masks/ with a ``__{backend}`` infix."""
+    paths = cache_paths(tmp_path)
+    assert paths.instance_masks_dir == tmp_path / "instance_masks"
+    assert paths.instance_mask_plate("nucleus", "cellpose").name == "nucleus__cellpose.zarr"
+    assert (
+        paths.instance_mask_plate("membrane", "cellpose_watershed")
+        == tmp_path / "instance_masks" / "membrane__cellpose_watershed.zarr"
+    )
+
+
+@pytest.fixture(scope="module")
+def cellpose_model():
+    if not _HAS_CUDA:
+        pytest.skip("Cellpose-SAM segmentation requires a CUDA GPU")
+    from dynacell.evaluation.segmentation_cellpose import load_cellpose_model
+
+    return load_cellpose_model(use_gpu=True)
+
+
+def _synthetic_nucleus(shape=(24, 256, 256)) -> np.ndarray:
+    """A single bright ellipsoid on a noisy background."""
+    z, y, x = np.indices(shape)
+    cz, cy, cx = (s / 2 for s in shape)
+    r2 = ((z - cz) / 6) ** 2 + ((y - cy) / 40) ** 2 + ((x - cx) / 40) ** 2
+    img = np.exp(-r2) * 2000.0
+    rng = np.random.default_rng(0)
+    return (img + rng.normal(50, 10, shape)).astype(np.float32)
+
+
+def test_segment_nucleus_shape_and_dtype(cellpose_model):
+    """Real end-to-end run returns a bool mask at native shape."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus
+
+    img = _synthetic_nucleus()
+    mask = segment_nucleus(img, _SPACING, cellpose_model)
+    assert mask.dtype == bool
+    assert mask.shape == img.shape
+
+
+def test_segment_nucleus_empty_input(cellpose_model):
+    """All-zero input yields an all-False native-shape mask (no cleanup crash)."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus
+
+    img = np.zeros((24, 256, 256), dtype=np.float32)
+    mask = segment_nucleus(img, _SPACING, cellpose_model)
+    assert mask.shape == img.shape
+    assert not mask.any()
+
+
+def test_segment_dispatch_cellpose_backend(cellpose_model):
+    """segment(..., backend='cellpose') routes nucleus to the cellpose pipeline."""
+    img = _synthetic_nucleus()
+    mask = segmentation.segment(img, "nucleus", seg_model=cellpose_model, backend="cellpose", spacing_zyx=_SPACING)
+    assert mask.dtype == bool
+    assert mask.shape == img.shape
+
+
+def test_segment_cellpose_requires_spacing_and_model():
+    """cellpose nucleus dispatch raises without seg_model / spacing."""
+    img = np.zeros((4, 32, 32), dtype=np.float32)
+    with pytest.raises(ValueError):
+        segmentation.segment(img, "nucleus", seg_model=None, backend="cellpose", spacing_zyx=_SPACING)
+    with pytest.raises(ValueError):
+        segmentation.segment(img, "nucleus", seg_model=object(), backend="cellpose", spacing_zyx=None)
+
+
+def test_segment_cellpose_membrane_not_implemented():
+    """cellpose backend is nucleus-only for now."""
+    img = np.zeros((4, 32, 32), dtype=np.float32)
+    with pytest.raises(NotImplementedError):
+        segmentation.segment(img, "membrane", seg_model=object(), backend="cellpose", spacing_zyx=_SPACING)
+
+
+def test_segment_nucleus_return_labels(cellpose_model):
+    """return_labels=True yields native-shape uint16 instances relabeled 1..K."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus
+
+    img = _synthetic_nucleus()
+    labels = segment_nucleus(img, _SPACING, cellpose_model, return_labels=True)
+    assert labels.dtype == np.uint16
+    assert labels.shape == img.shape
+    ids = np.unique(labels)
+    ids = ids[ids > 0]
+    if ids.size:  # sequential 1..K with no gaps
+        assert ids.tolist() == list(range(1, int(ids.max()) + 1))
+
+
+def test_segment_nucleus_bool_parity(cellpose_model):
+    """The bool footprint equals labels>0 for identical params."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus
+
+    img = _synthetic_nucleus()
+    mask = segment_nucleus(img, _SPACING, cellpose_model, return_labels=False)
+    labels = segment_nucleus(img, _SPACING, cellpose_model, return_labels=True)
+    np.testing.assert_array_equal(mask, labels > 0)
+
+
+def test_segment_nucleus_2d_slice(cellpose_model):
+    """do_3d=False on a (Y, X) slice returns 2D labels at native slice shape."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
+
+    sl = _synthetic_nucleus()[12]  # mid-z (Y, X)
+    labels = segment_nucleus_instances(sl, (0.11, 0.11), cellpose_model, do_3d=False, min_obj_size=10)
+    assert labels.dtype == np.uint16
+    assert labels.shape == sl.shape  # true 2D, no singleton Z
+    assert labels.ndim == 2
+
+
+def test_segment_nucleus_empty_labels(cellpose_model):
+    """All-zero input returns an all-zero uint16 label image."""
+    from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
+
+    img = np.zeros((24, 256, 256), dtype=np.float32)
+    labels = segment_nucleus_instances(img, _SPACING, cellpose_model)
+    assert labels.dtype == np.uint16
+    assert labels.shape == img.shape
+    assert not labels.any()

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
@@ -1,0 +1,239 @@
+"""GPU whole-cell instance segmentation: nuclei seeds + membrane EDT watershed.
+
+Productionizes the ``.tmp/wholecell_*_cellgrid.py`` prototypes. Given a membrane
+fluorescence image, the matching nucleus fluorescence, and pre-computed nucleus
+instance labels (the watershed seeds), it segments whole cells and returns
+cytoplasm-only instance labels:
+
+1. robust-clip + CLAHE the membrane and nucleus channels (GPU, via ``cubic``);
+2. (optional) downscale both to an isotropic ``cell_voxel_um`` working grid and
+   NN-resize the seeds to match — the morphological size parameters are physical
+   (um / um^2 / um^3) and converted to working-grid pixels so they are
+   grid-independent;
+3. build a solid cell mask: grayscale-close ``clip(membrane + nucleus)`` per XY
+   plane, threshold at the lower multi-Otsu boundary and fill holes (tissue);
+   subtract membrane "walls" (upper multi-Otsu boundary of a blurred membrane);
+   union the seed footprint so every nucleus is interior;
+4. marker-controlled EDT watershed (``cubic.segment_watershed``) seeded by the
+   nucleus labels — IDs are preserved;
+5. drop sub-``min_cell`` cells, sequential-relabel, NN-upscale to native;
+6. carve the nucleus footprint out (``cells[seed > 0] = 0``) so metrics score the
+   cytoplasmic shell only.
+
+Supports a single 3-D ``(Z, Y, X)`` volume and a single 2-D ``(Y, X)`` slice; the
+branch is selected by ``memb_img.ndim``. The 3-D path runs the recipe on the full
+volume (the per-XY-plane closing loops over Z) — it never segments per-slice and
+stitches.
+"""
+
+import numpy as np
+from cubic.cuda import ascupy, asnumpy, get_array_module
+from cubic.image_utils import rescale_isotropic, rescale_xy
+from cubic.segmentation.segment_utils import (
+    _binary_fill_holes,
+    _remove_small_holes,
+    _remove_small_objects,
+    segment_watershed,
+)
+from cubic.skimage import filters as _filters
+from cubic.skimage import morphology as _morphology
+from cubic.skimage import transform as _transform
+
+from dynacell.evaluation.segmentation_cellpose import _robust_clahe
+
+CELL_VOXEL_UM = 0.3
+"""Default isotropic working-grid voxel size (um) for the cell stage. ``None``
+runs the recipe at native resolution (using the lateral voxel size for the
+physical-to-pixel conversions; assumes near-isotropic for volume floors)."""
+
+CLOSE_UM = 2.5
+"""Grayscale-closing disk radius (um) that bridges dim cytoplasm in the sum."""
+
+WALL_SIGMA_UM = 0.35
+"""Gaussian sigma (um) applied to the membrane before wall thresholding."""
+
+WALL_MIN_UM = 1.0
+"""Drop membrane-wall specks below this physical size (um^ndim)."""
+
+HOLE_UM = 3.0
+"""Fill cell-mask holes below this physical size (um^ndim)."""
+
+MIN_CELL_UM = 15.0
+"""Drop whole cells below this physical size. Default is the 2-D area floor
+(um^2); set to a um^3 volume floor (e.g. 50) for ``dimension=3d`` runs."""
+
+
+def slice_index(memb_vol: np.ndarray, *, selection: str = "frac", fraction: float = 0.30) -> int:
+    """Pick a representative z-plane index from a membrane volume.
+
+    Parameters
+    ----------
+    memb_vol : numpy.ndarray
+        3-D ``(Z, Y, X)`` membrane fluorescence volume.
+    selection : str
+        ``"frac"`` returns ``round(fraction * (Z - 1))``; ``"sharpest"`` returns
+        the plane with the highest intensity variance.
+    fraction : float
+        Fractional depth used when ``selection="frac"``. Defaults to 0.30.
+
+    Returns
+    -------
+    int
+        The chosen z index.
+    """
+    z = memb_vol.shape[0]
+    if selection == "frac":
+        return int(round(fraction * (z - 1)))
+    if selection == "sharpest":
+        return int(np.argmax(memb_vol.reshape(z, -1).var(axis=1)))
+    raise ValueError(f"Unknown slice_selection: {selection!r} (expected 'frac' or 'sharpest').")
+
+
+def _relabel_sequential_device(labels):
+    """Relabel a (possibly device) integer label image to a dense ``1..K`` uint16."""
+    xp = get_array_module(labels)
+    ids = np.unique(labels)
+    ids = ids[ids > 0]
+    out = xp.zeros(labels.shape, dtype=xp.uint16)
+    if int(ids.size) == 0:
+        return out
+    remap = xp.zeros(int(ids.max()) + 1, dtype=xp.uint16)
+    remap[ids] = xp.arange(1, int(ids.size) + 1, dtype=xp.uint16)
+    return remap[labels]
+
+
+def _cells_on_grid(memb_g, nuc_g, seed_g, *, close_px, wall_sigma_px, wall_min_px, hole_px, min_cell_px):
+    """Run the channel-sum + wall-subtraction + watershed recipe on a working grid.
+
+    All inputs are GPU arrays at the same (working) resolution: ``memb_g`` /
+    ``nuc_g`` are robust-clipped + CLAHE'd float membrane / nucleus images,
+    ``seed_g`` the uint16 nucleus labels. Returns sequentially relabeled uint16
+    whole-cell instances on the same device.
+    """
+    xp = get_array_module(memb_g)
+    combined = np.clip(memb_g + nuc_g, 0.0, 1.0)
+    disk_fp = ascupy(_morphology.disk(close_px))
+    # grayscale closing per XY plane (a single plane in 2D, looped over Z in 3D)
+    if combined.ndim == 3:
+        closed = xp.zeros_like(combined)
+        for z in range(combined.shape[0]):
+            closed[z] = _morphology.closing(combined[z], disk_fp)
+    else:
+        closed = _morphology.closing(combined, disk_fp)
+    # lower multi-Otsu boundary (inclusive); Otsu fallback for near-binary images
+    try:
+        thr0 = _filters.threshold_multiotsu(closed, classes=3, nbins=128)[0]
+    except ValueError:
+        thr0 = _filters.threshold_otsu(closed)
+    tissue = _binary_fill_holes(closed > thr0)
+    memb_s = _filters.gaussian(memb_g, sigma=wall_sigma_px, preserve_range=True)
+    walls = memb_s > _filters.threshold_multiotsu(memb_s, classes=3, nbins=128)[1]
+    walls = _remove_small_objects(walls, min_size=wall_min_px)
+    # the seed OR guarantees every nucleus voxel is interior to the mask, so the
+    # marker-controlled watershed needs no orphan-seed restoration loop
+    cell_mask = (tissue & ~walls) | (seed_g > 0)
+    cell_mask = _remove_small_holes(cell_mask, area_threshold=hole_px)
+    cells = segment_watershed(cell_mask, markers=seed_g, mask=cell_mask)
+    cells = _remove_small_objects(cells, min_size=min_cell_px)
+    return _relabel_sequential_device(cells)
+
+
+def segment_whole_cell(
+    memb_img: np.ndarray,
+    nuc_img: np.ndarray,
+    seed_labels: np.ndarray,
+    spacing: tuple[float, ...],
+    *,
+    cell_voxel_um: float | None = CELL_VOXEL_UM,
+    close_um: float = CLOSE_UM,
+    wall_sigma_um: float = WALL_SIGMA_UM,
+    wall_min_um: float = WALL_MIN_UM,
+    hole_um: float = HOLE_UM,
+    min_cell_um: float = MIN_CELL_UM,
+    memb_clahe: bool = True,
+    subtract_nuclei: bool = True,
+) -> np.ndarray:
+    """Segment whole cells from membrane + nucleus + seed labels.
+
+    Parameters
+    ----------
+    memb_img : numpy.ndarray
+        Membrane fluorescence: 3-D ``(Z, Y, X)`` volume or 2-D ``(Y, X)`` slice.
+    nuc_img : numpy.ndarray
+        Nucleus fluorescence, same shape as *memb_img*. Summed with the membrane
+        to fill the dark nuclear core of the membrane channel.
+    seed_labels : numpy.ndarray
+        Native-resolution uint16 nucleus instance labels (watershed markers),
+        same shape as *memb_img*.
+    spacing : tuple of float
+        Physical voxel size in micrometers: ``(z, y, x)`` for 3-D, ``(y, x)`` for
+        2-D.
+    cell_voxel_um : float or None
+        Isotropic working-grid voxel size (um). ``None`` runs at native
+        resolution. The morphological size parameters below are physical and
+        converted to working-grid pixels.
+    close_um, wall_sigma_um, wall_min_um, hole_um, min_cell_um : float
+        Physical morphological parameters (see module constants). ``wall_min_um``,
+        ``hole_um`` and ``min_cell_um`` are areas (2-D) or volumes (3-D).
+    memb_clahe : bool
+        Apply CLAHE to the membrane channel (the nucleus channel is always
+        CLAHE'd).
+    subtract_nuclei : bool
+        Carve the nucleus footprint out of each whole-cell label so the result is
+        cytoplasm-only.
+
+    Returns
+    -------
+    numpy.ndarray
+        uint16 whole-cell (or cytoplasm-only) instance labels at native
+        resolution, same spatial shape as *memb_img*.
+    """
+    ndim = memb_img.ndim
+    native_shape = memb_img.shape
+    memb_c = _robust_clahe(memb_img, use_clahe=memb_clahe)
+    nuc_c = _robust_clahe(nuc_img, use_clahe=True)
+
+    if cell_voxel_um is not None:
+        v = cell_voxel_um
+        if ndim == 3:
+            memb_g = rescale_isotropic(memb_c, spacing, downscale_xy=True, order=3, target_z_voxel_size=v)
+            nuc_g = rescale_isotropic(nuc_c, spacing, downscale_xy=True, order=3, target_z_voxel_size=v)
+        else:
+            scale = spacing[-1] / v
+            memb_g = rescale_xy(memb_c, scale=scale, order=3, anti_aliasing=True, preserve_range=True)
+            nuc_g = rescale_xy(nuc_c, scale=scale, order=3, anti_aliasing=True, preserve_range=True)
+        seed_g = _transform.resize(
+            ascupy(seed_labels), memb_g.shape, order=0, anti_aliasing=False, preserve_range=True
+        ).astype(np.uint16)
+    else:
+        v = spacing[-1]
+        memb_g, nuc_g = memb_c, nuc_c
+        seed_g = ascupy(seed_labels.astype(np.uint16, copy=False))
+
+    close_px = max(3, round(close_um / v))
+    wall_sigma_px = max(0.5, wall_sigma_um / v)
+    wall_min_px = max(1, round(wall_min_um / v**ndim))
+    hole_px = max(1, round(hole_um / v**ndim))
+    min_cell_px = max(1, round(min_cell_um / v**ndim))
+
+    cells_g = _cells_on_grid(
+        memb_g,
+        nuc_g,
+        seed_g,
+        close_px=close_px,
+        wall_sigma_px=wall_sigma_px,
+        wall_min_px=wall_min_px,
+        hole_px=hole_px,
+        min_cell_px=min_cell_px,
+    )
+
+    if cell_voxel_um is not None:
+        cells = asnumpy(
+            _transform.resize(cells_g, native_shape, order=0, anti_aliasing=False, preserve_range=True)
+        ).astype(np.uint16)
+    else:
+        cells = asnumpy(cells_g).astype(np.uint16)
+
+    if subtract_nuclei:
+        cells[np.asarray(seed_labels) > 0] = 0
+    return cells

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell_test.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell_test.py
@@ -1,0 +1,102 @@
+"""Tests for whole-cell watershed segmentation + slice selection."""
+
+import numpy as np
+import pytest
+import torch
+
+from dynacell.evaluation.segmentation_whole_cell import segment_whole_cell, slice_index
+
+_HAS_CUDA = torch.cuda.is_available()
+
+
+def test_slice_index_frac():
+    """frac selection returns round(fraction * (Z - 1))."""
+    vol = np.zeros((11, 4, 4), dtype=np.float32)
+    assert slice_index(vol, selection="frac", fraction=0.30) == 3  # round(0.30 * 10)
+    assert slice_index(vol, selection="frac", fraction=0.0) == 0
+    assert slice_index(vol, selection="frac", fraction=1.0) == 10
+
+
+def test_slice_index_sharpest():
+    """sharpest selection returns the highest-variance plane."""
+    vol = np.zeros((5, 8, 8), dtype=np.float32)
+    vol[3] = np.tile([0.0, 1.0], (8, 4))  # high-variance checker on plane 3
+    assert slice_index(vol, selection="sharpest") == 3
+
+
+def test_slice_index_invalid():
+    vol = np.zeros((4, 4, 4), dtype=np.float32)
+    with pytest.raises(ValueError):
+        slice_index(vol, selection="bogus")
+
+
+def _two_cell_synthetic_2d(shape=(128, 128)):
+    """Two cytoplasmic squares split by a bright membrane wall, two nuclei seeds."""
+    h, w = shape
+    memb = np.zeros(shape, dtype=np.float32)
+    nuc = np.zeros(shape, dtype=np.float32)
+    seed = np.zeros(shape, dtype=np.uint16)
+    # cytoplasm fill for both cells
+    memb[20:108, 16:60] = 0.4
+    memb[20:108, 68:112] = 0.4
+    # bright walls: outer border + central divider
+    memb[18:20, 16:112] = 1.0
+    memb[108:110, 16:112] = 1.0
+    memb[18:110, 60:68] = 1.0  # divider
+    memb[18:110, 14:16] = 1.0
+    memb[18:110, 112:114] = 1.0
+    # nuclei (fluorescence + seed labels) at the two cell centers
+    nuc[56:72, 30:46] = 1.0
+    nuc[56:72, 82:98] = 1.0
+    seed[56:72, 30:46] = 1
+    seed[56:72, 82:98] = 2
+    return memb, nuc, seed
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="whole-cell watershed requires a CUDA GPU (cubic)")
+def test_segment_whole_cell_2d_one_cell_per_seed():
+    """A clean 2-cell synthetic yields one cytoplasm label per seed, walls separating."""
+    memb, nuc, seed = _two_cell_synthetic_2d()
+    cells = segment_whole_cell(memb, nuc, seed, (0.3, 0.3), cell_voxel_um=0.3, memb_clahe=False, subtract_nuclei=False)
+    assert cells.dtype == np.uint16
+    assert cells.shape == memb.shape
+    n_cells = int(cells.max())
+    assert 1 <= n_cells <= 2  # never more cells than seeds
+    # the two seed centers fall in distinct cell labels (walls keep them apart)
+    left = cells[64, 38]
+    right = cells[64, 90]
+    assert left != 0 and right != 0 and left != right
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="whole-cell watershed requires a CUDA GPU (cubic)")
+def test_segment_whole_cell_subtract_nuclei_carves_seeds():
+    """subtract_nuclei zeros the nucleus footprint (cytoplasm-only labels)."""
+    memb, nuc, seed = _two_cell_synthetic_2d()
+    carved = segment_whole_cell(memb, nuc, seed, (0.3, 0.3), cell_voxel_um=0.3, memb_clahe=False, subtract_nuclei=True)
+    assert not carved[seed > 0].any()  # every nucleus voxel is background
+    assert int(carved.max()) >= 1  # cytoplasmic shells remain
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="whole-cell watershed requires a CUDA GPU (cubic)")
+def test_segment_whole_cell_downscale_roundtrip():
+    """cell_voxel_um != native downscales then NN-upscales labels back to native shape."""
+    memb, nuc, seed = _two_cell_synthetic_2d()
+    cells = segment_whole_cell(memb, nuc, seed, (0.3, 0.3), cell_voxel_um=0.58, memb_clahe=False, subtract_nuclei=False)
+    assert cells.dtype == np.uint16
+    assert cells.shape == memb.shape  # back at native resolution
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="whole-cell watershed requires a CUDA GPU (cubic)")
+def test_segment_whole_cell_3d_runs_full_volume():
+    """The 3D path runs on (Z, Y, X) and returns native-shape uint16 labels."""
+    memb2d, nuc2d, seed2d = _two_cell_synthetic_2d(shape=(96, 96))
+    z = 9
+    memb = np.broadcast_to(memb2d, (z, *memb2d.shape)).astype(np.float32).copy()
+    nuc = np.broadcast_to(nuc2d, (z, *nuc2d.shape)).astype(np.float32).copy()
+    seed = np.broadcast_to(seed2d, (z, *seed2d.shape)).astype(np.uint16).copy()
+    cells = segment_whole_cell(
+        memb, nuc, seed, (0.3, 0.3, 0.3), cell_voxel_um=0.3, memb_clahe=False, subtract_nuclei=False
+    )
+    assert cells.dtype == np.uint16
+    assert cells.shape == memb.shape
+    assert int(cells.max()) >= 1

--- a/applications/dynacell/tests/test_evaluation_cache.py
+++ b/applications/dynacell/tests/test_evaluation_cache.py
@@ -21,10 +21,12 @@ from dynacell.evaluation.cache import (  # noqa: E402
     encoder_config_sha256_12,
     load_manifest,
     read_features,
+    read_instance_mask,
     read_mask,
     save_manifest,
     seed_cache_identity,
     write_features,
+    write_instance_mask,
     write_mask,
 )
 
@@ -344,6 +346,47 @@ def test_write_and_read_mask_roundtrip(tmp_path: Path) -> None:
     assert loaded.dtype == bool
     assert loaded.shape == masks.shape
     np.testing.assert_array_equal(loaded, masks)
+
+
+def test_cache_paths_instance_masks_dir(tmp_path: Path) -> None:
+    """CachePaths exposes the instance-mask plate layout."""
+    paths = cache_paths(tmp_path)
+    assert paths.instance_masks_dir == tmp_path / "instance_masks"
+    assert paths.instance_mask_plate("nucleus", "cellpose") == tmp_path / "instance_masks" / "nucleus__cellpose.zarr"
+
+
+def test_write_and_read_instance_mask_roundtrip(tmp_path: Path) -> None:
+    """uint16 instance labels round-trip without bool coercion."""
+    paths = cache_paths(tmp_path)
+    rng = np.random.default_rng(0)
+    labels = rng.integers(0, 7, size=(3, 4, 8, 8), dtype=np.uint16)  # (T, D, H, W)
+    write_instance_mask(paths, "nucleus", "A/1/0", labels, backend="cellpose")
+
+    loaded = read_instance_mask(paths, "nucleus", "A/1/0", backend="cellpose")
+    assert loaded is not None
+    assert loaded.dtype == np.uint16
+    assert loaded.shape == labels.shape
+    np.testing.assert_array_equal(loaded, labels)
+
+
+def test_instance_mask_2d_stored_with_singleton_d(tmp_path: Path) -> None:
+    """A 2-D run is stored with D=1 and reads back identically."""
+    paths = cache_paths(tmp_path)
+    labels = np.zeros((2, 1, 8, 8), dtype=np.uint16)  # (T, D=1, H, W)
+    labels[:, 0, 1:3, 1:3] = 4
+    write_instance_mask(paths, "membrane", "A/1/0", labels, backend="cellpose_watershed")
+    loaded = read_instance_mask(paths, "membrane", "A/1/0", backend="cellpose_watershed")
+    assert loaded.shape == (2, 1, 8, 8)
+    np.testing.assert_array_equal(loaded, labels)
+
+
+def test_read_instance_mask_missing_returns_none(tmp_path: Path) -> None:
+    """Missing plate or position returns None (not an error)."""
+    paths = cache_paths(tmp_path)
+    assert read_instance_mask(paths, "nucleus", "A/1/0", backend="cellpose") is None
+    labels = np.zeros((2, 3, 4, 4), dtype=np.uint16)
+    write_instance_mask(paths, "nucleus", "A/1/0", labels, backend="cellpose")
+    assert read_instance_mask(paths, "nucleus", "A/2/0", backend="cellpose") is None
 
 
 def test_read_mask_missing_plate_returns_none(tmp_path: Path) -> None:

--- a/applications/dynacell/tests/test_evaluation_grouped.py
+++ b/applications/dynacell/tests/test_evaluation_grouped.py
@@ -175,6 +175,28 @@ def test_grouped_rejects_condition0_model_field_override(tmp_path: Path):
         pipeline.evaluate_predictions_grouped(grouped_cfg)
 
 
+def test_grouped_rejects_instance_ap_field_override(tmp_path: Path):
+    """The instance-AP toggles are grouped invariants — a per-condition override raises.
+
+    ``compute_instance_ap`` (and the ``segmentation.*`` / ``instance_metrics.*``
+    instance fields) gate the seg backend and the shared instance-label cache
+    identity, so a condition that flips one would diverge from the bundle.
+    """
+    cond_a_root = tmp_path / "fixture_a"
+    cond_b_root = tmp_path / "fixture_b"
+    cond_a_root.mkdir()
+    cond_b_root.mkdir()
+    save_root = tmp_path / "saves"
+    save_root.mkdir()
+
+    grouped_cfg = _build_grouped_config(cond_a_root, cond_b_root, save_root)
+    grouped_cfg["conditions"][1]["compute_instance_ap"] = True
+
+    pipeline = live_pipeline_module()
+    with pytest.raises(ValueError, match="model-loading field"):
+        pipeline.evaluate_predictions_grouped(grouped_cfg)
+
+
 def test_grouped_warns_loudly_on_process_plus_cache_miss(tmp_path: Path, capsys):
     """``executor=process`` + multiple conditions + cache-miss prints a loud WARNING.
 

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -512,6 +512,41 @@ def test_fov_pred_masks_writes_manifest_source(tmp_path: Path, monkeypatch) -> N
     assert "A/1/0" in er_entry["positions"]
 
 
+def test_fov_masks_non_default_backend_keys_manifest_by_stem(tmp_path: Path, monkeypatch) -> None:
+    """A non-supermodel backend keys its manifest entry by the backend-aware stem.
+
+    ``supermodel`` masks live under ``organelle_masks[nucleus]`` and a ``cellpose``
+    binary run under ``organelle_masks[nucleus__cellpose]`` — matching their
+    distinct cache plate paths — so two backends in one cache dir never clobber
+    each other's manifest ``path`` / ``positions``.
+    """
+    import dynacell.evaluation.segmentation as segmentation
+
+    monkeypatch.setattr(segmentation, "segment", _seg_fn_factory(1))
+    img = np.zeros((1, 2, 3, 3), dtype=np.float32)
+
+    cfg_sm = _make_config(**{"target_name": "nucleus", "io.gt_cache_dir": str(tmp_path)})
+    ctx_sm = init_cache_context(cfg_sm, side="gt")
+    fov_masks(ctx_sm, "A/1/0", img, seg_model=_FakeSegModel())
+    flush_manifest(ctx_sm)
+
+    cfg_cp = _make_config(
+        **{"target_name": "nucleus", "segmentation.backend": "cellpose", "io.gt_cache_dir": str(tmp_path)}
+    )
+    ctx_cp = init_cache_context(cfg_cp, side="gt")
+    fov_masks(ctx_cp, "A/1/1", img, seg_model=_FakeSegModel())
+    flush_manifest(ctx_cp)
+
+    masks = load_manifest(cache_paths(tmp_path))["artifacts"]["organelle_masks"]
+    assert set(masks) == {"nucleus", "nucleus__cellpose"}
+    assert masks["nucleus"]["backend"] == "supermodel"
+    assert masks["nucleus"]["path"].endswith("organelle_masks/nucleus.zarr")
+    assert masks["nucleus"]["positions"] == ["A/1/0"]
+    assert masks["nucleus__cellpose"]["backend"] == "cellpose"
+    assert masks["nucleus__cellpose"]["path"].endswith("organelle_masks/nucleus__cellpose.zarr")
+    assert masks["nucleus__cellpose"]["positions"] == ["A/1/1"]
+
+
 def test_fov_gt_deep_features_dinov3_cache_hit(tmp_path: Path) -> None:
     """Pre-populated DINOv3 cache is returned without calling the extractor."""
     cfg = _make_config(

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -17,6 +17,7 @@ from dynacell.evaluation.cache import (  # noqa: E402
     cache_paths,
     load_manifest,
     read_features,
+    read_instance_mask,
     read_mask,
     write_features,
     write_mask,
@@ -27,7 +28,10 @@ from dynacell.evaluation.pipeline_cache import (  # noqa: E402
     fov_cp_features,
     fov_deep_features,
     fov_masks,
+    fov_nucleus_instances,
+    fov_whole_cell_instances,
     init_cache_context,
+    instance_cache_hit,
     precompute_deep_features,
 )
 
@@ -76,8 +80,8 @@ class _FakeSegModel:
 def _seg_fn_factory(value: int):
     """Return a stand-in for ``dynacell.evaluation.segmentation.segment`` returning a constant mask."""
 
-    def _segment(img, target_name, seg_model=None):
-        del target_name, seg_model
+    def _segment(img, target_name, seg_model=None, **kwargs):
+        del target_name, seg_model, kwargs
         return np.full(img.shape, value, dtype=np.uint8)
 
     return _segment
@@ -996,3 +1000,232 @@ def test_preprocess_version_match_is_noop(tmp_path: Path) -> None:
 
     _auto_invalidate_on_preprocess_version_mismatch(ctx)
     assert ctx.force["pred_celldino"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Instance-label cache helpers (nucleus + whole-cell)
+# --------------------------------------------------------------------------- #
+_CELLPOSE_PARAMS = {
+    "target_voxel_um": 0.58,
+    "cellprob_threshold": 0.0,
+    "flow_threshold": 0.4,
+    "min_obj_size": 30,
+}
+_WATERSHED_PARAMS = {
+    "cell_voxel_um": 0.3,
+    "close_um": 2.5,
+    "wall_sigma_um": 0.35,
+    "wall_min_um": 1.0,
+    "hole_um": 3.0,
+    "min_cell_um": 15.0,
+    "memb_clahe": True,
+    "subtract_nuclei": True,
+}
+
+
+def _two_label_stack(stack):
+    """Stand-in instance segmenter: two fixed labels at opposite corners."""
+    lab = np.zeros(stack.shape, dtype=np.uint16)
+    lab[..., :2, :2] = 1
+    lab[..., -2:, -2:] = 2
+    return lab
+
+
+def _nucleus_instance_config(tmp_path: Path, **extra):
+    return _make_config(
+        **{
+            "io.gt_cache_dir": str(tmp_path / "gt"),
+            "target_name": "nucleus",
+            "compute_instance_ap": True,
+            "segmentation.backend": "cellpose",
+            "segmentation.dimension": "2d",
+            "segmentation.cellpose": dict(_CELLPOSE_PARAMS),
+            **extra,
+        }
+    )
+
+
+def test_fov_nucleus_instances_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:
+    """Cache miss segments each timepoint, stores (T, 1, Y, X) uint16, records manifest."""
+    from dynacell.evaluation import segmentation_cellpose
+
+    calls = {"n": 0}
+
+    def fake(img, spacing, model, *, do_3d=False, **kw):
+        calls["n"] += 1
+        return _two_label_stack(img)
+
+    monkeypatch.setattr(segmentation_cellpose, "segment_nucleus_instances", fake)
+    ctx = init_cache_context(_nucleus_instance_config(tmp_path), side="gt")
+    nuc_stack = np.zeros((2, 16, 16), dtype=np.float32)  # (T, Y, X) — sliced 2D
+
+    labels = fov_nucleus_instances(ctx, "A/1/0", nuc_stack, _FakeSegModel())
+    assert labels.dtype == np.uint16
+    assert labels.shape == (2, 1, 16, 16)  # singleton D for 2D
+    assert calls["n"] == 2  # one per timepoint
+
+    paths = cache_paths(tmp_path / "gt")
+    read = read_instance_mask(paths, "nucleus", "A/1/0", backend="cellpose")
+    assert read is not None and read.shape == (2, 1, 16, 16)
+    flush_manifest(ctx)
+    manifest = load_manifest(paths)
+    assert "nucleus__cellpose" in manifest["artifacts"].get("instance_masks", {})
+
+
+def test_fov_nucleus_instances_cache_hit_skips_compute(tmp_path: Path, monkeypatch) -> None:
+    """A second run reads the cache and never calls the segmenter."""
+    from dynacell.evaluation import segmentation_cellpose
+
+    monkeypatch.setattr(segmentation_cellpose, "segment_nucleus_instances", lambda *a, **k: _two_label_stack(a[0]))
+    ctx = init_cache_context(_nucleus_instance_config(tmp_path), side="gt")
+    nuc_stack = np.zeros((2, 16, 16), dtype=np.float32)
+    fov_nucleus_instances(ctx, "A/1/0", nuc_stack, _FakeSegModel())
+    flush_manifest(ctx)
+
+    def fail(*a, **k):
+        raise AssertionError("segment_nucleus_instances should not run on a cache hit")
+
+    monkeypatch.setattr(segmentation_cellpose, "segment_nucleus_instances", fail)
+    ctx2 = init_cache_context(_nucleus_instance_config(tmp_path), side="gt")
+    labels = fov_nucleus_instances(ctx2, "A/1/0", nuc_stack, _FakeSegModel())
+    assert labels.shape == (2, 1, 16, 16)
+
+
+def test_instance_cache_hit_states(tmp_path: Path, monkeypatch) -> None:
+    """instance_cache_hit: False when disabled / missing / forced; True when present."""
+    from dynacell.evaluation import segmentation_cellpose
+
+    # Disabled cache (no gt_cache_dir) is always a miss.
+    disabled = init_cache_context(
+        _make_config(**{"target_name": "nucleus", "compute_instance_ap": True, "segmentation.backend": "cellpose"}),
+        side="gt",
+    )
+    assert instance_cache_hit(disabled, "A/1/0") is False
+
+    monkeypatch.setattr(segmentation_cellpose, "segment_nucleus_instances", lambda *a, **k: _two_label_stack(a[0]))
+    ctx = init_cache_context(_nucleus_instance_config(tmp_path), side="gt")
+    assert instance_cache_hit(ctx, "A/1/0") is False  # nothing written yet
+    fov_nucleus_instances(ctx, "A/1/0", np.zeros((2, 16, 16), np.float32), _FakeSegModel())
+    assert instance_cache_hit(ctx, "A/1/0") is True  # now present
+    ctx.force["gt_instances"] = True
+    assert instance_cache_hit(ctx, "A/1/0") is False  # forced recompute counts as a miss
+
+
+def test_fov_whole_cell_instances_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:
+    """Whole-cell path segments per-t via segment_whole_cell and caches uint16 labels."""
+    from dynacell.evaluation import segmentation_whole_cell
+
+    def fake_wc(memb, nuc, seed, spacing, **kw):
+        return np.asarray(seed, dtype=np.uint16)  # echo the seed labels
+
+    monkeypatch.setattr(segmentation_whole_cell, "segment_whole_cell", fake_wc)
+    cfg = _make_config(
+        **{
+            "io.gt_cache_dir": str(tmp_path / "gt"),
+            "target_name": "membrane",
+            "compute_instance_ap": True,
+            "segmentation.backend": "cellpose_watershed",
+            "segmentation.dimension": "2d",
+            "segmentation.nuclei_channel_name": "Nuclei",
+            "segmentation.cellpose": dict(_CELLPOSE_PARAMS),
+            "segmentation.watershed": dict(_WATERSHED_PARAMS),
+        }
+    )
+    ctx = init_cache_context(cfg, side="gt")
+    memb = np.zeros((2, 16, 16), np.float32)
+    nuc = np.zeros((2, 16, 16), np.float32)
+    seed = np.zeros((2, 16, 16), np.uint16)
+    seed[:, :4, :4] = 1
+    seed[:, -4:, -4:] = 2
+    cells = fov_whole_cell_instances(ctx, "A/1/0", memb, nuc, seed)
+    assert cells.dtype == np.uint16 and cells.shape == (2, 1, 16, 16)
+    read = read_instance_mask(cache_paths(tmp_path / "gt"), "membrane", "A/1/0", backend="cellpose_watershed")
+    assert read is not None and int(read.max()) == 2
+
+
+def test_instance_cache_identity_invalidation(tmp_path: Path, monkeypatch) -> None:
+    """Changing a cellpose param flips the manifest identity → force recompute."""
+    from dynacell.evaluation import segmentation_cellpose
+
+    monkeypatch.setattr(segmentation_cellpose, "segment_nucleus_instances", lambda *a, **k: _two_label_stack(a[0]))
+    ctx = init_cache_context(_nucleus_instance_config(tmp_path), side="gt")
+    fov_nucleus_instances(ctx, "A/1/0", np.zeros((2, 16, 16), np.float32), _FakeSegModel())
+    flush_manifest(ctx)
+
+    changed = dict(_CELLPOSE_PARAMS, min_obj_size=99)
+    ctx2 = init_cache_context(_nucleus_instance_config(tmp_path, **{"segmentation.cellpose": changed}), side="gt")
+    assert ctx2.force["gt_instances"] is True
+
+
+def test_validate_instance_ap_config_rejects() -> None:
+    """The bidirectional guard rejects every invalid backend/target/toggle combo."""
+    from dynacell.evaluation.pipeline import _validate_instance_ap_config
+
+    bad = [
+        {
+            "target_name": "nucleus",
+            "compute_instance_ap": True,
+            "segmentation.backend": "cellpose_watershed",
+            "segmentation.nuclei_channel_name": "Nuclei",
+        },  # watershed needs membrane
+        {"target_name": "membrane", "compute_instance_ap": True, "segmentation.backend": "cellpose_watershed"},
+        # watershed needs nuclei_channel_name
+        {
+            "target_name": "membrane",
+            "compute_instance_ap": False,
+            "segmentation.backend": "cellpose_watershed",
+            "segmentation.nuclei_channel_name": "Nuclei",
+        },  # watershed needs compute_instance_ap
+        {"target_name": "membrane", "compute_instance_ap": True, "segmentation.backend": "supermodel"},
+        # AP needs an instance backend
+        {"target_name": "membrane", "compute_instance_ap": True, "segmentation.backend": "cellpose"},
+        # cellpose AP is nucleus-only
+    ]
+    for overrides in bad:
+        with pytest.raises(ValueError):
+            _validate_instance_ap_config(_make_config(**overrides))
+
+
+def test_validate_instance_ap_config_accepts() -> None:
+    """Valid instance combos and the default supermodel run pass the guard."""
+    from dynacell.evaluation.pipeline import _validate_instance_ap_config
+
+    _validate_instance_ap_config(_make_config())  # supermodel, no instance AP
+    _validate_instance_ap_config(
+        _make_config(**{"target_name": "nucleus", "compute_instance_ap": True, "segmentation.backend": "cellpose"})
+    )
+    _validate_instance_ap_config(
+        _make_config(
+            **{
+                "target_name": "membrane",
+                "compute_instance_ap": True,
+                "segmentation.backend": "cellpose_watershed",
+                "segmentation.nuclei_channel_name": "Nuclei",
+            }
+        )
+    )
+
+
+def test_final_metrics_cache_gate_requires_ap_columns(tmp_path: Path) -> None:
+    """A cached AP-less mask npy must not satisfy a compute_instance_ap run."""
+    from dynacell.evaluation.pipeline import _final_metrics_cache_valid
+
+    save_dir = tmp_path / "out"
+    save_dir.mkdir()
+    np.save(save_dir / "pixel_metrics.npy", np.array([{"FOV": "A/1/0", "Timepoint": 0}], dtype=object))
+    cfg = _make_config(
+        **{
+            "compute_instance_ap": True,
+            "compute_feature_metrics": False,
+            "save": {
+                "save_dir": str(save_dir),
+                "pixel_metrics_filename": "pixel_metrics.npy",
+                "mask_metrics_filename": "mask_metrics.npy",
+                "feature_metrics_filename": "feature_metrics.npy",
+            },
+        }
+    )
+    np.save(save_dir / "mask_metrics.npy", np.array([{"FOV": "A/1/0", "DICE": 0.8}], dtype=object))
+    assert _final_metrics_cache_valid(cfg) is False  # no mAP column -> recompute
+    np.save(save_dir / "mask_metrics.npy", np.array([{"FOV": "A/1/0", "DICE": 0.8, "mAP": 0.5}], dtype=object))
+    assert _final_metrics_cache_valid(cfg) is True  # AP columns present -> reuse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,9 @@ cytoland = { workspace = true }
 airtable-utils = { workspace = true }
 qc = { workspace = true }
 dynacell = { workspace = true }
-# cubic 0.7.0a8 (FSC mean-center-before-Hamming-window fix) is not on PyPI yet;
-# pull it from main, which reports 0.7.0a8 and satisfies the ==0.7.0a8 pin.
-cubic = { git = "https://github.com/alxndrkalinin/cubic.git", branch = "main" }
+# cubic 0.7.0a9 (GPU-resident Cellpose-SAM eval API + FSC/FRC NaN fix) is not on
+# PyPI yet; pin the exact commit (reports 0.7.0a9, satisfies the ==0.7.0a9 pin).
+cubic = { git = "https://github.com/alxndrkalinin/cubic.git", rev = "b84db9a" }
 waveorder = { git = "https://github.com/mehta-lab/waveorder.git", branch = "main" }
 aicssegmentation = { git = "https://github.com/alxndrkalinin/aics-segmentation.git", branch = "main" }
 segmenter-model-zoo = { git = "https://github.com/alxndrkalinin/segmenter_model_zoo.git", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,6 @@ cytoland = { workspace = true }
 airtable-utils = { workspace = true }
 qc = { workspace = true }
 dynacell = { workspace = true }
-# Pin torch to a CUDA-12 build so the whole venv is CUDA-12-consistent: cupy
-# (cupy-cuda12x, CUDA 12.x only) resolves its CUDA libs through cuda-pathfinder,
-# which with a mixed stack would pick torch's CUDA-13 libcublas.so.13 and break
-# cupy (it needs libcublas.so.12). The PyPI torch 2.12 is CUDA-13-only; cu128 is
-# the newest CUDA-12 build (currently torch 2.11).
-torch = [ { index = "pytorch-cu128" } ]
-torchvision = [ { index = "pytorch-cu128" } ]
 # cubic 0.7.0a9 (GPU-resident Cellpose-SAM eval API + FSC/FRC NaN fix) is not on
 # PyPI yet; pin the exact commit (reports 0.7.0a9, satisfies the ==0.7.0a9 pin).
 cubic = { git = "https://github.com/alxndrkalinin/cubic.git", rev = "b84db9a" }
@@ -72,10 +65,13 @@ waveorder = { git = "https://github.com/mehta-lab/waveorder.git", branch = "main
 aicssegmentation = { git = "https://github.com/alxndrkalinin/aics-segmentation.git", branch = "main" }
 segmenter-model-zoo = { git = "https://github.com/alxndrkalinin/segmenter_model_zoo.git", branch = "main" }
 aicsmlsegment = { git = "https://github.com/alxndrkalinin/aics-ml-segmentation.git", branch = "main" }
+# RAPIDS publishes cucim's CUDA-13 wheels only to the NVIDIA index (the PyPI
+# cucim-cu13 entry is an sdist stub with no binary wheel); pull it from there.
+cucim-cu13 = { index = "nvidia" }
 
 [[tool.uv.index]]
-name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
+name = "nvidia"
+url = "https://pypi.nvidia.com"
 explicit = true
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ cytoland = { workspace = true }
 airtable-utils = { workspace = true }
 qc = { workspace = true }
 dynacell = { workspace = true }
+# Pin torch to a CUDA-12 build so the whole venv is CUDA-12-consistent: cupy
+# (cupy-cuda12x, CUDA 12.x only) resolves its CUDA libs through cuda-pathfinder,
+# which with a mixed stack would pick torch's CUDA-13 libcublas.so.13 and break
+# cupy (it needs libcublas.so.12). The PyPI torch 2.12 is CUDA-13-only; cu128 is
+# the newest CUDA-12 build (currently torch 2.11).
+torch = [ { index = "pytorch-cu128" } ]
+torchvision = [ { index = "pytorch-cu128" } ]
 # cubic 0.7.0a9 (GPU-resident Cellpose-SAM eval API + FSC/FRC NaN fix) is not on
 # PyPI yet; pin the exact commit (reports 0.7.0a9, satisfies the ==0.7.0a9 pin).
 cubic = { git = "https://github.com/alxndrkalinin/cubic.git", rev = "b84db9a" }
@@ -65,6 +72,11 @@ waveorder = { git = "https://github.com/mehta-lab/waveorder.git", branch = "main
 aicssegmentation = { git = "https://github.com/alxndrkalinin/aics-segmentation.git", branch = "main" }
 segmenter-model-zoo = { git = "https://github.com/alxndrkalinin/segmenter_model_zoo.git", branch = "main" }
 aicsmlsegment = { git = "https://github.com/alxndrkalinin/aics-ml-segmentation.git", branch = "main" }
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -934,38 +934,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "cucim-cu12"
+name = "cucim-cu13"
 version = "26.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "click" },
-    { name = "cupy-cuda12x" },
+    { name = "cupy-cuda13x" },
     { name = "lazy-loader" },
     { name = "numpy" },
-    { name = "nvidia-nvimgcodec-cu12" },
+    { name = "nvidia-nvimgcodec-cu13" },
     { name = "scikit-image" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/b7/30b7ff644856bea7c25773d8ce2b3223113b757131f21828cb7b45c31860/cucim_cu12-26.4.0.tar.gz", hash = "sha256:cc05f4a5125edc1a91f3d85b364f01a6dfdf22eb40251ff6dbf05d1c734f5c9b", size = 3869, upload-time = "2026-04-09T10:32:50.956Z" }
+wheels = [
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ad94be2c46de4c7f06ca3020c74ddc1e87149b277d69116b00ef7a733d72bc8" },
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:655292496907f5c3728ed5343806c940f226c2978ba0e6e327d2687284717cbb" },
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdd2c7ce1029d80a960d3471e42a8f75038c85e02d2c66a803d1c9f8e46b05db" },
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:692f4c640ee1c5d1d6dd65db6bebf9210f5bd3ac39354be7580a10322ba504a3" },
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49013b329d4887fc00688c8f5edb61c09541e7dfa2f2bff651981fd23a7f0711" },
+    { url = "https://pypi.nvidia.com/cucim-cu13/cucim_cu13-26.4.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8db4b750de7898050e564804e88b363a927c25d9280dbfa4071ca9bde6a5f74" },
+]
 
 [[package]]
 name = "cuda-bindings"
-version = "12.9.7"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
-    { url = "https://files.pythonhosted.org/packages/91/97/e3c6e58ece26a053419ba0a18444b5443cfc64451bbf37f84e8143b8bdca/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c7ef48c5e13ae90f3b2ecfb72f8e99ac43c8f4c43e67e1325b8aae331453687", size = 7611059, upload-time = "2026-05-27T18:44:15.252Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/7b/f1575e41e1a17dc2f2a408b2e8e864c9324e41e3e23f6401e5efc54c152a/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:266379e4942051f544a8e7ea1a30ead8d7e8199b6b30fcdc8917cae2bf614e61", size = 6978549, upload-time = "2026-05-27T18:44:18.839Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/dc/62d62eb4f91eb721bcf46da51b13e9872ccd8fa7e60eb8ba7b7baeac72c6/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59cf4a37b0d662ba15037c9ceebe1a306ebf2c01a8235a09be13cd07094fdb74", size = 7457675, upload-time = "2026-05-27T18:44:20.637Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/77/94d9b85f26add6fe9c9cb7c4ec3b96bc598f7ea5cfbd7490cc0a36adf5be/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbcd4801954eb3508f4dc2fa0d0c8eb93eb3f45326fd61be2731418c371e7a0", size = 6870886, upload-time = "2026-05-27T18:44:24.164Z" },
-    { url = "https://files.pythonhosted.org/packages/04/dd/3ec34b569e1b990b11276feba306bf8f446656cc38e8ed0f49b5facfeffa/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3747ea132642416786a8e31bf229032df3a7856911ae5426a7be53d032df183d", size = 7345663, upload-time = "2026-05-27T18:44:26.333Z" },
-    { url = "https://files.pythonhosted.org/packages/68/e4/075052d42872cf8162da53f14447a4b8abc004c3750e4b724ee502428da0/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:775960ac9e530717f3b48e165cc6f68684fa9a4141764fd923e4c1a9820acc73", size = 7060090, upload-time = "2026-05-27T18:44:30.281Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/cd/3289c810a4d45e5364a3387a74b4c9b6f6f57ee96ae0e5b537cc61dec242/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c47ec1a7a441d91aab32339951df7a1be53451121a12c094bba51467717a35a", size = 7504419, upload-time = "2026-05-27T18:44:31.992Z" },
-    { url = "https://files.pythonhosted.org/packages/11/43/472a6281c3d94e71687e27c657a8f60718d3579b4d94c41deea503165f8a/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a833d399b31071fab4cf3de2929840ae462dc4848116eeff033d09219e7116", size = 6899146, upload-time = "2026-05-27T18:44:35.556Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/13/10c1d0b32a9da65142d213e0733d748457fb3fd066aee4317335266f15c6/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11aeafa2b33995f890086b3fb0f062075176d956e9b6a6fe1a699dddc413f6ad", size = 7369087, upload-time = "2026-05-27T18:44:37.359Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
 ]
 
 [[package]]
@@ -978,67 +983,64 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "12.8.1"
+version = "13.0.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/c8/7dce3a0b15b42a3b58e7d96eb22a687d3bf2c44e01d149a6874629cd9938/cuda_toolkit-12.8.1-py2.py3-none-any.whl", hash = "sha256:adc7906af4ecbf9a352f9dca5734eceb21daec281ccfcf5675e1d2f724fc2cba", size = 2283, upload-time = "2025-08-13T02:03:07.842Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
 ]
 
 [package.optional-dependencies]
-cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", version = "11.3.3.83", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
-name = "cupy-cuda12x"
-version = "14.1.0"
+name = "cupy-cuda13x"
+version = "14.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder" },
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/11/c8ee77e4f285530527f3c2eb4a0df444056f5bd53451385d04e64d676cb5/cupy_cuda12x-14.1.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:0ef0fcdfea1a1c650c217f34223553e0914df140d82ecd457c047e849025c21c", size = 144383804, upload-time = "2026-05-23T01:10:11.429Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/0b/802bbda4b40957c3c151f8338436bbea225a9bd3290bed5488e32131d641/cupy_cuda12x-14.1.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:cf33564a11c966de724a45bb84b30ca6fa08d0a3d5696316af230ba4177bfbde", size = 133516920, upload-time = "2026-05-23T01:10:16.586Z" },
-    { url = "https://files.pythonhosted.org/packages/05/2c/e4869255f3d1a153ec3ae815243be1b3c1a7a1d9011cdc3757201b18e032/cupy_cuda12x-14.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:31c388f6b20acc265658363466cf58c5419e0ca47ff54d44d78e6ef6f997d3ac", size = 95238833, upload-time = "2026-05-23T01:10:21.589Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/69/57ac08d11fa2826644898009acc81c29d2628d2beb30a95cc057d4390da3/cupy_cuda12x-14.1.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:44c12a92216fbc65c6f4ebc055c801ab43eaf8c9316bd1a9ef9b91ad8c1d57db", size = 143920077, upload-time = "2026-05-23T01:10:26.873Z" },
-    { url = "https://files.pythonhosted.org/packages/23/a1/6b83754040db8f2e3dfefa7671144f4c2f105adbe9da76ce76a61a5c5df8/cupy_cuda12x-14.1.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:e9f2006077082ef04cec7ac6a897730b21fe51ebbd2b020bef503ccf5ccd7b4d", size = 133071609, upload-time = "2026-05-23T01:10:32.129Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/94/d8e3d720cf4b3c8e31e5a7e4afc598bd84e46e8002f70cbddaf02652cd68/cupy_cuda12x-14.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:3dba5342eff14b534104c5caeec0ed80699244cbc03d7cc93c4573f6c94cdae9", size = 95219626, upload-time = "2026-05-23T01:10:36.532Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ec/9a1ebe6a16c906f7c866d346716dbfb26506075609b95acf20a1a6781b9c/cupy_cuda12x-14.1.0-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:cc78d1f0ebc1c4e77e81c6d293cbc2402c5bf4bd6d86f586e5816fe7f69b3c91", size = 143788622, upload-time = "2026-05-23T01:10:42.234Z" },
-    { url = "https://files.pythonhosted.org/packages/59/ff/831460649d69cc2c22b634b1027771e56406c119b432abacfd18226e15e0/cupy_cuda12x-14.1.0-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:f6e50046ef5923243273852f97812d35dba5726c9d32390e1c89530a03a3491f", size = 132406357, upload-time = "2026-05-23T01:10:48.877Z" },
-    { url = "https://files.pythonhosted.org/packages/41/9f/1bf6d007ad90b050e5bc2e480135bd3afe748bae90867b17448e56d1536a/cupy_cuda12x-14.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:f0dd1cffe925ccbb823e4cd7b10e7b5b41813804c754e2192225892c785f18d9", size = 95793926, upload-time = "2026-05-23T01:10:58.524Z" },
-    { url = "https://files.pythonhosted.org/packages/86/50/6dab7e3e10fc711c07703be460a34edb87ac1841fa10c247c22cf8b5f144/cupy_cuda12x-14.1.0-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:3a30f8f08135295ffa23378268c848eacb2d204af26ed46194540c741de2b38f", size = 144093044, upload-time = "2026-05-23T01:11:06.559Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5c/e5aa39d6c1a3189c456323cb8a44ce3dbb2d2d516b606433dd9dfe6a10dd/cupy_cuda12x-14.1.0-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:1670cfcf2ba4fc7b0eff39851c1618e1ba0b92259e49fd68249339530022b27c", size = 132635331, upload-time = "2026-05-23T01:11:11.984Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/df/33e14f4648910db90d9aa3ac03c7012eec2e5d05a7ab69ec74a7864d6354/cupy_cuda13x-14.1.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9226f3279c64aa6f07a79ba0081f3275a99a36c2db3f836f4b687dd8d77fa8bc", size = 73276230, upload-time = "2026-06-01T04:54:10.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a7/7105dad3285c35451aae7efcc0a09e5b114de25065e3971552d906354e3e/cupy_cuda13x-14.1.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a57c3eda202ffd70e34b9031a88f17c810a75e816398b4028360027cb3a4cd4d", size = 69532519, upload-time = "2026-06-01T04:54:14.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4b/6f20833eedbfd1d44925780a2fdffaf72b3c78145a228359c7f2d534e0a8/cupy_cuda13x-14.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:c0ce59e54da561eeaebef0460242cfd159518d63b388d9d566d198d1d7614634", size = 35192036, upload-time = "2026-06-01T04:54:17.885Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0f/149a9e6c561f44e6522be6c3fdacdaed17d8fd5a1651004a0782ce045502/cupy_cuda13x-14.1.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:cc671cb766f1c42cb6eed3bf27e9da6092721bcb3d77e09aef28e2f5b089ea38", size = 72811428, upload-time = "2026-06-01T04:54:22.432Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f6/f4cd043ad8c8e18410e9cea73a8de8778a0a05c705b8505729a794758bf1/cupy_cuda13x-14.1.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:ff4526725c1398ea19d578044737aa24859b08e1f469aba0ca45dfd6f9aa505d", size = 69094726, upload-time = "2026-06-01T04:54:26.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/64/f2b60a0f4d73820d774906bf8684df0c8494820d78b3494121c7ec57ee25/cupy_cuda13x-14.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:54949b4e4f90e3588eeef25b55037f156578364e4835eb9ae1b93e236f2e58d5", size = 35171412, upload-time = "2026-06-01T04:54:31.313Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ca/9bc8d6d40003640653161e2dba78740f2055df8bb48e216eed5584cecc3c/cupy_cuda13x-14.1.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:8b068f6958811bc50d81bd0a83267ec4cffc3d7e842120b9646ec547f5a69298", size = 72680680, upload-time = "2026-06-01T04:54:35.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2d/8c79c577e9b35c60e5600217d1a849ab76c18a289f99a4145aa85388a531/cupy_cuda13x-14.1.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:39f8aeeb5bad16603956f8ec00094e058a9dd5db92ab514975686750363c3692", size = 68432306, upload-time = "2026-06-01T04:54:38.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/8d4d77138eb5f60a2a1fb5484a89dad2bc6bc6283682179994d722cfb4b5/cupy_cuda13x-14.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:dae6f77edfe96ab8e014d3e589dca33906d212fdf8f72e66850d4612bc031783", size = 35323057, upload-time = "2026-06-01T04:54:42.541Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c4/eb46fec30fffd7a57a80cc7f027e50a1d530b332e81362a8b874905da2d1/cupy_cuda13x-14.1.1-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:509f378c865c0b6bc9ed1dfe9e94b08b4511e9865363fdac55f9d66fe341e91d", size = 72984246, upload-time = "2026-06-01T04:54:46.464Z" },
+    { url = "https://files.pythonhosted.org/packages/24/59/e0098ca2e1ba99a0086ad4b515b2d7dbb8ae0f13b9721c02eed0db4adec5/cupy_cuda13x-14.1.1-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:6c0d19789e9f9515988d51dffaff70af8b3dcdddcdf2fbafa9eff08df7be0a51", size = 68662887, upload-time = "2026-06-01T04:54:50.932Z" },
 ]
 
 [[package]]
@@ -1311,10 +1313,8 @@ eval = [
     { name = "transformers" },
 ]
 eval-gpu = [
-    { name = "cucim-cu12" },
-    { name = "cupy-cuda12x" },
-    { name = "nvidia-cufft-cu12", version = "11.3.3.83", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cufft-cu12", version = "11.4.1.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "cucim-cu13" },
+    { name = "cupy-cuda13x" },
 ]
 preprocess = [
     { name = "iohub" },
@@ -1348,8 +1348,8 @@ requires-dist = [
     { name = "aicssegmentation", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/aics-segmentation.git?branch=main" },
     { name = "cellpose", marker = "extra == 'eval'" },
     { name = "cubic", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/cubic.git?rev=b84db9a" },
-    { name = "cucim-cu12", marker = "extra == 'eval-gpu'" },
-    { name = "cupy-cuda12x", marker = "extra == 'eval-gpu'" },
+    { name = "cucim-cu13", marker = "extra == 'eval-gpu'", index = "https://pypi.nvidia.com/" },
+    { name = "cupy-cuda13x", marker = "extra == 'eval-gpu'" },
     { name = "dynaclr", marker = "extra == 'eval'", editable = "applications/dynaclr" },
     { name = "hydra-core", marker = "extra == 'eval'", specifier = ">=1.2" },
     { name = "hydra-core", marker = "extra == 'report'", specifier = ">=1.2" },
@@ -1360,7 +1360,6 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'eval'" },
     { name = "matplotlib", marker = "extra == 'report'" },
     { name = "monai" },
-    { name = "nvidia-cufft-cu12", marker = "extra == 'eval-gpu'" },
     { name = "omegaconf" },
     { name = "pandas", marker = "extra == 'eval'" },
     { name = "pandas", marker = "extra == 'report'" },
@@ -1471,7 +1470,7 @@ requires-dist = [
     { name = "seaborn" },
     { name = "statsmodels", marker = "extra == 'eval'" },
     { name = "tabulate" },
-    { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision" },
     { name = "tracksdata", marker = "extra == 'tracking'" },
     { name = "umap-learn", marker = "extra == 'eval'" },
     { name = "viscy-data", extras = ["triplet"], editable = "packages/viscy-data" },
@@ -3685,225 +3684,165 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.19.0.56"
+name = "nvidia-cublas"
+version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/41/65225d42fba06fb3dd3972485ea258e7dd07a40d6e01c95da6766ad87354/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625", size = 657906812, upload-time = "2026-02-03T20:44:12.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
 ]
 
 [[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.4.1.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-]
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
 ]
 
 [[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
 ]
 
 [[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+name = "nvidia-cufft"
+version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
+name = "nvidia-cufile"
+version = "1.15.1.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.28.9"
+name = "nvidia-curand"
+version = "10.4.0.35"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/c4/120d2dfd92dff2c776d68f361ff8705fdea2ca64e20b612fab0fd3f581ac/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:50a36e01c4a090b9f9c47d92cec54964de6b9fcb3362d0e19b8ffc6323c21b60", size = 296766525, upload-time = "2025-11-18T05:49:16.094Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab", size = 296782137, upload-time = "2025-11-18T05:49:34.248Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
 ]
 
 [[package]]
-name = "nvidia-nvimgcodec-cu12"
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvimgcodec-cu13"
 version = "0.7.0.11"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/48/74d33dd126f84a4212480e2cf07504f457b5bae5acd33c0f6bf839ea17d4/nvidia_nvimgcodec_cu12-0.7.0.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:52d834be8122bb5b8fc3151cc3bedb95368b3e7ac76af0c4561772ab2a847b2b", size = 27409358, upload-time = "2025-12-02T09:28:16.358Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b4/f06528ebcb82da84f4a96efe7a210c277767cb86ad2f61f8b1a17d17f251/nvidia_nvimgcodec_cu12-0.7.0.11-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:32d3457859c5784e4c0f6a2f56b6a9afec8fe646cec1cbe4bb5c320948d92dfe", size = 33735220, upload-time = "2025-12-02T09:30:02.546Z" },
-    { url = "https://files.pythonhosted.org/packages/be/79/95b36049a9504d59d79929e9f3bec001b270f29aec8486e5fb9783a9502c/nvidia_nvimgcodec_cu12-0.7.0.11-py3-none-win_amd64.whl", hash = "sha256:495e07e071fcb2115f7f1948a04f6c51f96d61b83c614af753f7cc1bf369a46c", size = 18448810, upload-time = "2025-12-02T09:20:33.838Z" },
+    { url = "https://files.pythonhosted.org/packages/55/04/09d25e7af95cfd2a946326ad9276623c1ef6a0063dd85e03296074539ee2/nvidia_nvimgcodec_cu13-0.7.0.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:65ee61c93aaed80e21dc5db428bc7641fca6dcc319c166835a961359f7703736", size = 29987288, upload-time = "2025-12-02T09:28:57.139Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ab/e23d570d282394188882526f65a8719bc03e10ce11bc398ea6d81ed5d480/nvidia_nvimgcodec_cu13-0.7.0.11-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6075220b7ece40b5d975969f423e4ff9bc6d02bae4ac64ff8c8bf67d1234b12e", size = 31336639, upload-time = "2025-12-02T09:30:23.923Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a1/1c57461f85a681e2b3f6e41597fea1c550695d23a974afa4eaddba16f826/nvidia_nvimgcodec_cu13-0.7.0.11-py3-none-win_amd64.whl", hash = "sha256:39ef829c17e7bba7eb26c067604b0af77445ed611b5443b51579a913bbfa776f", size = 13735507, upload-time = "2025-12-02T09:19:41.233Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+name = "nvidia-nvjitlink"
+version = "13.0.88"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.9.86"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu12"
+name = "nvidia-nvshmem-cu13"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+name = "nvidia-nvtx"
+version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -6108,40 +6047,46 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.11.0+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:7c78215c3af4f62e63f2b2e360f1722fc719b0853c7ac22666483d9810613a4c", upload-time = "2026-04-27T17:43:49Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:6f367e62fd81b75cdf23ca4b75ced834d2db2cf98d1588ac935bde345de9de23", upload-time = "2026-04-27T17:48:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:c2a5984deba8e001d166bf9cb83b8351f63a28b009e1a2fa0e4bbf08c90b259b", upload-time = "2026-04-27T17:52:32Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:d6c21797ff75271b4fbdd905e2d703be4ecea5ea5bbdde4d1c201e9c71bc411d", upload-time = "2026-04-27T17:56:46Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:d86c125d720c2c368c53bd1a4ef062916d91fa965c10448c74c78b5d039faf2d", upload-time = "2026-04-27T18:01:14Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
+    { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
 ]
 
 [[package]]
@@ -6186,29 +6131,34 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.26.0+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:8c0d1c4fbb2c9a4d5d41d0aaa87da20e525bcb2a154ce405725b0be59456804b", upload-time = "2026-04-09T23:21:36Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:0232cb219927a52d6c98ff202f32d1cdf4802c2195a85fc1f1a0c1b0b4983a4d", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:367d42ea703844ecdb516e9d5eb09929012a58705d2622cf4e9e3c37f278cb85", upload-time = "2026-04-09T23:21:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:6319e1ba49c6f62ac9902f73d0eab207b8a4dc6b4d3392fe9edd9903fff1be0a", upload-time = "2026-04-09T23:21:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:f160dc552a086244f7102c898f7be8ef46a41b36bce5ea80a4f2493cb30ca1fc", upload-time = "2026-04-09T23:21:41Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c8/5cd91932f7f3671b0743dc4ae1a4c16b1d0b45bf4087976277d325bda718/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", size = 1758824, upload-time = "2026-05-13T14:57:15.227Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/36/7fb7d19477b3d93283b52fea11fa8ee30ab9064a08c97b4a6b91445e26cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65772ff3ec4f4f5d680e30019835555dd239e7fefee4b0a846375fe1cb1592ef", size = 7831034, upload-time = "2026-05-13T14:57:06.483Z" },
+    { url = "https://files.pythonhosted.org/packages/62/43/dfd894c3f8b01b5b33fde990f0159c1926ebc7b6e2c4193e2efb7da3c4cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7a9966a088d06b4cf6c610e03be62de469efa6f2cd2e7c7eed8e925ed6af59ac", size = 7579774, upload-time = "2026-05-13T14:56:59.337Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0c/722e989f9cf026e97ef7cb24a9bb1859e099f72d247ae35388fb89729f73/torchvision-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c037709072ca9b19750c0cbe9e8bb6f91c9a1be1befa26df33e281deccbd8c7", size = 4021073, upload-time = "2026-05-13T14:57:00.848Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
+    { url = "https://files.pythonhosted.org/packages/92/22/c0633677b3b3f3e69554a21ac087bf705f829c40cd5e3783507b8c006681/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c1fac0fc2a7adf29481fc1938a0e7845c57ba1147a986784109c4d98f434ea8c", size = 1758818, upload-time = "2026-05-13T14:56:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/48/e8/55f9d9667b56dae470e69e31beac9b00d458ea393feec1aae95cc4f3f1c9/torchvision-0.27.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cbf89764fc76f3f17fbf80c12d5a89c691e91cb9d82c38412aaf0568655ffb19", size = 7789667, upload-time = "2026-05-13T14:56:48.858Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bc/6f8681daf3bbc4c315bb0005110f99d28e3ecd675bf9c8f2c0d393fbac7a/torchvision-0.27.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:91f61b9865423037c327eb56afa207cc72de874e458c361840db9dcf5ce0c0eb", size = 7579848, upload-time = "2026-05-13T14:56:38.209Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6c/8d8020e6bd1e46c53e487c9c4e9457a07f2ee28931028fb5d71e2da40adc/torchvision-0.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:5bb82fc3c55daf1788621e504310b0a286f1069627a8742f692aebb075ef25a7", size = 4119284, upload-time = "2026-05-13T14:56:46.625Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/7e/e78c48662a8d551606efdbe11c6b9c1d6d2391b92cd0e4591b9e6a2412b8/torchvision-0.27.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2c4099a15150143b9b034730b404a56d572efe0b79489b4c765d929cb4eac7f3", size = 1758828, upload-time = "2026-05-13T14:56:52.293Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dd/d03ee9f9ee7bf11a8c7c776fb8e7fd6102f59c013791a2a4e5175bd6cba7/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b4c6bb0a670dcba017b3643e21902c9b8a1cc1c127d602f1488fa29ec3c6e865", size = 7790618, upload-time = "2026-05-13T14:56:44.721Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/4002336a74742be70728603ec1769feb2b55e0d19c532c9ec9f92008de76/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1c2db4bde82bc48ebff73436a6adf34d4f809448268a70d9a1285f5c8f92313d", size = 7580217, upload-time = "2026-05-13T14:56:43.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cb/4dd4783eb3565f526ba6e64b6f6ca26c00eacc924cdfe60455db9d91b84b/torchvision-0.27.0-cp314-cp314t-win_amd64.whl", hash = "sha256:72bf547e58ddb948689734eed6f4b6a2031f979dba4fb08e3690688b392e929f", size = 4226392, upload-time = "2026-05-13T14:56:40.235Z" },
 ]
 
 [[package]]
@@ -6299,19 +6249,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fb/82a802dac4689f2a2fb2e69302e6a138eecc3e175bbe976ba3cfc717683a/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e", size = 188507879, upload-time = "2026-05-07T19:05:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/af/9904ec6d3c93d9b24e5ec360445bbdf758b7f00bfbeedb89cb0eb64eb8bb/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce", size = 201460637, upload-time = "2026-05-07T18:46:34.749Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f9/4835a8ea746b88727d8899f4e3ccce4f9cacb38abfc3bb0a638266c53111/triton-3.7.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684", size = 188608706, upload-time = "2026-05-07T19:05:39.218Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/68/fa86e5a39608000f645535b2c124920126327ab731f8c4fafd5b07ff8d4b/triton-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5", size = 201546766, upload-time = "2026-05-07T18:46:42.088Z" },
 ]
 
 [[package]]
@@ -6524,9 +6474,9 @@ requires-dist = [
     { name = "tensorstore", marker = "extra == 'triplet'" },
     { name = "tifffile", marker = "extra == 'all'" },
     { name = "tifffile", marker = "extra == 'livecell'" },
-    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchvision", marker = "extra == 'all'", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchvision", marker = "extra == 'livecell'", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", specifier = ">=2.10" },
+    { name = "torchvision", marker = "extra == 'all'" },
+    { name = "torchvision", marker = "extra == 'livecell'" },
     { name = "tqdm" },
     { name = "zarr" },
 ]
@@ -6579,7 +6529,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pytorch-metric-learning" },
     { name = "timm", specifier = ">=1.0.15" },
-    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", specifier = ">=2.10" },
     { name = "torchdiffeq", marker = "extra == 'celldiff'" },
     { name = "transformers", specifier = ">=4.40" },
 ]
@@ -6640,7 +6590,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pooch", marker = "extra == 'notebook'", specifier = ">=1.9" },
     { name = "scikit-image", marker = "extra == 'notebook'", specifier = ">=0.26" },
-    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", specifier = ">=2.10" },
 ]
 provides-extras = ["notebook"]
 
@@ -6745,7 +6695,7 @@ requires-dist = [
     { name = "scipy" },
     { name = "tensorboard" },
     { name = "tensorstore" },
-    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", specifier = ">=2.10" },
     { name = "umap-learn", marker = "extra == 'all'" },
     { name = "umap-learn", marker = "extra == 'eval'" },
     { name = "viscy-data", editable = "packages/viscy-data" },

--- a/uv.lock
+++ b/uv.lock
@@ -950,20 +950,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/9a/b7/30b7ff644856bea7c
 
 [[package]]
 name = "cuda-bindings"
-version = "13.2.0"
+version = "12.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955", size = 6320619, upload-time = "2026-03-11T00:12:45.939Z" },
-    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+    { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/e3c6e58ece26a053419ba0a18444b5443cfc64451bbf37f84e8143b8bdca/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c7ef48c5e13ae90f3b2ecfb72f8e99ac43c8f4c43e67e1325b8aae331453687", size = 7611059, upload-time = "2026-05-27T18:44:15.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7b/f1575e41e1a17dc2f2a408b2e8e864c9324e41e3e23f6401e5efc54c152a/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:266379e4942051f544a8e7ea1a30ead8d7e8199b6b30fcdc8917cae2bf614e61", size = 6978549, upload-time = "2026-05-27T18:44:18.839Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dc/62d62eb4f91eb721bcf46da51b13e9872ccd8fa7e60eb8ba7b7baeac72c6/cuda_bindings-12.9.7-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59cf4a37b0d662ba15037c9ceebe1a306ebf2c01a8235a09be13cd07094fdb74", size = 7457675, upload-time = "2026-05-27T18:44:20.637Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/77/94d9b85f26add6fe9c9cb7c4ec3b96bc598f7ea5cfbd7490cc0a36adf5be/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbcd4801954eb3508f4dc2fa0d0c8eb93eb3f45326fd61be2731418c371e7a0", size = 6870886, upload-time = "2026-05-27T18:44:24.164Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/3ec34b569e1b990b11276feba306bf8f446656cc38e8ed0f49b5facfeffa/cuda_bindings-12.9.7-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3747ea132642416786a8e31bf229032df3a7856911ae5426a7be53d032df183d", size = 7345663, upload-time = "2026-05-27T18:44:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e4/075052d42872cf8162da53f14447a4b8abc004c3750e4b724ee502428da0/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:775960ac9e530717f3b48e165cc6f68684fa9a4141764fd923e4c1a9820acc73", size = 7060090, upload-time = "2026-05-27T18:44:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/cd/3289c810a4d45e5364a3387a74b4c9b6f6f57ee96ae0e5b537cc61dec242/cuda_bindings-12.9.7-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c47ec1a7a441d91aab32339951df7a1be53451121a12c094bba51467717a35a", size = 7504419, upload-time = "2026-05-27T18:44:31.992Z" },
+    { url = "https://files.pythonhosted.org/packages/11/43/472a6281c3d94e71687e27c657a8f60718d3579b4d94c41deea503165f8a/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a833d399b31071fab4cf3de2929840ae462dc4848116eeff033d09219e7116", size = 6899146, upload-time = "2026-05-27T18:44:35.556Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/13/10c1d0b32a9da65142d213e0733d748457fb3fd066aee4317335266f15c6/cuda_bindings-12.9.7-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11aeafa2b33995f890086b3fb0f062075176d956e9b6a6fe1a699dddc413f6ad", size = 7369087, upload-time = "2026-05-27T18:44:37.359Z" },
 ]
 
 [[package]]
@@ -976,42 +978,45 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "13.0.2"
+version = "12.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/7dce3a0b15b42a3b58e7d96eb22a687d3bf2c44e01d149a6874629cd9938/cuda_toolkit-12.8.1-py2.py3-none-any.whl", hash = "sha256:adc7906af4ecbf9a352f9dca5734eceb21daec281ccfcf5675e1d2f724fc2cba", size = 2283, upload-time = "2025-08-13T02:03:07.842Z" },
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", version = "11.3.3.83", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1276,7 +1281,6 @@ source = { editable = "applications/dynacell" }
 dependencies = [
     { name = "lightning" },
     { name = "monai" },
-    { name = "nvidia-cublas-cu12" },
     { name = "omegaconf" },
     { name = "pydantic" },
     { name = "viscy-data", extra = ["mmap"] },
@@ -1309,7 +1313,8 @@ eval = [
 eval-gpu = [
     { name = "cucim-cu12" },
     { name = "cupy-cuda12x" },
-    { name = "nvidia-cufft-cu12" },
+    { name = "nvidia-cufft-cu12", version = "11.3.3.83", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cufft-cu12", version = "11.4.1.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 preprocess = [
     { name = "iohub" },
@@ -1355,7 +1360,6 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'eval'" },
     { name = "matplotlib", marker = "extra == 'report'" },
     { name = "monai" },
-    { name = "nvidia-cublas-cu12", specifier = ">=12.9.2.10" },
     { name = "nvidia-cufft-cu12", marker = "extra == 'eval-gpu'" },
     { name = "omegaconf" },
     { name = "pandas", marker = "extra == 'eval'" },
@@ -1467,7 +1471,7 @@ requires-dist = [
     { name = "seaborn" },
     { name = "statsmodels", marker = "extra == 'eval'" },
     { name = "tabulate" },
-    { name = "torchvision" },
+    { name = "torchvision", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tracksdata", marker = "extra == 'tracking'" },
     { name = "umap-learn", marker = "extra == 'eval'" },
     { name = "viscy-data", extras = ["triplet"], editable = "packages/viscy-data" },
@@ -3681,164 +3685,158 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas"
-version = "13.1.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
-]
-
-[[package]]
 name = "nvidia-cublas-cu12"
-version = "12.9.2.10"
+version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-cupti"
-version = "13.0.85"
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
-    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc"
-version = "13.0.88"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
 ]
 
 [[package]]
 name = "nvidia-cuda-nvrtc-cu12"
-version = "12.9.86"
+version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
-    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
-    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
 ]
 
 [[package]]
-name = "nvidia-cuda-runtime"
-version = "13.0.96"
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
 ]
 
 [[package]]
-name = "nvidia-cudnn-cu13"
-version = "9.20.0.48"
+name = "nvidia-cudnn-cu12"
+version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/41/65225d42fba06fb3dd3972485ea258e7dd07a40d6e01c95da6766ad87354/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625", size = 657906812, upload-time = "2026-02-03T20:44:12.638Z" },
 ]
 
 [[package]]
-name = "nvidia-cufft"
-version = "12.0.0.61"
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
 ]
 
 [[package]]
 name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+]
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
     { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
 ]
 
 [[package]]
-name = "nvidia-cufile"
-version = "1.15.1.6"
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
 ]
 
 [[package]]
-name = "nvidia-curand"
-version = "10.4.0.35"
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
 ]
 
 [[package]]
-name = "nvidia-cusolver"
-version = "12.0.4.66"
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse"
-version = "12.6.3.3"
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu13"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
-    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
 ]
 
 [[package]]
-name = "nvidia-nccl-cu13"
-version = "2.29.7"
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/c4/120d2dfd92dff2c776d68f361ff8705fdea2ca64e20b612fab0fd3f581ac/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:50a36e01c4a090b9f9c47d92cec54964de6b9fcb3362d0e19b8ffc6323c21b60", size = 296766525, upload-time = "2025-11-18T05:49:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab", size = 296782137, upload-time = "2025-11-18T05:49:34.248Z" },
 ]
 
 [[package]]
@@ -3852,40 +3850,60 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-nvjitlink"
-version = "13.0.88"
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
 ]
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
     { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
-name = "nvidia-nvshmem-cu13"
+name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx"
-version = "13.0.85"
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
@@ -6090,46 +6108,40 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.11.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
-    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
-    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
-    { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
-    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:7c78215c3af4f62e63f2b2e360f1722fc719b0853c7ac22666483d9810613a4c", upload-time = "2026-04-27T17:43:49Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:6f367e62fd81b75cdf23ca4b75ced834d2db2cf98d1588ac935bde345de9de23", upload-time = "2026-04-27T17:48:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:c2a5984deba8e001d166bf9cb83b8351f63a28b009e1a2fa0e4bbf08c90b259b", upload-time = "2026-04-27T17:52:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:d6c21797ff75271b4fbdd905e2d703be4ecea5ea5bbdde4d1c201e9c71bc411d", upload-time = "2026-04-27T17:56:46Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:d86c125d720c2c368c53bd1a4ef062916d91fa965c10448c74c78b5d039faf2d", upload-time = "2026-04-27T18:01:14Z" },
 ]
 
 [[package]]
@@ -6174,34 +6186,29 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.27.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.26.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
 dependencies = [
     { name = "numpy" },
     { name = "pillow" },
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c8/5cd91932f7f3671b0743dc4ae1a4c16b1d0b45bf4087976277d325bda718/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", size = 1758824, upload-time = "2026-05-13T14:57:15.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/36/7fb7d19477b3d93283b52fea11fa8ee30ab9064a08c97b4a6b91445e26cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65772ff3ec4f4f5d680e30019835555dd239e7fefee4b0a846375fe1cb1592ef", size = 7831034, upload-time = "2026-05-13T14:57:06.483Z" },
-    { url = "https://files.pythonhosted.org/packages/62/43/dfd894c3f8b01b5b33fde990f0159c1926ebc7b6e2c4193e2efb7da3c4cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7a9966a088d06b4cf6c610e03be62de469efa6f2cd2e7c7eed8e925ed6af59ac", size = 7579774, upload-time = "2026-05-13T14:56:59.337Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0c/722e989f9cf026e97ef7cb24a9bb1859e099f72d247ae35388fb89729f73/torchvision-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c037709072ca9b19750c0cbe9e8bb6f91c9a1be1befa26df33e281deccbd8c7", size = 4021073, upload-time = "2026-05-13T14:57:00.848Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
-    { url = "https://files.pythonhosted.org/packages/92/22/c0633677b3b3f3e69554a21ac087bf705f829c40cd5e3783507b8c006681/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c1fac0fc2a7adf29481fc1938a0e7845c57ba1147a986784109c4d98f434ea8c", size = 1758818, upload-time = "2026-05-13T14:56:54.988Z" },
-    { url = "https://files.pythonhosted.org/packages/48/e8/55f9d9667b56dae470e69e31beac9b00d458ea393feec1aae95cc4f3f1c9/torchvision-0.27.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cbf89764fc76f3f17fbf80c12d5a89c691e91cb9d82c38412aaf0568655ffb19", size = 7789667, upload-time = "2026-05-13T14:56:48.858Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bc/6f8681daf3bbc4c315bb0005110f99d28e3ecd675bf9c8f2c0d393fbac7a/torchvision-0.27.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:91f61b9865423037c327eb56afa207cc72de874e458c361840db9dcf5ce0c0eb", size = 7579848, upload-time = "2026-05-13T14:56:38.209Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6c/8d8020e6bd1e46c53e487c9c4e9457a07f2ee28931028fb5d71e2da40adc/torchvision-0.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:5bb82fc3c55daf1788621e504310b0a286f1069627a8742f692aebb075ef25a7", size = 4119284, upload-time = "2026-05-13T14:56:46.625Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/7e/e78c48662a8d551606efdbe11c6b9c1d6d2391b92cd0e4591b9e6a2412b8/torchvision-0.27.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2c4099a15150143b9b034730b404a56d572efe0b79489b4c765d929cb4eac7f3", size = 1758828, upload-time = "2026-05-13T14:56:52.293Z" },
-    { url = "https://files.pythonhosted.org/packages/21/dd/d03ee9f9ee7bf11a8c7c776fb8e7fd6102f59c013791a2a4e5175bd6cba7/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b4c6bb0a670dcba017b3643e21902c9b8a1cc1c127d602f1488fa29ec3c6e865", size = 7790618, upload-time = "2026-05-13T14:56:44.721Z" },
-    { url = "https://files.pythonhosted.org/packages/39/08/4002336a74742be70728603ec1769feb2b55e0d19c532c9ec9f92008de76/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1c2db4bde82bc48ebff73436a6adf34d4f809448268a70d9a1285f5c8f92313d", size = 7580217, upload-time = "2026-05-13T14:56:43.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cb/4dd4783eb3565f526ba6e64b6f6ca26c00eacc924cdfe60455db9d91b84b/torchvision-0.27.0-cp314-cp314t-win_amd64.whl", hash = "sha256:72bf547e58ddb948689734eed6f4b6a2031f979dba4fb08e3690688b392e929f", size = 4226392, upload-time = "2026-05-13T14:56:40.235Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:8c0d1c4fbb2c9a4d5d41d0aaa87da20e525bcb2a154ce405725b0be59456804b", upload-time = "2026-04-09T23:21:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:0232cb219927a52d6c98ff202f32d1cdf4802c2195a85fc1f1a0c1b0b4983a4d", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:367d42ea703844ecdb516e9d5eb09929012a58705d2622cf4e9e3c37f278cb85", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:6319e1ba49c6f62ac9902f73d0eab207b8a4dc6b4d3392fe9edd9903fff1be0a", upload-time = "2026-04-09T23:21:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:f160dc552a086244f7102c898f7be8ef46a41b36bce5ea80a4f2493cb30ca1fc", upload-time = "2026-04-09T23:21:41Z" },
 ]
 
 [[package]]
@@ -6292,19 +6299,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.7.0"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
-    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
-    { url = "https://files.pythonhosted.org/packages/40/fb/82a802dac4689f2a2fb2e69302e6a138eecc3e175bbe976ba3cfc717683a/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e", size = 188507879, upload-time = "2026-05-07T19:05:32.209Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/af/9904ec6d3c93d9b24e5ec360445bbdf758b7f00bfbeedb89cb0eb64eb8bb/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce", size = 201460637, upload-time = "2026-05-07T18:46:34.749Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f9/4835a8ea746b88727d8899f4e3ccce4f9cacb38abfc3bb0a638266c53111/triton-3.7.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684", size = 188608706, upload-time = "2026-05-07T19:05:39.218Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/68/fa86e5a39608000f645535b2c124920126327ab731f8c4fafd5b07ff8d4b/triton-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5", size = 201546766, upload-time = "2026-05-07T18:46:42.088Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]
@@ -6517,9 +6524,9 @@ requires-dist = [
     { name = "tensorstore", marker = "extra == 'triplet'" },
     { name = "tifffile", marker = "extra == 'all'" },
     { name = "tifffile", marker = "extra == 'livecell'" },
-    { name = "torch", specifier = ">=2.10" },
-    { name = "torchvision", marker = "extra == 'all'" },
-    { name = "torchvision", marker = "extra == 'livecell'" },
+    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "extra == 'all'", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "extra == 'livecell'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm" },
     { name = "zarr" },
 ]
@@ -6572,7 +6579,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pytorch-metric-learning" },
     { name = "timm", specifier = ">=1.0.15" },
-    { name = "torch", specifier = ">=2.10" },
+    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchdiffeq", marker = "extra == 'celldiff'" },
     { name = "transformers", specifier = ">=4.40" },
 ]
@@ -6633,7 +6640,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "pooch", marker = "extra == 'notebook'", specifier = ">=1.9" },
     { name = "scikit-image", marker = "extra == 'notebook'", specifier = ">=0.26" },
-    { name = "torch", specifier = ">=2.10" },
+    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
 ]
 provides-extras = ["notebook"]
 
@@ -6738,7 +6745,7 @@ requires-dist = [
     { name = "scipy" },
     { name = "tensorboard" },
     { name = "tensorstore" },
-    { name = "torch", specifier = ">=2.10" },
+    { name = "torch", specifier = ">=2.10", index = "https://download.pytorch.org/whl/cu128" },
     { name = "umap-learn", marker = "extra == 'all'" },
     { name = "umap-learn", marker = "extra == 'eval'" },
     { name = "viscy-data", editable = "packages/viscy-data" },

--- a/uv.lock
+++ b/uv.lock
@@ -926,8 +926,8 @@ wheels = [
 
 [[package]]
 name = "cubic"
-version = "0.7.0a8"
-source = { git = "https://github.com/alxndrkalinin/cubic.git?branch=main#d46e345b96671a3559c6e4a094c39ebed3513358" }
+version = "0.7.0a9"
+source = { git = "https://github.com/alxndrkalinin/cubic.git?rev=b84db9a#b84db9afbb58cc0a7b53fc739accf0bc178050a2" }
 dependencies = [
     { name = "numpy" },
     { name = "scikit-image" },
@@ -1276,6 +1276,7 @@ source = { editable = "applications/dynacell" }
 dependencies = [
     { name = "lightning" },
     { name = "monai" },
+    { name = "nvidia-cublas-cu12" },
     { name = "omegaconf" },
     { name = "pydantic" },
     { name = "viscy-data", extra = ["mmap"] },
@@ -1341,7 +1342,7 @@ requires-dist = [
     { name = "aicsmlsegment", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/aics-ml-segmentation.git?branch=main" },
     { name = "aicssegmentation", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/aics-segmentation.git?branch=main" },
     { name = "cellpose", marker = "extra == 'eval'" },
-    { name = "cubic", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/cubic.git?branch=main" },
+    { name = "cubic", marker = "extra == 'eval'", git = "https://github.com/alxndrkalinin/cubic.git?rev=b84db9a" },
     { name = "cucim-cu12", marker = "extra == 'eval-gpu'" },
     { name = "cupy-cuda12x", marker = "extra == 'eval-gpu'" },
     { name = "dynaclr", marker = "extra == 'eval'", editable = "applications/dynaclr" },
@@ -1354,6 +1355,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'eval'" },
     { name = "matplotlib", marker = "extra == 'report'" },
     { name = "monai" },
+    { name = "nvidia-cublas-cu12", specifier = ">=12.9.2.10" },
     { name = "nvidia-cufft-cu12", marker = "extra == 'eval-gpu'" },
     { name = "omegaconf" },
     { name = "pandas", marker = "extra == 'eval'" },
@@ -3691,6 +3693,19 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti"
 version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
@@ -3706,6 +3721,16 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds instance-segmentation **average precision** (cubic `average_precision`, pred vs GT) to the dynacell evaluation pipeline for **two targets**, gated by `compute_instance_ap`, in **2D (default, single slice) and 3D (full-volume `do_3D`)**:

- **nucleus** (`backend=cellpose`) — each side segments its own nucleus channel into instance labels independently.
- **whole-cell** (`backend=cellpose_watershed`, membrane) — shared GT-nuclei Cellpose-SAM seeds → membrane EDT watershed → cytoplasm-only labels (a cubic port of the approved `.tmp/wholecell` cellgrid prototype).

Both share one AP wrapper, a uint16 instance-label cache (manifest auto-invalidation + a whole-cell seed preflight), merged-column metric output (`AP_<th>`/`mAP`/`n_gt`/`n_pred`/`instance_*@0.50` in `mask_metrics`), and the `_process_one_fov` instance branch. A bidirectional guard validates the backend/target/toggle combo; the toggles are grouped-run invariants; the cached-final gate requires AP columns when AP is requested.

## Commits

1. `build(deps)` — bump cubic to 0.7.0a9 (GPU-resident `segment_cpsam` + FSC/FRC refinement), re-baseline the pixel-metrics FSC golden (`Z_FSC_Resolution` Δ≈8.7e-4; base metrics byte-stable). *(This commit also added `nvidia-cublas-cu12`, later dropped.)*
2. `feat` — GPU-resident Cellpose-SAM nucleus backend (`segment_cpsam`, 2D, instance labels). cellpose 4.1.x dropped `model.backbone`; set `"sam_vitl"` in `load_cellpose_model`.
3. `feat` — whole-cell + nucleus instance average-precision (the wiring above).
4. `build(deps)` — pin torch to CUDA-12 (cu128) for a cupy-consistent stack. **Reverted by commit 6** — kept here for history.
5. `perf` — build the Cellpose 3-channel input on-device (drop a GPU→host→GPU round-trip).
6. `build(deps)` — **use CUDA-13 cupy/cucim instead of pinning torch to cu128** (see below).

## CUDA stack (commit 6) — note for reviewers

cupy/cucim resolve their CUDA libs at runtime via `cuda-pathfinder`, which picks up whatever CUDA-major nvidia wheels are present in the venv. PyPI `torch 2.12` is **CUDA-13-native** (it pulls the cu13 `cuda-toolkit` nvidia wheels), and the HPC GPU driver is CUDA 13.0. So rather than dragging torch *down* to cu12 (commit 4, which downgraded torch `2.12`→`2.11` **workspace-wide**, affecting cytoland/dynaclr/etc.), commit 6 keeps torch 2.12 and moves cupy/cucim *up* to their **CUDA-13** builds:

- `eval_gpu` extra: `cupy-cuda12x`/`cucim-cu12` → **`cupy-cuda13x`/`cucim-cu13`**.
- The venv is now **single-CUDA-major (cu13)**: pathfinder resolves cupy's `libcublas`/`libcufft` to the cu13 nvidia wheels torch already pulls → cupy works with **no `LD_LIBRARY_PATH`**, durably across `uv sync`.
- `cucim-cu13` is pulled from the **NVIDIA index** (`https://pypi.nvidia.com`) — its PyPI entry is an sdist stub with no binary wheel.
- The cu128 torch pin and `pytorch-cu128` index are removed; torch/torchvision/triton are back to their PyPI defaults (`2.12`/`0.27`/`3.7`). Zero `cu12` packages remain after `uv sync`.

## Verification

- Fresh venv rebuilt clean: **torch 2.12.0+cu130, cupy-cuda13x 14.1.1, cucim-cu13 26.4.0, zero cu12 packages**; cupy matmul/FFT + `cucim.skimage` import + torch CUDA all verified directly with no `LD_LIBRARY_PATH`.
- dynacell eval suite green on the cu13 stack: `instance_metrics_test`, `segmentation_whole_cell_test` (GPU recipe + `slice_index`), `segmentation_cellpose_test` (`segment_cpsam` 2D/3D/labels + on-device 3-ch), `test_pixel_metrics_parity`, cache uint16 round-trip, `test_pipeline_cache` (instance/guard/cached-gate), `test_evaluation_grouped` (invariant rejection).
- Pre-existing failures in `test_benchmark_config_composition` / `test_evaluate_compose` are unrelated (untracked benchmark-config WIP + a stale manifest spacing) — confirmed they fail with this change stashed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
