### PR TITLE
docs: Updated the badges + added link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
 # VisCy
 
-[![Python package index](https://img.shields.io/pypi/v/viscy.svg)](https://pypi.org/project/viscy)
-[![PyPI monthly downloads](https://img.shields.io/pypi/dm/viscy.svg)](https://pypistats.org/packages/viscy)
-[![GitHub contributors](https://img.shields.io/github/contributors-anon/mehta-lab/VisCy)](https://github.com/mehta-lab/VisCy/graphs/contributors)
-![GitHub Repo stars](https://img.shields.io/github/stars/mehta-lab/VisCy)
-[![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15022186.svg)](https://doi.org/10.5281/zenodo.15022186)
+|             |                                                                                                                                                              |
+| :---------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| **Status**  | [![Docs][badge-docs]][link-docs] [![Tests][badge-tests]][link-tests]                                                                                          |
+| **Package** | [![PyPI][badge-pypi]][link-pypi] [![Downloads][badge-downloads]][link-downloads]                                                                              |
+|  **Meta**   | [![SPEC 0][badge-spec0]][link-spec0] [![Contributors][badge-contributors]][link-contributors] [![Stars][badge-stars]][link-repo]                              |
+|  **Cite**   | [![DOI][badge-doi]][link-doi]                                                                                                                                 |
+
+[badge-docs]: https://github.com/mehta-lab/VisCy/actions/workflows/docs.yml/badge.svg
+[badge-tests]: https://github.com/mehta-lab/VisCy/actions/workflows/test.yml/badge.svg
+[badge-pypi]: https://img.shields.io/pypi/v/viscy.svg
+[badge-downloads]: https://img.shields.io/pypi/dm/viscy.svg
+[badge-spec0]: https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038
+[badge-contributors]: https://img.shields.io/github/contributors-anon/mehta-lab/VisCy
+[badge-stars]: https://img.shields.io/github/stars/mehta-lab/VisCy
+[badge-doi]: https://zenodo.org/badge/DOI/10.5281/zenodo.15022186.svg
+
+[link-docs]: https://mehta-lab.github.io/VisCy/stable/
+[link-tests]: https://github.com/mehta-lab/VisCy/actions/workflows/test.yml
+[link-pypi]: https://pypi.org/project/viscy
+[link-downloads]: https://pypistats.org/packages/viscy
+[link-spec0]: https://scientific-python.org/specs/spec-0000/
+[link-contributors]: https://github.com/mehta-lab/VisCy/graphs/contributors
+[link-repo]: https://github.com/mehta-lab/VisCy
+[link-doi]: https://doi.org/10.5281/zenodo.15022186
 
 VisCy (blend of `vision` and `cyto`) is a deep learning pipeline for training and deploying computer vision models for image-based phenotyping at single-cell resolution.
 
@@ -42,6 +60,10 @@ git clone https://github.com/mehta-lab/VisCy.git
 cd VisCy
 uv sync
 ```
+
+## Documentation
+
+Full documentation is hosted at <https://mehta-lab.github.io/VisCy/stable/>.
 
 ## Development
 


### PR DESCRIPTION
If you'd like you can link the docs to the top right corner of the GitHub repo (see vid).


https://github.com/user-attachments/assets/8dd5c03f-ba13-4330-9098-4607a432f2da

