### PR TITLE
feat(dynacell): pix2pix3d nucleus predict leaves wired to modernized GAN checkpoints

### DIFF
--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,50 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on A549 mantis (h2b), predicting against a549_mantis_h2b_denv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_denv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: a549_mantis_h2b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_denv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
+
+model:
+  init_args:
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_denv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_denv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,50 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on A549 mantis (h2b), predicting against a549_mantis_h2b_mock test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_mock.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: a549_mantis_h2b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_mock
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
+
+model:
+  init_args:
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_mock.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_mock
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,50 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on A549 mantis (h2b), predicting against a549_mantis_h2b_zikv test.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_zikv.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: a549_mantis_h2b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_zikv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
+
+model:
+  init_args:
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_zikv.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_zikv
+  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,46 @@
+# pix2pix3d_unetvit predict: nucleus (Nuclei marker) trained on A549 mantis (h2b), predicting against ipsc_confocal test_cropped.
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: nucleus__a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_pix2pix3d_unetvit_a549trained.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_ON_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_denv
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_denv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501549, converged early at epoch 15). predict_step uses generator_ema
+    # (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_mock
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_mock
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501549, converged early at epoch 15). predict_step uses generator_ema
+    # (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_zikv
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__ipsc_confocal__pix2pix3d_unetvit__a549_mantis_h2b_zikv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501549, converged early at epoch 15). predict_step uses generator_ema
+    # (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,10 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33501549, converged early at epoch 15). predict_step uses generator_ema
+    # (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_denv
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_denv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_mock
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_mock
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -14,10 +14,17 @@ benchmark:
   predict_set: a549_mantis_h2b_zikv
   model_name: pix2pix3d_unetvit
   experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__pix2pix3d_unetvit__a549_mantis_h2b_zikv
+  # A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+  # `nucleus` target from targets/nucleus.yml so the resolver finds h2b.
+  dataset_ref:
+    target: h2b
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,10 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit/checkpoints/last.ckpt
+    # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
+    # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
+    # generator_ema (use_ema_at_predict=True default).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:


### PR DESCRIPTION
Stacked on top of #449 (base = `dynacell-cellpose-watershed-eval`).

Prepares the full nucleus predict matrix for the three modernized
`pix2pix3d_unetvit` GANs trained to completion (iPSC / A549 / joint,
Run-D recipe, 40 ep). 13-file delta on top of the eval branch — which
already carries the modernized engine + overlays and the
`hardware_predict_any_gpu` migration, so this is config-only.

## Changes

**1. Wire trained checkpoints into the 8 existing predict leaves** (`ba72c77`)
Replace the `REPLACE_ME` / stale paths with the best `loss/validate_ema`
checkpoints from the modernized runs:
| trained_on | checkpoint | job |
|---|---|---|
| iPSC | `epoch=15-step=51200` | 33501549 |
| joint | `epoch=39-step=214400` | 33502019 |

Predict uses the EMA generator (`use_ema_at_predict=True`, engine default).

**2. Fix a latent `TargetNotFoundError`** (same commit)
The six a549 predict leaves lacked `dataset_ref: {target: h2b}`. The A549
manifest keys nucleus by gene (`h2b`), so the iPSC-side `nucleus` target
inherited from `targets/nucleus.yml` would fail to resolve. Bug is present
on the base branch (leaves were never wired, so it was never hit).

**3. Add the 4 missing a549-trained predict leaves** (`a55517e`)
`a549_mantis` had no predict leaves. Added ipsc_confocal + a549 h2b
mock/denv/zikv, best checkpoint `epoch=39-step=86400` (job 33501550).
Output stores use the `_a549trained` infix (fnet3d_paper convention) to
avoid colliding with iPSC-trained predictions in the shared dirs.

## Validation
All 12 leaves compose and resolve via `submit_benchmark_job.py
--print-resolved-config` (exit 0), each to the correct **test** store
(`cell.zarr` for iPSC; `H2B_{mock,DENV,ZIKV}.ozx` for a549); all three
checkpoints verified on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)