### PR TITLE
ci: Added release workflow

### DIFF
--- a/.github/scripts/route-tag.sh
+++ b/.github/scripts/route-tag.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Route a release tag to its workspace package and version.
+#
+# Usage: route-tag.sh <tag>
+# Prints `package=<name>` and `version=<version>` (GitHub Actions output format)
+# to stdout; a human-readable line goes to stderr. Exits 1 with an ::error::
+# annotation on an unrecognized tag.
+#
+# Each arm is anchored on `v[0-9]*`, and the bare-v umbrella arm stays LAST, so a
+# `viscy-…` tag or a subpackage tag missing its `v` (e.g. viscy-data-0.5.0) can't
+# fall through to the umbrella with a garbage version. Adding a package = add one
+# arm. The prefixes mirror each package's `pattern-prefix` in its pyproject.toml.
+set -euo pipefail
+
+tag="${1:?usage: route-tag.sh <tag>}"
+
+case "$tag" in
+  # libraries (packages/)
+  viscy-data-v[0-9]*)       package=viscy-data;       version=${tag#viscy-data-v} ;;
+  viscy-models-v[0-9]*)     package=viscy-models;     version=${tag#viscy-models-v} ;;
+  viscy-transforms-v[0-9]*) package=viscy-transforms; version=${tag#viscy-transforms-v} ;;
+  viscy-utils-v[0-9]*)      package=viscy-utils;      version=${tag#viscy-utils-v} ;;
+  # applications (applications/)
+  airtable-utils-v[0-9]*)   package=airtable-utils;   version=${tag#airtable-utils-v} ;;
+  cytoland-v[0-9]*)         package=cytoland;         version=${tag#cytoland-v} ;;
+  dynacell-v[0-9]*)         package=dynacell;         version=${tag#dynacell-v} ;;
+  dynaclr-v[0-9]*)          package=dynaclr;          version=${tag#dynaclr-v} ;;
+  viscy-qc-v[0-9]*)         package=viscy-qc;         version=${tag#viscy-qc-v} ;;
+  # umbrella (must stay last)
+  v[0-9]*)                  package=viscy;            version=${tag#v} ;;
+  *) echo "::error::Unrecognized release tag '$tag' (expected '<pkg>-vX.Y.Z' or 'vX.Y.Z')" >&2; exit 1 ;;
+esac
+
+echo "Routed $tag -> package=$package version=$version" >&2
+printf 'package=%s\nversion=%s\n' "$package" "$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+# Publishes one VisCy package to PyPI when a maintainer publishes a GitHub Release.
+# The tag on the Release selects the package. Each package is versioned independently
+# The prefix isolates its tag history, so versions need not match across packages:
+#   v2.1.0                    -> viscy            (umbrella)
+#   viscy-data-v0.5.3         -> viscy-data
+#   viscy-models-v1.4.0       -> viscy-models
+#   viscy-transforms-v0.9.1   -> viscy-transforms
+#   viscy-utils-v0.2.7        -> viscy-utils
+# Setup (PyPI trusted publishers + GitHub environments): see .github/RELEASE_SETUP.md
+# Design rationale: see .github/RELEASE_CI_PLAN.md
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  # Route the Release tag -> {package, version}. Separate job because `environment.name`
+  # on the publish job is resolved at the job level and can only read `needs.*` outputs.
+  parse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      package: ${{ steps.route.outputs.package }}
+      version: ${{ steps.route.outputs.version }}
+    steps:
+      - name: Route tag to package
+        id: route
+        env:
+          TAG: ${{ github.event.release.tag_name }}   # untrusted input via env, never inline in run:
+        run: |
+          set -euo pipefail
+          # Every arm is anchored on a digit after `v`. A greedy `v*` would swallow
+          # `viscy-…` and a subpackage tag missing its `v` (e.g. viscy-data-0.5.0)
+          # into the umbrella with a garbage version. Specific arms first.
+          case "$TAG" in
+            viscy-data-v[0-9]*)       package=viscy-data;       version=${TAG#viscy-data-v} ;;
+            viscy-models-v[0-9]*)     package=viscy-models;     version=${TAG#viscy-models-v} ;;
+            viscy-transforms-v[0-9]*) package=viscy-transforms; version=${TAG#viscy-transforms-v} ;;
+            viscy-utils-v[0-9]*)      package=viscy-utils;      version=${TAG#viscy-utils-v} ;;
+            v[0-9]*)                  package=viscy;            version=${TAG#v} ;;
+            *) echo "::error::Unrecognized release tag '$TAG' (expected '<pkg>-vX.Y.Z' or 'vX.Y.Z')"; exit 1 ;;
+          esac
+          echo "Routed $TAG -> package=$package version=$version"
+          {
+            echo "package=$package"
+            echo "version=$version"
+          } >>"$GITHUB_OUTPUT"
+
+  release:
+    needs: parse
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi-${{ needs.parse.outputs.package }}   # per-package OIDC isolation (see RELEASE_SETUP.md)
+      url: https://pypi.org/project/${{ needs.parse.outputs.package }}/${{ needs.parse.outputs.version }}/
+    permissions:
+      id-token: write   # OIDC trusted publishing
+      contents: write   # attach built dists to the GitHub Release (post-publish)
+    env:
+      PACKAGE: ${{ needs.parse.outputs.package }}
+      VERSION: ${{ needs.parse.outputs.version }}
+    steps:
+      - name: Check out the release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0      # full history …
+          fetch-tags: true    # … and tags so uv-dynamic-versioning can resolve the version
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+
+      # Build BOTH from source. Plain `uv build` chains sdist -> wheel-from-sdist, and the
+      # unpacked sdist has no .git, so uv-dynamic-versioning would fall back to 0.0.0 for the
+      # wheel. `--sdist --wheel` builds each directly from the checkout. `--no-sources` drops
+      # workspace path rewrites so deps resolve as normal PyPI packages (matches `pypa/build`).
+      - name: Build sdist and wheel
+        run: uv build --package "$PACKAGE" --sdist --wheel --no-sources --out-dir dist
+
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      # Cross-check the built version against the tag. The sdist is always named
+      # `<name>-<version>.tar.gz`, so an exact suffix match catches both the
+      # uv-dynamic-versioning 0.0.0 fallback and any tag/build drift — with no
+      # substring false positives (e.g. version 10.0.0 vs the 0.0.0 fallback).
+      - name: Verify built version matches the tag
+        run: |
+          set -euo pipefail
+          ls -1 dist/
+          if ! compgen -G "dist/*-${VERSION}.tar.gz" >/dev/null; then
+            echo "::error::no sdist matches tag version '${VERSION}' — version derivation likely failed"
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # attestations: true is the default on >=1.11 -> PEP 740 provenance, no extra config
+
+      - name: Attach distributions to the GitHub Release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ name: Release
 # The tag on the Release selects the package. Each package is versioned independently
 # The prefix isolates its tag history, so versions need not match across packages:
 #   v2.1.0                    -> viscy            (umbrella)
-#   viscy-data-v0.5.3         -> viscy-data
+#   viscy-data-v0.5.3         -> viscy-data       (library)
 #   viscy-models-v1.4.0       -> viscy-models
 #   viscy-transforms-v0.9.1   -> viscy-transforms
 #   viscy-utils-v0.2.7        -> viscy-utils
+#   airtable-utils-v0.1.0     -> airtable-utils   (application)
+#   cytoland-v0.3.0           -> cytoland
+#   dynacell-v0.2.0           -> dynacell
+#   dynaclr-v0.1.0            -> dynaclr
+#   viscy-qc-v0.1.0           -> viscy-qc
 # Setup (PyPI trusted publishers + GitHub environments): see .github/RELEASE_SETUP.md
 # Design rationale: see .github/RELEASE_CI_PLAN.md
 
@@ -31,28 +36,13 @@ jobs:
       package: ${{ steps.route.outputs.package }}
       version: ${{ steps.route.outputs.version }}
     steps:
+      - name: Check out (for the routing script)
+        uses: actions/checkout@v6
       - name: Route tag to package
         id: route
         env:
           TAG: ${{ github.event.release.tag_name }}   # untrusted input via env, never inline in run:
-        run: |
-          set -euo pipefail
-          # Every arm is anchored on a digit after `v`. A greedy `v*` would swallow
-          # `viscy-…` and a subpackage tag missing its `v` (e.g. viscy-data-0.5.0)
-          # into the umbrella with a garbage version. Specific arms first.
-          case "$TAG" in
-            viscy-data-v[0-9]*)       package=viscy-data;       version=${TAG#viscy-data-v} ;;
-            viscy-models-v[0-9]*)     package=viscy-models;     version=${TAG#viscy-models-v} ;;
-            viscy-transforms-v[0-9]*) package=viscy-transforms; version=${TAG#viscy-transforms-v} ;;
-            viscy-utils-v[0-9]*)      package=viscy-utils;      version=${TAG#viscy-utils-v} ;;
-            v[0-9]*)                  package=viscy;            version=${TAG#v} ;;
-            *) echo "::error::Unrecognized release tag '$TAG' (expected '<pkg>-vX.Y.Z' or 'vX.Y.Z')"; exit 1 ;;
-          esac
-          echo "Routed $TAG -> package=$package version=$version"
-          {
-            echo "package=$package"
-            echo "version=$version"
-          } >>"$GITHUB_OUTPUT"
+        run: bash .github/scripts/route-tag.sh "$TAG" >> "$GITHUB_OUTPUT"
 
   release:
     needs: parse

--- a/applications/qc/pyproject.toml
+++ b/applications/qc/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = [ "hatchling", "uv-dynamic-versioning" ]
 
 [project]
-name = "qc"
+name = "viscy-qc"
 description = "Quality control metrics for OME-Zarr microscopy datasets"
 readme = "README.md"
 keywords = [ "microscopy", "quality control", "zarr" ]
@@ -54,5 +54,5 @@ waveorder = { git = "https://github.com/mehta-lab/waveorder.git", branch = "main
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
-pattern-prefix = "qc-"
+pattern-prefix = "viscy-qc-"
 fallback-version = "0.0.0"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -146,9 +146,10 @@ Authoring notes:
 
 ## Release a package
 
-Versions come from git tags via
-[`uv-dynamic-versioning`](https://github.com/ninoseki/uv-dynamic-versioning); the
-tag **prefix** picks the package.
+Publishing a GitHub Release ships that package to PyPI — no tokens, no manual upload,
+no version bump in code. Versions come from the tag via
+[`uv-dynamic-versioning`](https://github.com/ninoseki/uv-dynamic-versioning); the tag
+**prefix** picks the package, and each package versions independently.
 
 | Package | Tag prefix | Example |
 |---|---|---|
@@ -158,18 +159,40 @@ tag **prefix** picks the package.
 | `viscy-utils` | `viscy-utils-` | `viscy-utils-v0.3.0` |
 | `viscy` (umbrella) | none | `v0.6.0` |
 
-```sh
-git checkout main && git pull && git fetch --tags
-git tag viscy-data-v0.2.1                          # (1)!
-uv build --package viscy-data --out-dir dist/      # (2)!
-ls dist/                                           # viscy_data-0.2.1-...whl  (3)!
-git push origin viscy-data-v0.2.1                  # (4)!
-```
+Create the Release on the tag:
 
-1. One tag per package you ship.
-2. Version is derived from the tag.
-3. Verify the wheel name matches the tag before pushing.
-4. Nothing is public until you push the tag.
+=== ":material-console: gh CLI"
+
+    ```sh
+    # standard release
+    gh release create viscy-data-v0.2.1 --generate-notes --title "viscy-data v0.2.1"
+
+    # pre-release (rc / alpha / beta)
+    gh release create viscy-data-v0.2.1rc1 --prerelease --generate-notes
+    ```
+
+=== ":material-web: Web"
+
+    1. **Releases → Draft a new release.**
+    2. Choose or create the tag, e.g. `viscy-data-v0.2.1`.
+    3. Tick **Set as a pre-release** for an `rc` / `a` / `b` tag.
+    4. **Publish release.**
+
+Spell versions the PEP 440 way: `v0.2.1`, `v0.2.1rc1`. A
+misspelled or unprefixed tag fails the run before anything builds.
+
+!!! note "What CI does"
+
+    Publishing the Release runs `.github/workflows/release.yml`: parse the tag, build
+    the sdist and wheel, verify the version matches the tag, publish to PyPI over OIDC
+    (PEP 740 attestations, no stored secrets), and attach the artifacts to the Release.
+
+!!! note "How publishing is authorized"
+
+    Each package publishes through PyPI
+    [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC): GitHub mints
+    a short-lived credential per run, scoped to `release.yml` and that package's
+    environment (`pypi-viscy`, `pypi-viscy-data`, …).
 
 !!! note "Docs deploy automatically"
 
@@ -177,7 +200,7 @@ git push origin viscy-data-v0.2.1                  # (4)!
     to `main` updates the `dev` build; a `vX.Y.Z` umbrella tag publishes a release
     and moves `stable`.
 
-## Before you open a PR
+## Before you open a PR check that:
 
 - [ ] Tests cover the change and `uv run pytest` passes
 - [ ] `uvx prek run --all-files` is clean

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -147,17 +147,23 @@ Authoring notes:
 ## Release a package
 
 Publishing a GitHub Release ships that package to PyPI — no tokens, no manual upload,
-no version bump in code. Versions come from the tag via
+no version bump in code. Both the workspace libraries and the applications release this
+way. Versions come from the tag via
 [`uv-dynamic-versioning`](https://github.com/ninoseki/uv-dynamic-versioning); the tag
 **prefix** picks the package, and each package versions independently.
 
 | Package | Tag prefix | Example |
 |---|---|---|
+| `viscy` (umbrella) | none | `v0.6.0` |
 | `viscy-data` | `viscy-data-` | `viscy-data-v0.2.1` |
 | `viscy-models` | `viscy-models-` | `viscy-models-v0.4.0` |
 | `viscy-transforms` | `viscy-transforms-` | `viscy-transforms-v0.1.3` |
 | `viscy-utils` | `viscy-utils-` | `viscy-utils-v0.3.0` |
-| `viscy` (umbrella) | none | `v0.6.0` |
+| `airtable-utils` | `airtable-utils-` | `airtable-utils-v0.1.0` |
+| `cytoland` | `cytoland-` | `cytoland-v0.3.0` |
+| `dynacell` | `dynacell-` | `dynacell-v0.2.0` |
+| `dynaclr` | `dynaclr-` | `dynaclr-v0.1.0` |
+| `viscy-qc` | `viscy-qc-` | `viscy-qc-v0.1.0` |
 
 Create the Release on the tag:
 

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -18,10 +18,10 @@ The table below is regenerated at build time from the installed distributions
 
 | Package | Version | Install |
 |---------|---------|---------|
-| [`viscy-data`](viscy-data.md) | `0.0.0.post233.dev0+0f63d97b` | `pip install viscy-data` |
-| [`viscy-models`](viscy-models.md) | `0.0.0.post233.dev0+0f63d97b` | `pip install viscy-models` |
-| [`viscy-transforms`](viscy-transforms.md) | `0.0.0.post233.dev0+0f63d97b` | `pip install viscy-transforms` |
-| [`viscy-utils`](viscy-utils.md) | `0.0.0.post233.dev0+0f63d97b` | `pip install viscy-utils` |
+| [`viscy-data`](viscy-data.md) | `0.0.0.post209.dev0+4edfaf8b` | `pip install viscy-data` |
+| [`viscy-models`](viscy-models.md) | `0.0.0.post209.dev0+4edfaf8b` | `pip install viscy-models` |
+| [`viscy-transforms`](viscy-transforms.md) | `0.0.0.post209.dev0+4edfaf8b` | `pip install viscy-transforms` |
+| [`viscy-utils`](viscy-utils.md) | `0.0.0.post209.dev0+4edfaf8b` | `pip install viscy-utils` |
 
 <!-- versions:end -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ viscy-utils = { workspace = true }
 dynaclr = { workspace = true }
 cytoland = { workspace = true }
 airtable-utils = { workspace = true }
-qc = { workspace = true }
+viscy-qc = { workspace = true }
 dynacell = { workspace = true }
 # cubic 0.7.0a9 (GPU-resident Cellpose-SAM eval API + FSC/FRC NaN fix) is not on
 # PyPI yet; pin the exact commit (reports 0.7.0a9, satisfies the ==0.7.0a9 pin).

--- a/uv.lock
+++ b/uv.lock
@@ -28,10 +28,10 @@ members = [
     "cytoland",
     "dynacell",
     "dynaclr",
-    "qc",
     "viscy",
     "viscy-data",
     "viscy-models",
+    "viscy-qc",
     "viscy-transforms",
     "viscy-utils",
 ]
@@ -1918,9 +1918,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -1928,9 +1926,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -1938,9 +1934,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -1948,18 +1942,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
-    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -1967,9 +1957,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -5234,46 +5222,6 @@ wheels = [
 ]
 
 [[package]]
-name = "qc"
-source = { editable = "applications/qc" }
-dependencies = [
-    { name = "airtable-utils" },
-    { name = "click" },
-    { name = "pydantic" },
-    { name = "viscy-utils" },
-    { name = "waveorder" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "airtable-utils", editable = "applications/airtable" },
-    { name = "click" },
-    { name = "pydantic" },
-    { name = "viscy-utils", editable = "packages/viscy-utils" },
-    { name = "waveorder", git = "https://github.com/mehta-lab/waveorder.git?branch=main" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-cov", specifier = ">=7" },
-]
-test = [
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-cov", specifier = ">=7" },
-]
-
-[[package]]
 name = "qtpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -6816,6 +6764,46 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.40" },
 ]
 provides-extras = ["celldiff"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7" },
+]
+test = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7" },
+]
+
+[[package]]
+name = "viscy-qc"
+source = { editable = "applications/qc" }
+dependencies = [
+    { name = "airtable-utils" },
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "viscy-utils" },
+    { name = "waveorder" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "airtable-utils", editable = "applications/airtable" },
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "viscy-utils", editable = "packages/viscy-utils" },
+    { name = "waveorder", git = "https://github.com/mehta-lab/waveorder.git?branch=main" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Add tag-driven PyPI release workflow

Publishing a GitHub Release now ships its package to PyPI. This replaces the manual `git tag` + local `uv build` workflow and has less footguns.

### How it works

`.github/workflows/release.yml` runs on `release: published`:

1. **Parse**: the tag prefix picks the package (`viscy-data-v*` -> `viscy-data`, just `v*` -> umbrella `viscy`). Packages version independently.
2. **Build**:  `uv build --sdist --wheel --no-sources`; the tag sets the version, so nothing in the code changes.
3. **Verify**: match the built sdist against the tag, catching the `0.0.0` fallback and any drift.
4. **Publish**:  over PyPI OIDC trusted publishing: short-lived per-run credentials, a per-package environment, no stored tokens, PEP 740 attestations.
5. **Attach**:  add the wheel and sdist to the Release.

### Docs

The **Release a package** section now documents this with web and `gh cli` instructions.

## Release setup (PyPI trusted publishing) 

### TODOs:

Trusted publishing matches on the workflow file, so `release.yml` must live on `main` before any publisher works.

### Steps

1. [ ] **Merge this PR**:  `release.yml` lands on the default branch.
2. [ ] **`viscy` (existing project:  normal publisher.**
   PyPI → `viscy` → *Manage → Settings → Publishing → Add a new publisher (GitHub)*.
3. [ ] **`viscy-data`, `viscy-models`, `viscy-transforms`, `viscy-utils` (new),  pending publishers.** PyPI -> *Account -> Publishing -> pending publishers -> Add a new pending publisher (GitHub)*, once per package.

#### Form values


Head to PyPI and go to [https://pypi.org/manage/account/publishing/](https://pypi.org/manage/account/publishing/). You will see a form to fill out that looks like the screenshot below:
<img width="956" height="1300" alt="Screenshot 2026-06-04 at 1 46 16 PM" src="https://github.com/user-attachments/assets/5371e6dc-efcb-420f-b95a-e39da9d29cf2" />

Every publisher takes the same fields, varying only the project and environment:

| Form field | `viscy` | `viscy-data` | `viscy-models` | `viscy-transforms` | `viscy-utils` |
|---|---|---|---|---|---|
| PyPI Project Name | `viscy` | `viscy-data` | `viscy-models` | `viscy-transforms` | `viscy-utils` |
| Owner | `mehta-lab` | `mehta-lab` | `mehta-lab` | `mehta-lab` | `mehta-lab` |
| Repository name | `VisCy` | `VisCy` | `VisCy` | `VisCy` | `VisCy` |
| Workflow name | `release.yml` | `release.yml` | `release.yml` | `release.yml` | `release.yml` |
| Environment name | `pypi-viscy` | `pypi-viscy-data` | `pypi-viscy-models` | `pypi-viscy-transforms` | `pypi-viscy-utils` |

#### Notes

- Fill **Environment name** even though the form marks it optional - `release.yml` sets `environment: pypi-<package>`, so the publisher must list the same name.
- Register the pending publishers from the account that should own the projects - the registrant owns whatever the first publish creates.



