### PR TITLE
feat(dynacell/eval): focus-aware 2D projection (in-focus slab + focus slice)

### DIFF
--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -159,6 +159,44 @@ For an A40 / single-GPU interactive node where you'd run serial anyway, this is 
 
 Tests: `applications/dynacell/tests/test_evaluation_grouped.py` validates byte-equal parity against sequential per-condition runs on the same cache-only fixture used by `test_evaluation_pipeline_parallel_cpu.py`, plus rejection cases for empty `conditions` and forbidden model-loading-field overrides.
 
+## Focus-aware 2D projection (`dynacell/evaluation/focus.py`)
+
+The 3D→2D reduction in eval is **focus-aware** so the projection isn't dominated by
+out-of-focus caps (A549 Z=48; the in-focus band is ~5 planes). Three knobs, all
+default-off (default behavior unchanged):
+
+- `feature_metrics.focus_slab.{enabled,halfwidth,channel_name}` — deep-feature crops
+  (`build_crops`) + `per_cell_similarity` max-project over a `2*halfwidth+1` slab
+  centered on the in-focus plane (h=2 → ±2 → 5 planes). CP regionprops stay 3D
+  (untagged). Enabling it folds `+focusslab_h{h}_{ch}` into each deep-feature
+  `preprocess_version` so embedding caches auto-invalidate.
+- `segmentation.slice_selection=focus` — 2D instance seg picks the in-focus plane
+  (single slice, no slab) vs the old `frac=0.30`.
+- `precompute-gt build.focus=true` — writes `focus_slice` zattrs (DynaCLR/qc schema)
+  to a **writable** GT store.
+
+**Plane source (precedence, in `resolve_focus_planes`):** (1) precomputed
+`focus_slice` zattrs in the store (iPSC `.zarr` fast path); (2) the
+`io.gt_cache_dir/focus_planes/<channel>/<pos>.json` cache; (3) compute from the
+`focus.{channel_name,na_det,lambda_ill,pixel_size,device}` phase channel + persist to
+that cache. **Compute-at-eval-time (3) is why focus works on the read-only published
+A549 `.ozx`** — they carry no zattrs and `pack_ozx` is not bit-reproducible, so we do
+NOT fork them; the plane is derived from the `Phase3D` already inside each store and
+the published bytes stay identical to AWS Open Data v1. The estimator is
+`waveorder.focus.focus_from_transverse_band` (NOT the `qc` app — keeps the dep graph
+`applications/ → packages/`); the zattrs writer uses `viscy_utils.meta_utils`.
+
+Heterogeneous T is real in the pooled A549 `.ozx` (positions differ in timepoint
+count); the per-position writer/resolver handle it (per-position `shape[0]`).
+
+**Re-eval campaign:** `tools/run_focus_campaign.slurm` + `tools/submit_focus_campaign.sh`
+run it two-phase to produce-then-hit the GT cache: phase 1 = the 4 `*_ipsc_trained`
+leaves (each touches its organelle's 3 A549 conditions + iPSC, so collectively they
+warm every GT cache), phase 2 = the other 16 leaves (`afterany` phase 1, read-only
+warm GT, fan out fully parallel, 2 evals/GPU, 12 h). Overrides: `glcm.enabled=true`,
+`focus_slab.enabled=true halfwidth=2`, `slice_selection=focus`,
+`force_recompute.final_metrics=true`.
+
 ## Predict submission modes
 
 `tools/submit_benchmark_batch.py` (and the `tools/predict_batch.sh` wrapper) covers three submission shapes. They are mutually exclusive — pick by parallelism shape, not by familiarity:

--- a/applications/dynacell/CLAUDE.md
+++ b/applications/dynacell/CLAUDE.md
@@ -168,8 +168,11 @@ default-off (default behavior unchanged):
 - `feature_metrics.focus_slab.{enabled,halfwidth,channel_name}` — deep-feature crops
   (`build_crops`) + `per_cell_similarity` max-project over a `2*halfwidth+1` slab
   centered on the in-focus plane (h=2 → ±2 → 5 planes). CP regionprops stay 3D
-  (untagged). Enabling it folds `+focusslab_h{h}_{ch}` into each deep-feature
-  `preprocess_version` so embedding caches auto-invalidate.
+  (untagged). Enabling it folds `+focusslab_h{h}_{ch}_{sig}` into each deep-feature
+  `preprocess_version` so embedding caches auto-invalidate — `{sig}` is a short hash of
+  the focus-compute params (`focus.{na_det,lambda_ill,pixel_size}`), so a focus-param
+  change also invalidates (the same params are recorded in the `slice_selection=focus`
+  instance-mask cache identity).
 - `segmentation.slice_selection=focus` — 2D instance seg picks the in-focus plane
   (single slice, no slab) vs the old `frac=0.30`.
 - `precompute-gt build.focus=true` — writes `focus_slice` zattrs (DynaCLR/qc schema)

--- a/applications/dynacell/pyproject.toml
+++ b/applications/dynacell/pyproject.toml
@@ -62,6 +62,10 @@ optional-dependencies.eval = [
   "torch-fidelity @ git+https://github.com/toshas/torch-fidelity.git@5e211a9",
   "tqdm",
   "transformers",
+  # In-focus z-plane estimation (focus_from_transverse_band) for focus_slice
+  # metadata; same estimator qc.FocusSliceMetric wraps, used here directly to
+  # avoid an applications/ -> applications/ (qc) dependency.
+  "waveorder",
 ]
 optional-dependencies.eval_gpu = [
   # CUDA-13 builds so cupy/cucim match torch's CUDA-13 stack (PyPI torch 2.12 is

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -31,8 +31,10 @@ segmentation:
   dimension: 2d        # 2d | 3d — instance backends only (3d = full-volume do_3D)
   slice_selection: frac    # frac | sharpest | focus — picks the 2d plane (dimension=2d)
   slice_fraction: 0.30     # fractional Z depth when slice_selection=frac
-  # slice_selection=focus reads the in-focus plane per FOV from the GT
-  # focus_slice zattrs (write via precompute-gt build.focus); single slice, no slab.
+  # slice_selection=focus picks the in-focus plane per FOV (single slice, no slab).
+  # The plane comes from precomputed focus_slice zattrs when present, else it is
+  # computed on the fly from the phase channel and cached in io.gt_cache_dir (so it
+  # works on read-only published .ozx). Estimator params live in the `focus:` block.
   focus_channel_name: Phase3D
   nuclei_channel_name: null  # GT-plate channel for watershed seeds (cellpose_watershed only)
   # Nucleus Cellpose-SAM params (the cellpose path + the cellpose_watershed seeds).
@@ -73,6 +75,19 @@ io:
                         # GT membrane (A549: membrane in CAAX_*.ozx, nuclei in H2B_*.ozx);
                         # positions are matched by name, so the stores must share FOV names.
   require_complete_cache: false  # if true, eval raises on configured cache misses instead of filling
+
+# Phase-channel focus-plane estimation, shared by the deep-feature slab
+# (feature_metrics.focus_slab) and instance-seg slice_selection=focus. The plane is
+# read from precomputed focus_slice zattrs when present, else computed on the fly from
+# this channel and cached in io.gt_cache_dir (so focus-aware eval runs on read-only
+# published .ozx without re-packing them). pixel_size defaults to the lateral spacing
+# (pixel_metrics.spacing[-1]); na_det/lambda_ill are the mantis acquisition defaults.
+focus:
+  channel_name: Phase3D
+  na_det: 1.35
+  lambda_ill: 0.450
+  pixel_size: null  # null -> pixel_metrics.spacing[-1]
+  device: cpu
 
 pixel_metrics:
   spacing: ???

--- a/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/eval.yaml
@@ -29,8 +29,11 @@ target_name: ???
 segmentation:
   backend: supermodel  # supermodel | cellpose (nucleus) | cellpose_watershed (whole-cell)
   dimension: 2d        # 2d | 3d — instance backends only (3d = full-volume do_3D)
-  slice_selection: frac    # frac | sharpest — picks the 2d plane (dimension=2d)
+  slice_selection: frac    # frac | sharpest | focus — picks the 2d plane (dimension=2d)
   slice_fraction: 0.30     # fractional Z depth when slice_selection=frac
+  # slice_selection=focus reads the in-focus plane per FOV from the GT
+  # focus_slice zattrs (write via precompute-gt build.focus); single slice, no slab.
+  focus_channel_name: Phase3D
   nuclei_channel_name: null  # GT-plate channel for watershed seeds (cellpose_watershed only)
   # Nucleus Cellpose-SAM params (the cellpose path + the cellpose_watershed seeds).
   cellpose:
@@ -91,6 +94,16 @@ feature_metrics:
       enabled: false
       levels: 32
       distances: [1]
+  # In-focus slab for the 2D deep-feature crops + per-cell similarity. When
+  # enabled, the max-Z projection is restricted to a band centered on the phase
+  # focus plane (read from focus_slice zattrs; write via precompute-gt build.focus)
+  # instead of the full stack — keeps the MIP off the out-of-focus caps. Slab is
+  # taken from GT and applied to the prediction (slice-by-slice). Does NOT affect
+  # CP regionprops (those stay 3D).
+  focus_slab:
+    enabled: false
+    halfwidth: 2          # 2*halfwidth+1 planes (h=1-2 ≈ 3-5 planes is the sweet spot)
+    channel_name: Phase3D
 
 # Feature extractor configuration — required only when compute_feature_metrics=true
 # (or when the corresponding precompute-gt build.* flag is set). Fields stay ???

--- a/applications/dynacell/src/dynacell/evaluation/_configs/precompute.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/precompute.yaml
@@ -13,16 +13,8 @@ build:
   celldino: true
   focus: false  # write focus_slice zattrs (in-focus plane per FOV) to the GT store
 
-# Phase-channel focus estimation (build.focus=true). Lets projection slabs be
-# centered on the in-focus plane instead of a fixed depth fraction. pixel_size
-# defaults to the lateral spacing (pixel_metrics.spacing[-1]); na_det/lambda_ill
-# are the mantis acquisition defaults — override per dataset.
-focus:
-  channel_name: Phase3D
-  na_det: 1.35
-  lambda_ill: 0.450
-  pixel_size: null  # null -> pixel_metrics.spacing[-1]
-  device: cpu
+# The focus-estimator params (channel_name / na_det / lambda_ill / pixel_size / device)
+# are inherited from eval.yaml's top-level `focus:` block; override there or on the CLI.
 
 # precompute-gt only fills the GT cache; no eval loop runs and no prediction
 # plate is read. These flags stay off by default so save_dir / pred_path are

--- a/applications/dynacell/src/dynacell/evaluation/_configs/precompute.yaml
+++ b/applications/dynacell/src/dynacell/evaluation/_configs/precompute.yaml
@@ -11,6 +11,18 @@ build:
   dinov3: true
   dynaclr: true
   celldino: true
+  focus: false  # write focus_slice zattrs (in-focus plane per FOV) to the GT store
+
+# Phase-channel focus estimation (build.focus=true). Lets projection slabs be
+# centered on the in-focus plane instead of a fixed depth fraction. pixel_size
+# defaults to the lateral spacing (pixel_metrics.spacing[-1]); na_det/lambda_ill
+# are the mantis acquisition defaults — override per dataset.
+focus:
+  channel_name: Phase3D
+  na_det: 1.35
+  lambda_ill: 0.450
+  pixel_size: null  # null -> pixel_metrics.spacing[-1]
+  device: cpu
 
 # precompute-gt only fills the GT cache; no eval loop runs and no prediction
 # plate is read. These flags stay off by default so save_dir / pred_path are

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -18,15 +18,51 @@ the dependency graph ``applications/ → packages/`` only.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 import torch
 from iohub.ngff import open_ome_zarr
+from omegaconf import DictConfig, OmegaConf
 from waveorder.focus import focus_from_transverse_band
 
 from viscy_utils.meta_utils import write_meta_field
 
 FOCUS_FIELD = "focus_slice"
 MIDBAND_FRACTIONS: tuple[float, float] = (0.125, 0.25)
+
+
+@dataclass(frozen=True)
+class FocusSlabConfig:
+    """Resolved ``feature_metrics.focus_slab`` settings (only when enabled).
+
+    Attributes
+    ----------
+    channel_name : str
+        GT phase channel whose ``focus_slice`` zattrs supply the focus plane.
+    halfwidth : int
+        Planes on each side of the focus plane; the slab spans
+        ``2*halfwidth + 1`` planes.
+    """
+
+    channel_name: str
+    halfwidth: int
+
+
+def read_focus_slab_config(config: DictConfig) -> FocusSlabConfig | None:
+    """Resolve ``feature_metrics.focus_slab`` from a config, or ``None`` when off.
+
+    Returns ``None`` when the block is absent or ``enabled`` is false (the
+    default), so every call site shares one source of truth for the toggle and
+    the ``channel_name`` / ``halfwidth`` defaults.
+    """
+    cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
+    if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
+        return None
+    return FocusSlabConfig(
+        channel_name=str(OmegaConf.select(cfg, "channel_name", default="Phase3D")),
+        halfwidth=int(OmegaConf.select(cfg, "halfwidth", default=2)),
+    )
 
 
 def estimate_focus_plane(

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -62,9 +62,15 @@ def read_focus_slab_config(config: DictConfig) -> FocusSlabConfig | None:
     cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
     if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
         return None
+    halfwidth = int(OmegaConf.select(cfg, "halfwidth", default=2))
+    if halfwidth < 0:
+        raise ValueError(
+            f"feature_metrics.focus_slab.halfwidth must be >= 0, got {halfwidth} "
+            "(a negative halfwidth yields an empty slab and crashes the max-Z projection)."
+        )
     return FocusSlabConfig(
         channel_name=str(OmegaConf.select(cfg, "channel_name", default="Phase3D")),
-        halfwidth=int(OmegaConf.select(cfg, "halfwidth", default=2)),
+        halfwidth=halfwidth,
     )
 
 

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -18,7 +18,10 @@ the dependency graph ``applications/ → packages/`` only.
 
 from __future__ import annotations
 
+import json
+import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -65,6 +68,52 @@ def read_focus_slab_config(config: DictConfig) -> FocusSlabConfig | None:
     )
 
 
+@dataclass(frozen=True)
+class FocusComputeConfig:
+    """Resolved ``focus`` block: physical params for computing the focus plane.
+
+    Shared by the deep-feature slab path and the instance-seg ``slice_selection=focus``
+    path so both estimate the plane identically. ``pixel_size`` defaults to the lateral
+    spacing (``pixel_metrics.spacing[-1]``); ``na_det`` / ``lambda_ill`` are the mantis
+    acquisition defaults.
+
+    Attributes
+    ----------
+    channel_name : str
+        Phase channel the focus plane is estimated from.
+    na_det, lambda_ill, pixel_size : float
+        Detection NA, illumination wavelength, object-space lateral pixel size.
+    device : str
+        Torch device for the estimator (``"cpu"`` or ``"cuda"``).
+    """
+
+    channel_name: str
+    na_det: float
+    lambda_ill: float
+    pixel_size: float
+    device: str
+
+
+def read_focus_compute_config(config: DictConfig, *, channel_name: str | None = None) -> FocusComputeConfig:
+    """Resolve the ``focus`` compute block, defaulting ``pixel_size`` to the lateral spacing.
+
+    ``channel_name`` overrides ``focus.channel_name`` (e.g. the instance path passes
+    ``segmentation.focus_channel_name``). Used for the eval-time compute-if-absent path,
+    so focus works on read-only published ``.ozx`` stores that carry no ``focus_slice``
+    zattrs (the plane is derived from the phase channel already inside the store).
+    """
+    pixel_size = OmegaConf.select(config, "focus.pixel_size", default=None)
+    if pixel_size is None:
+        pixel_size = float(config.pixel_metrics.spacing[-1])
+    return FocusComputeConfig(
+        channel_name=channel_name or str(OmegaConf.select(config, "focus.channel_name", default="Phase3D")),
+        na_det=float(OmegaConf.select(config, "focus.na_det", default=1.35)),
+        lambda_ill=float(OmegaConf.select(config, "focus.lambda_ill", default=0.450)),
+        pixel_size=float(pixel_size),
+        device=str(OmegaConf.select(config, "focus.device", default="cpu")),
+    )
+
+
 def estimate_focus_plane(
     zyx: np.ndarray, *, na_det: float, lambda_ill: float, pixel_size: float, device: str = "cpu"
 ) -> int:
@@ -94,45 +143,146 @@ def focus_slab_from_plane(z_focus: int, z_total: int, halfwidth: int) -> slice:
     return slice(max(0, z_focus - halfwidth), min(z_total, z_focus + halfwidth + 1))
 
 
-def build_focus_slabs(position, *, channel_name: str, halfwidth: int, t_count: int) -> list[slice]:
-    """Per-timepoint in-focus slabs for ``position`` from its ``focus_slice`` zattrs.
+def build_focus_slabs(
+    position,
+    *,
+    halfwidth: int,
+    t_count: int,
+    compute: FocusComputeConfig,
+    cache_dir: str | Path | None = None,
+    pos_name: str | None = None,
+) -> list[slice]:
+    """Per-timepoint in-focus slabs for ``position``, centered on the focus plane.
 
-    Reads the cached focus plane per timepoint (written by ``dynacell precompute-gt
-    build.focus=true``) and centers a ``2*halfwidth + 1`` plane slab on each. Raises
-    if the metadata is absent — fail loud rather than silently fall back to a
-    full-volume projection while ``focus_slab`` is enabled.
-
-    ``position`` is the **GT** position (``(T, C, Z, Y, X)``); the same slabs apply
-    to the prediction, which maps slice-by-slice.
+    The plane is resolved by :func:`resolve_focus_planes` (precomputed zattrs →
+    ``gt_cache_dir`` cache → compute-from-phase + cache), then a ``2*halfwidth + 1``
+    plane slab is centered on each. ``position`` is the **GT** position
+    (``(T, C, Z, Y, X)``); the same slabs apply to the prediction, which maps
+    slice-by-slice.
     """
     z_total = position.data.shape[2]
-    slabs: list[slice] = []
-    for t in range(t_count):
-        plane = read_focus_plane(position, channel_name, t)
-        if plane is None:
-            raise ValueError(
-                f"feature_metrics.focus_slab is enabled but no focus_slice[{channel_name!r}] "
-                "metadata exists at this GT position. Run `dynacell precompute-gt build.focus=true` "
-                "first, or set feature_metrics.focus_slab.enabled=false."
-            )
-        slabs.append(focus_slab_from_plane(plane, z_total, halfwidth))
-    return slabs
+    planes = resolve_focus_planes(position, t_count=t_count, compute=compute, cache_dir=cache_dir, pos_name=pos_name)
+    return [focus_slab_from_plane(plane, z_total, halfwidth) for plane in planes]
 
 
-def read_focus_plane(position, channel_name: str, t: int) -> int | None:
-    """Read the cached per-timepoint focus plane from a position's zattrs.
+def _planes_from_zattrs(position, channel_name: str, t_count: int) -> list[int] | None:
+    """Per-timepoint focus planes from a position's ``focus_slice`` zattrs, or ``None``.
 
-    Returns ``None`` when no ``focus_slice`` metadata exists for ``channel_name``
-    (caller falls back to a fixed-fraction plane). Mirrors the layout written by
-    :func:`write_focus_slice_metadata`.
+    Returns ``None`` when no ``focus_slice[channel_name]`` metadata exists (caller then
+    computes from the phase channel). Falls back to the dataset-mean plane for any
+    timepoint missing from ``per_timepoint`` (DynaCLR ``z_range="auto"`` interop).
     """
     focus_meta = position.zattrs.get(FOCUS_FIELD, {}).get(channel_name)
     if focus_meta is None:
         return None
-    per_t = focus_meta.get("per_timepoint")
-    if per_t is not None and str(t) in per_t:
-        return int(per_t[str(t)])
-    return int(round(focus_meta["dataset_statistics"]["z_focus_mean"]))
+    per_t = focus_meta.get("per_timepoint") or {}
+    fallback = focus_meta.get("dataset_statistics", {}).get("z_focus_mean")
+    planes: list[int] = []
+    for t in range(t_count):
+        if str(t) in per_t:
+            planes.append(int(per_t[str(t)]))
+        elif fallback is not None:
+            planes.append(int(round(fallback)))
+        else:
+            return None
+    return planes
+
+
+def _focus_cache_path(cache_dir: str | Path, channel_name: str, pos_name: str) -> Path:
+    """Per-position focus-plane cache file under ``<cache_dir>/focus_planes/<channel>/``."""
+    return Path(cache_dir) / "focus_planes" / channel_name / f"{pos_name.replace('/', '__')}.json"
+
+
+def _read_focus_cache(
+    cache_dir: str | Path,
+    channel_name: str,
+    pos_name: str,
+    t_count: int,
+    na_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+) -> list[int] | None:
+    """Read cached focus planes, or ``None`` on miss / param-mismatch / short cache."""
+    path = _focus_cache_path(cache_dir, channel_name, pos_name)
+    if not path.is_file():
+        return None
+    rec = json.loads(path.read_text())
+    params = rec.get("params", {})
+    if (params.get("na_det"), params.get("lambda_ill"), params.get("pixel_size")) != (na_det, lambda_ill, pixel_size):
+        return None
+    planes = rec.get("planes", [])
+    if len(planes) < t_count:
+        return None
+    return [int(p) for p in planes[:t_count]]
+
+
+def _write_focus_cache(
+    cache_dir: str | Path,
+    channel_name: str,
+    pos_name: str,
+    planes: list[int],
+    na_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+) -> None:
+    """Atomically persist focus planes (tmp + ``os.replace``) so parallel evals don't tear writes."""
+    path = _focus_cache_path(cache_dir, channel_name, pos_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "params": {"na_det": na_det, "lambda_ill": lambda_ill, "pixel_size": pixel_size},
+        "planes": [int(p) for p in planes],
+    }
+    tmp = path.with_suffix(f".json.tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, path)
+
+
+def resolve_focus_planes(
+    position,
+    *,
+    t_count: int,
+    compute: FocusComputeConfig,
+    cache_dir: str | Path | None = None,
+    pos_name: str | None = None,
+) -> list[int]:
+    """Per-timepoint focus planes for ``position``. Source precedence:
+
+    1. ``focus_slice`` zattrs in the store (precomputed by ``precompute-gt build.focus``;
+       DynaCLR-compatible) — the iPSC writable-store fast path,
+    2. the ``gt_cache_dir`` focus cache (computed-and-persisted) — lets focus-aware eval
+       run on **read-only published ``.ozx``** that carry no zattrs,
+    3. compute from the position's phase (``compute.channel_name``) volume + persist.
+
+    Computing from phase is cheap and deterministic, so (2)/(3) reproduce the same planes
+    anyone could derive from the published data — no need to fork the immutable store.
+    """
+    channel_name = compute.channel_name
+    planes = _planes_from_zattrs(position, channel_name, t_count)
+    if planes is not None:
+        return planes
+    if cache_dir is not None and pos_name is not None:
+        cached = _read_focus_cache(
+            cache_dir, channel_name, pos_name, t_count, compute.na_det, compute.lambda_ill, compute.pixel_size
+        )
+        if cached is not None:
+            return cached
+    channel_index = list(position.channel_names).index(channel_name)
+    tzyx = np.asarray(position.data[:, channel_index])
+    planes = [
+        estimate_focus_plane(
+            tzyx[t],
+            na_det=compute.na_det,
+            lambda_ill=compute.lambda_ill,
+            pixel_size=compute.pixel_size,
+            device=compute.device,
+        )
+        for t in range(t_count)
+    ]
+    if cache_dir is not None and pos_name is not None:
+        _write_focus_cache(
+            cache_dir, channel_name, pos_name, planes, compute.na_det, compute.lambda_ill, compute.pixel_size
+        )
+    return planes
 
 
 def write_focus_slice_metadata(

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -1,0 +1,158 @@
+"""In-focus z-slice detection and ``focus_slice`` metadata (DynaCLR-compatible).
+
+Centering a 2-D projection slab on the *in-focus* plane (instead of a fixed depth
+fraction) is what keeps a max-Z projection from being dominated by out-of-focus
+caps. The focal plane is estimated with
+:func:`waveorder.focus.focus_from_transverse_band` — the same midband
+spatial-frequency-power estimator that ``qc.FocusSliceMetric`` wraps — computed on
+the **phase** channel (the label-free VS input present in every GT store), so the
+plane is organelle-independent and shared by GT + prediction.
+
+The written ``focus_slice`` zattrs layout matches what DynaCLR's ``z_range="auto"``
+reads (``focus_slice[<channel>].dataset_statistics.z_focus_mean`` on the plate, plus
+``fov_statistics`` / ``per_timepoint`` per position), so the metadata is
+interoperable. The estimator and the zattrs writer are pulled from external/package
+deps (``waveorder``, ``viscy_utils``) — never from the ``qc`` application — to keep
+the dependency graph ``applications/ → packages/`` only.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from iohub.ngff import open_ome_zarr
+from waveorder.focus import focus_from_transverse_band
+
+from viscy_utils.meta_utils import write_meta_field
+
+FOCUS_FIELD = "focus_slice"
+MIDBAND_FRACTIONS: tuple[float, float] = (0.125, 0.25)
+
+
+def estimate_focus_plane(
+    zyx: np.ndarray, *, na_det: float, lambda_ill: float, pixel_size: float, device: str = "cpu"
+) -> int:
+    """Return the best-focus z index of a ``(Z, Y, X)`` volume.
+
+    Wraps :func:`waveorder.focus.focus_from_transverse_band` (midband
+    transverse-band power). ``na_det`` / ``lambda_ill`` / ``pixel_size`` are the
+    detection NA, illumination wavelength, and object-space pixel size (same
+    length units).
+    """
+    return int(
+        focus_from_transverse_band(
+            torch.as_tensor(np.asarray(zyx), device=device),
+            NA_det=na_det,
+            lambda_ill=lambda_ill,
+            pixel_size=pixel_size,
+            midband_fractions=MIDBAND_FRACTIONS,
+        )
+    )
+
+
+def focus_slab_from_plane(z_focus: int, z_total: int, halfwidth: int) -> slice:
+    """Return a ``slice`` of ``2*halfwidth + 1`` planes centered on ``z_focus``.
+
+    Clipped to ``[0, z_total)``. ``halfwidth=0`` selects the single focus plane.
+    """
+    return slice(max(0, z_focus - halfwidth), min(z_total, z_focus + halfwidth + 1))
+
+
+def build_focus_slabs(position, *, channel_name: str, halfwidth: int, t_count: int) -> list[slice]:
+    """Per-timepoint in-focus slabs for ``position`` from its ``focus_slice`` zattrs.
+
+    Reads the cached focus plane per timepoint (written by ``dynacell precompute-gt
+    build.focus=true``) and centers a ``2*halfwidth + 1`` plane slab on each. Raises
+    if the metadata is absent — fail loud rather than silently fall back to a
+    full-volume projection while ``focus_slab`` is enabled.
+
+    ``position`` is the **GT** position (``(T, C, Z, Y, X)``); the same slabs apply
+    to the prediction, which maps slice-by-slice.
+    """
+    z_total = position.data.shape[2]
+    slabs: list[slice] = []
+    for t in range(t_count):
+        plane = read_focus_plane(position, channel_name, t)
+        if plane is None:
+            raise ValueError(
+                f"feature_metrics.focus_slab is enabled but no focus_slice[{channel_name!r}] "
+                "metadata exists at this GT position. Run `dynacell precompute-gt build.focus=true` "
+                "first, or set feature_metrics.focus_slab.enabled=false."
+            )
+        slabs.append(focus_slab_from_plane(plane, z_total, halfwidth))
+    return slabs
+
+
+def read_focus_plane(position, channel_name: str, t: int) -> int | None:
+    """Read the cached per-timepoint focus plane from a position's zattrs.
+
+    Returns ``None`` when no ``focus_slice`` metadata exists for ``channel_name``
+    (caller falls back to a fixed-fraction plane). Mirrors the layout written by
+    :func:`write_focus_slice_metadata`.
+    """
+    focus_meta = position.zattrs.get(FOCUS_FIELD, {}).get(channel_name)
+    if focus_meta is None:
+        return None
+    per_t = focus_meta.get("per_timepoint")
+    if per_t is not None and str(t) in per_t:
+        return int(per_t[str(t)])
+    return int(round(focus_meta["dataset_statistics"]["z_focus_mean"]))
+
+
+def write_focus_slice_metadata(
+    plate_path: str,
+    *,
+    channel_name: str,
+    na_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+    device: str = "cpu",
+) -> dict:
+    """Compute per-(position, timepoint) focus planes and write ``focus_slice`` zattrs.
+
+    Mirrors ``qc.FocusSliceMetric`` + ``generate_qc_metadata``: writes
+    ``focus_slice[channel_name].dataset_statistics`` on the plate and
+    ``{fov_statistics, per_timepoint, dataset_statistics}`` on each position.
+
+    The store is opened ``mode="r+"`` — the target must be writable. Packed
+    ``.ozx`` stores are read-only; estimate against the unpacked OME-Zarr and
+    repackage, or run this on a writable copy.
+
+    Returns the dataset-level statistics dict.
+    """
+    with open_ome_zarr(plate_path, mode="r+") as plate:
+        channel_index = plate.channel_names.index(channel_name)
+        per_position: list[tuple[object, list[int]]] = []
+        all_planes: list[int] = []
+        for _, pos in plate.positions():
+            tzyx = np.asarray(pos.data[:, channel_index])
+            planes = [
+                estimate_focus_plane(
+                    tzyx[t], na_det=na_det, lambda_ill=lambda_ill, pixel_size=pixel_size, device=device
+                )
+                for t in range(tzyx.shape[0])
+            ]
+            per_position.append((pos, planes))
+            all_planes.extend(planes)
+
+        arr = np.asarray(all_planes, dtype=float)
+        dataset_stats = {
+            "z_focus_mean": float(arr.mean()),
+            "z_focus_std": float(arr.std()),
+            "z_focus_min": int(arr.min()),
+            "z_focus_max": int(arr.max()),
+        }
+        write_meta_field(plate, {"dataset_statistics": dataset_stats}, FOCUS_FIELD, channel_name)
+        for pos, planes in per_position:
+            a = np.asarray(planes, dtype=float)
+            write_meta_field(
+                pos,
+                {
+                    "fov_statistics": {"z_focus_mean": float(a.mean()), "z_focus_std": float(a.std())},
+                    "per_timepoint": {str(t): int(v) for t, v in enumerate(planes)},
+                    "dataset_statistics": dataset_stats,
+                },
+                FOCUS_FIELD,
+                channel_name,
+            )
+        return dataset_stats

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -18,6 +18,7 @@ the dependency graph ``applications/ → packages/`` only.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from dataclasses import dataclass
@@ -98,6 +99,24 @@ class FocusComputeConfig:
     lambda_ill: float
     pixel_size: float
     device: str
+
+    @property
+    def estimator_params(self) -> dict[str, float]:
+        """Physical params that change the estimated focus plane.
+
+        These belong in any cache identity that turns on focus: a change to
+        ``na_det`` / ``lambda_ill`` / ``pixel_size`` moves the in-focus plane, so a
+        cache keyed without them would silently reuse stale planes/slabs. The
+        ``channel_name`` is recorded separately by each identity, and ``device`` only
+        selects the torch backend for a deterministic arg-max — neither belongs here.
+        """
+        return {"na_det": self.na_det, "lambda_ill": self.lambda_ill, "pixel_size": self.pixel_size}
+
+    @property
+    def estimator_sig(self) -> str:
+        """Short, stable signature of :attr:`estimator_params` for string cache tags."""
+        raw = "_".join(f"{k}={v:g}" for k, v in self.estimator_params.items())
+        return hashlib.sha256(raw.encode()).hexdigest()[:8]
 
 
 def read_focus_compute_config(config: DictConfig, *, channel_name: str | None = None) -> FocusComputeConfig:

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -571,6 +571,7 @@ def per_cell_similarity(
     metrics: tuple[str, ...] = ("pcc",),
     reduce: tuple[str, ...] = ("mean", "median"),
     use_gpu: bool = True,
+    z_slab: slice | None = None,
 ) -> dict[str, float]:
     """Per-cell paired GT-vs-pred image similarity, reduced over cells.
 
@@ -585,12 +586,25 @@ def per_cell_similarity(
     than silently emitting all-NaN (or no) ``PerCell_*`` columns — a silent
     miss would hide a config typo and confuse the final-metrics cache gate,
     which keys off the expected ``PerCell_*`` columns.
+
+    Parameters
+    ----------
+    z_slab : slice or None
+        When provided, restrict the volume (and hence each cell's bbox + the
+        ``ssim`` max-Z projection) to this in-focus band of planes before
+        scoring. Mirrors :func:`build_crops`'s ``z_slab`` so the per-cell
+        similarity and the deep-feature embeddings see the same slab. ``None``
+        (default) uses the full stack — the legacy behavior.
     """
     _require_cubic()
     if not metrics or set(metrics) - {"pcc", "ssim"}:
         raise ValueError(f"cell_similarity.metrics must be a non-empty subset of {{'pcc', 'ssim'}}; got {metrics!r}")
     if not reduce or set(reduce) - {"mean", "median"}:
         raise ValueError(f"cell_similarity.reduce must be a non-empty subset of {{'mean', 'median'}}; got {reduce!r}")
+    if z_slab is not None:
+        predict_t = predict_t[z_slab]
+        target_t = target_t[z_slab]
+        cell_segmentation_t = cell_segmentation_t[z_slab]
     use_cuda = bool(use_gpu and torch.cuda.is_available())
     to_xp = ascupy if use_cuda else asnumpy
     pred = to_xp(predict_t)
@@ -686,24 +700,38 @@ def features_from_crops(crops, feature_extractor):
     return np.stack(feats, axis=0)
 
 
-def build_crops(image, cell_segmentation, patch_size):
+def build_crops(image, cell_segmentation, patch_size, *, z_slab: slice | None = None):
     """Compute the 2-D max-z projection + per-cell crops for one image.
 
     Shared by every deep-feature extractor in the eval pipeline so the
     max-projection, cell iteration, and crop construction run once per
     (FOV, timepoint) instead of once per backbone.
+
+    Parameters
+    ----------
+    z_slab : slice or None
+        When provided, restrict both the max-Z projection and the per-cell
+        label footprint to this band of planes — an in-focus slab centered on
+        the segmentation slice (see :func:`segmentation_whole_cell.focus_slab`).
+        Out-of-focus caps (e.g. A549's all-membrane top planes) are excluded so
+        the MIP is not dominated by them. ``None`` (default) projects the whole
+        stack — the legacy behavior.
     """
     if image.shape != cell_segmentation.shape:
         raise ValueError(f"Shape mismatch: image {image.shape} vs cell_segmentation {cell_segmentation.shape}")
+    if z_slab is not None:
+        image = image[z_slab]
+        cell_segmentation = cell_segmentation[z_slab]
     image_2d = _minmax_norm(np.max(image, axis=0))
     return _build_per_cell_crops_2d(image_2d, cell_segmentation, patch_size)
 
 
-def deep_features(image, cell_segmentation, feature_extractor, patch_size):
+def deep_features(image, cell_segmentation, feature_extractor, patch_size, *, z_slab: slice | None = None):
     """Per-cell deep embeddings for one image, shape ``(n_cells, feature_dim)``.
 
     Prefer :func:`build_crops` + :func:`features_from_crops` when the same
-    crops feed multiple extractors.
+    crops feed multiple extractors. ``z_slab`` is forwarded to
+    :func:`build_crops` (in-focus slab projection; ``None`` = full stack).
     """
-    crops = build_crops(image, cell_segmentation, patch_size)
+    crops = build_crops(image, cell_segmentation, patch_size, z_slab=z_slab)
     return features_from_crops(crops, feature_extractor)

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -499,6 +499,14 @@ def cp_regionprops(image, cell_segmentation, spacing, *, norm=None, glcm_cfg=Non
     glcm_enabled = bool(glcm_cfg.get("enabled", False))
     img = _robust_norm(image, norm.get("p_lo", 1.0), norm.get("p_hi", 99.0))
 
+    names = active_cp_feature_names(glcm_enabled)
+    # cuCIM's GPU regionprops_dict indexes results[0] on an empty list and raises
+    # IndexError when the label image has no regions, so short-circuit a no-cell
+    # FOV before any regionprops_table call. Some iPSC nucleus/membrane FOVs have
+    # an empty cleaned segmentation; er/mito FOVs always have cells.
+    if int(cell_segmentation.max()) == 0:
+        return np.empty((0, len(names)), dtype=float)
+
     use_cuda = bool(use_gpu and torch.cuda.is_available())
     if use_cuda:
         img = ascupy(img)
@@ -540,7 +548,6 @@ def cp_regionprops(image, cell_segmentation, spacing, *, norm=None, glcm_cfg=Non
     if glcm_enabled:
         columns.update(_per_cell_glcm(img, cell_segmentation, glcm_cfg))
 
-    names = active_cp_feature_names(glcm_enabled)
     if columns["intensity_mean"].shape[0] == 0:
         return np.empty((0, len(names)), dtype=float)
     return np.stack([np.asarray(columns[name], dtype=float) for name in names], axis=1)

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -712,7 +712,7 @@ def build_crops(image, cell_segmentation, patch_size, *, z_slab: slice | None = 
     z_slab : slice or None
         When provided, restrict both the max-Z projection and the per-cell
         label footprint to this band of planes — an in-focus slab centered on
-        the segmentation slice (see :func:`segmentation_whole_cell.focus_slab`).
+        the GT phase focus plane (see :func:`focus.build_focus_slabs`).
         Out-of-focus caps (e.g. A549's all-membrane top planes) are excluded so
         the MIP is not dominated by them. ``None`` (default) projects the whole
         stack — the legacy behavior.

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -71,6 +71,25 @@ from dynacell.evaluation.runtime import (
 from dynacell.evaluation.utils import plot_metrics
 
 
+def _build_focus_slabs_map(config: DictConfig, gt_positions) -> dict[str, list[slice | None]] | None:
+    """Per-FOV in-focus slabs keyed by GT position name, or ``None`` when disabled.
+
+    Used to feed the batched deep-feature warm pass the same GT-derived slabs the
+    per-FOV path uses (so the warm cache is not poisoned with full-stack MIPs).
+    """
+    cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
+    if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
+        return None
+    from dynacell.evaluation.focus import build_focus_slabs
+
+    channel_name = str(OmegaConf.select(cfg, "channel_name", default="Phase3D"))
+    halfwidth = int(OmegaConf.select(cfg, "halfwidth", default=2))
+    return {
+        name: build_focus_slabs(pos, channel_name=channel_name, halfwidth=halfwidth, t_count=pos.data.shape[0])
+        for name, pos in gt_positions
+    }
+
+
 def _zscore_per_side(pred: np.ndarray, target: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Per-side z-score: separate (mean, std) computed for each matrix."""
     pred_z = (pred - pred.mean(axis=0)) / (pred.std(axis=0) + 1e-8)
@@ -120,25 +139,46 @@ def _fov_pred_features_per_t(
     celldino_feature_extractor,
     patch_size: int,
     spacing,
+    z_slabs: list[slice | None] | None = None,
 ) -> dict[str, list[np.ndarray] | None]:
     """Return per-backbone per-t prediction features.
 
     Uses the pred cache when configured; otherwise computes fresh
     per-timepoint, sharing one set of 2-D crops across all deep backbones
     to avoid redundant max-projection + crop construction per backbone.
+    ``z_slabs`` (GT-derived per-timepoint in-focus slabs) restricts the crop
+    projection; ``None`` = full stack.
     """
     if pred_cache_ctx.enabled:
         return {
             "cp": fov_cp_features(pred_cache_ctx, pos_name, predict, cell_segmentation),
             "dinov3": fov_deep_features(
-                pred_cache_ctx, pos_name, predict, cell_segmentation, dinov3_feature_extractor, "dinov3"
+                pred_cache_ctx,
+                pos_name,
+                predict,
+                cell_segmentation,
+                dinov3_feature_extractor,
+                "dinov3",
+                z_slabs=z_slabs,
             ),
             "dynaclr": fov_deep_features(
-                pred_cache_ctx, pos_name, predict, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
+                pred_cache_ctx,
+                pos_name,
+                predict,
+                cell_segmentation,
+                dynaclr_feature_extractor,
+                "dynaclr",
+                z_slabs=z_slabs,
             ),
             "celldino": (
                 fov_deep_features(
-                    pred_cache_ctx, pos_name, predict, cell_segmentation, celldino_feature_extractor, "celldino"
+                    pred_cache_ctx,
+                    pos_name,
+                    predict,
+                    cell_segmentation,
+                    celldino_feature_extractor,
+                    "celldino",
+                    z_slabs=z_slabs,
                 )
                 if celldino_feature_extractor is not None
                 else None
@@ -164,7 +204,9 @@ def _fov_pred_features_per_t(
                 use_gpu=use_gpu,
             )
         )
-        crops_t = build_crops(predict[t], cell_segmentation[t], patch_size)
+        crops_t = build_crops(
+            predict[t], cell_segmentation[t], patch_size, z_slab=None if z_slabs is None else z_slabs[t]
+        )
         dinov3.append(features_from_crops(crops_t, dinov3_feature_extractor))
         dynaclr.append(features_from_crops(crops_t, dynaclr_feature_extractor))
         if celldino is not None:
@@ -451,6 +493,7 @@ def _process_one_fov(
     ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
     paths in ``evaluate_predictions``.
     """
+    from dynacell.evaluation.focus import build_focus_slabs, read_focus_plane
     from dynacell.evaluation.instance_metrics import instance_average_precision
     from dynacell.evaluation.segmentation import segment
     from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
@@ -484,6 +527,21 @@ def _process_one_fov(
 
     T = predict.shape[0]
 
+    # In-focus slab for the 2D deep-feature crops + per-cell similarity (off by
+    # default). Computed once from the GT phase focus plane (focus_slice zattrs,
+    # written by precompute-gt build.focus) and shared with the prediction
+    # (slice-by-slice); None per t means full-stack projection. Does not touch CP.
+    focus_slab_cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
+    if focus_slab_cfg is not None and bool(OmegaConf.select(focus_slab_cfg, "enabled", default=False)):
+        z_slabs: list[slice | None] = build_focus_slabs(
+            pos_gt,
+            channel_name=str(OmegaConf.select(focus_slab_cfg, "channel_name", default="Phase3D")),
+            halfwidth=int(OmegaConf.select(focus_slab_cfg, "halfwidth", default=2)),
+            t_count=T,
+        )
+    else:
+        z_slabs = [None] * T
+
     # Mask path: when compute_instance_ap is set, the binary fov_masks path is
     # replaced by an instance-label path (nucleus or whole-cell). gt_cells /
     # pred_cells are (T, D, H, W) uint16 instance labels; the binary mask metrics
@@ -501,8 +559,20 @@ def _process_one_fov(
             target_cells, predict_cells = target, predict
         else:
             sel = OmegaConf.select(config, "segmentation.slice_selection", default="frac")
-            frac = float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30))
-            z_idx = [slice_index(target[t], selection=sel, fraction=frac) for t in range(T)]
+            if sel == "focus":
+                # Single in-focus plane from the GT phase focus_slice metadata
+                # (write via precompute-gt build.focus). Same z applied to GT,
+                # prediction, and nuclei seeds — still 2D, no slab.
+                focus_ch = str(OmegaConf.select(config, "segmentation.focus_channel_name", default="Phase3D"))
+                z_idx = [read_focus_plane(pos_gt, focus_ch, t) for t in range(T)]
+                if any(z is None for z in z_idx):
+                    raise ValueError(
+                        f"segmentation.slice_selection='focus' needs focus_slice[{focus_ch!r}] metadata in the GT "
+                        "store; run `dynacell precompute-gt build.focus=true` first."
+                    )
+            else:
+                frac = float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30))
+                z_idx = [slice_index(target[t], selection=sel, fraction=frac) for t in range(T)]
             target_cells = np.stack([target[t, z_idx[t]] for t in range(T)])  # (T, Y, X)
             predict_cells = np.stack([predict[t, z_idx[t]] for t in range(T)])
         if backend == "cellpose_watershed":
@@ -562,11 +632,23 @@ def _process_one_fov(
             gt_cp_per_t = fov_cp_features(cache_ctx, pos_name_pred, target, cell_segmentation)
         with region_timer("deep_gt_dinov3", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             gt_dinov3_per_t = fov_deep_features(
-                cache_ctx, pos_name_pred, target, cell_segmentation, dinov3_feature_extractor, "dinov3"
+                cache_ctx,
+                pos_name_pred,
+                target,
+                cell_segmentation,
+                dinov3_feature_extractor,
+                "dinov3",
+                z_slabs=z_slabs,
             )
         with region_timer("deep_gt_dynaclr", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             gt_dynaclr_per_t = fov_deep_features(
-                cache_ctx, pos_name_pred, target, cell_segmentation, dynaclr_feature_extractor, "dynaclr"
+                cache_ctx,
+                pos_name_pred,
+                target,
+                cell_segmentation,
+                dynaclr_feature_extractor,
+                "dynaclr",
+                z_slabs=z_slabs,
             )
         if celldino_feature_extractor is not None:
             with region_timer("deep_gt_celldino", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
@@ -577,6 +659,7 @@ def _process_one_fov(
                     cell_segmentation,
                     celldino_feature_extractor,
                     "celldino",
+                    z_slabs=z_slabs,
                 )
         with region_timer("features_pred_per_t", pos_name_pred), gpu_serialization_lock(gate=use_gpu):
             pred_per_t = _fov_pred_features_per_t(
@@ -589,6 +672,7 @@ def _process_one_fov(
                 celldino_feature_extractor,
                 config.feature_metrics.patch_size,
                 config.pixel_metrics.spacing,
+                z_slabs=z_slabs,
             )
 
     microssim_data: list[dict] = []
@@ -638,6 +722,7 @@ def _process_one_fov(
                         metrics=cell_sim_metrics,
                         reduce=cell_sim_reduce,
                         use_gpu=use_gpu,
+                        z_slab=z_slabs[t],
                     )
                 )
         if config.compute_microssim:
@@ -1139,6 +1224,11 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
                     side_positions["pred"] = pred_positions
                     side_channels["pred"] = io_config.pred_channel_name
                 if sides_for_precompute:
+                    # In-focus slabs (GT-derived, keyed by pos_name) so the
+                    # batched warm pass builds the same slab crops the per-FOV
+                    # path expects — else the cache would be poisoned with
+                    # full-stack MIPs under the focus_slab cache key.
+                    focus_slabs = _build_focus_slabs_map(config, gt_positions)
                     with region_timer("precompute_all", "<parent>"):
                         precompute_deep_features(
                             sides_for_precompute,
@@ -1147,6 +1237,7 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
                             seg_positions,
                             deep_extractors,
                             flush_threshold=flush_threshold,
+                            focus_slabs=focus_slabs,
                         )
                         for ctx in sides_for_precompute.values():
                             flush_manifest(ctx)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -77,15 +77,15 @@ def _build_focus_slabs_map(config: DictConfig, gt_positions) -> dict[str, list[s
     Used to feed the batched deep-feature warm pass the same GT-derived slabs the
     per-FOV path uses (so the warm cache is not poisoned with full-stack MIPs).
     """
-    cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
-    if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
-        return None
-    from dynacell.evaluation.focus import build_focus_slabs
+    from dynacell.evaluation.focus import build_focus_slabs, read_focus_slab_config
 
-    channel_name = str(OmegaConf.select(cfg, "channel_name", default="Phase3D"))
-    halfwidth = int(OmegaConf.select(cfg, "halfwidth", default=2))
+    slab_cfg = read_focus_slab_config(config)
+    if slab_cfg is None:
+        return None
     return {
-        name: build_focus_slabs(pos, channel_name=channel_name, halfwidth=halfwidth, t_count=pos.data.shape[0])
+        name: build_focus_slabs(
+            pos, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=pos.data.shape[0]
+        )
         for name, pos in gt_positions
     }
 
@@ -493,7 +493,7 @@ def _process_one_fov(
     ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
     paths in ``evaluate_predictions``.
     """
-    from dynacell.evaluation.focus import build_focus_slabs, read_focus_plane
+    from dynacell.evaluation.focus import build_focus_slabs, read_focus_plane, read_focus_slab_config
     from dynacell.evaluation.instance_metrics import instance_average_precision
     from dynacell.evaluation.segmentation import segment
     from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
@@ -531,13 +531,10 @@ def _process_one_fov(
     # default). Computed once from the GT phase focus plane (focus_slice zattrs,
     # written by precompute-gt build.focus) and shared with the prediction
     # (slice-by-slice); None per t means full-stack projection. Does not touch CP.
-    focus_slab_cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
-    if focus_slab_cfg is not None and bool(OmegaConf.select(focus_slab_cfg, "enabled", default=False)):
+    slab_cfg = read_focus_slab_config(config)
+    if slab_cfg is not None:
         z_slabs: list[slice | None] = build_focus_slabs(
-            pos_gt,
-            channel_name=str(OmegaConf.select(focus_slab_cfg, "channel_name", default="Phase3D")),
-            halfwidth=int(OmegaConf.select(focus_slab_cfg, "halfwidth", default=2)),
-            t_count=T,
+            pos_gt, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=T
         )
     else:
         z_slabs = [None] * T

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -77,14 +77,16 @@ def _build_focus_slabs_map(config: DictConfig, gt_positions) -> dict[str, list[s
     Used to feed the batched deep-feature warm pass the same GT-derived slabs the
     per-FOV path uses (so the warm cache is not poisoned with full-stack MIPs).
     """
-    from dynacell.evaluation.focus import build_focus_slabs, read_focus_slab_config
+    from dynacell.evaluation.focus import build_focus_slabs, read_focus_compute_config, read_focus_slab_config
 
     slab_cfg = read_focus_slab_config(config)
     if slab_cfg is None:
         return None
+    fc = read_focus_compute_config(config, channel_name=slab_cfg.channel_name)
+    cache_dir = OmegaConf.select(config, "io.gt_cache_dir", default=None)
     return {
         name: build_focus_slabs(
-            pos, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=pos.data.shape[0]
+            pos, halfwidth=slab_cfg.halfwidth, t_count=pos.data.shape[0], compute=fc, cache_dir=cache_dir, pos_name=name
         )
         for name, pos in gt_positions
     }
@@ -493,7 +495,12 @@ def _process_one_fov(
     ``_aggregate_fov_result``. Used by both the serial and process FOV-loop
     paths in ``evaluate_predictions``.
     """
-    from dynacell.evaluation.focus import build_focus_slabs, read_focus_plane, read_focus_slab_config
+    from dynacell.evaluation.focus import (
+        build_focus_slabs,
+        read_focus_compute_config,
+        read_focus_slab_config,
+        resolve_focus_planes,
+    )
     from dynacell.evaluation.instance_metrics import instance_average_precision
     from dynacell.evaluation.segmentation import segment
     from dynacell.evaluation.segmentation_cellpose import segment_nucleus_instances
@@ -533,8 +540,14 @@ def _process_one_fov(
     # (slice-by-slice); None per t means full-stack projection. Does not touch CP.
     slab_cfg = read_focus_slab_config(config)
     if slab_cfg is not None:
+        fc = read_focus_compute_config(config, channel_name=slab_cfg.channel_name)
         z_slabs: list[slice | None] = build_focus_slabs(
-            pos_gt, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=T
+            pos_gt,
+            halfwidth=slab_cfg.halfwidth,
+            t_count=T,
+            compute=fc,
+            cache_dir=OmegaConf.select(config, "io.gt_cache_dir", default=None),
+            pos_name=pos_name_pred,
         )
     else:
         z_slabs = [None] * T
@@ -557,16 +570,19 @@ def _process_one_fov(
         else:
             sel = OmegaConf.select(config, "segmentation.slice_selection", default="frac")
             if sel == "focus":
-                # Single in-focus plane from the GT phase focus_slice metadata
-                # (write via precompute-gt build.focus). Same z applied to GT,
-                # prediction, and nuclei seeds — still 2D, no slab.
+                # Single in-focus plane per FOV (still 2D, no slab). Same z applied to
+                # GT, prediction, and nuclei seeds. From precomputed focus_slice zattrs
+                # when present, else computed from the phase channel and cached in
+                # io.gt_cache_dir — so it works on read-only published .ozx.
                 focus_ch = str(OmegaConf.select(config, "segmentation.focus_channel_name", default="Phase3D"))
-                z_idx = [read_focus_plane(pos_gt, focus_ch, t) for t in range(T)]
-                if any(z is None for z in z_idx):
-                    raise ValueError(
-                        f"segmentation.slice_selection='focus' needs focus_slice[{focus_ch!r}] metadata in the GT "
-                        "store; run `dynacell precompute-gt build.focus=true` first."
-                    )
+                fc = read_focus_compute_config(config, channel_name=focus_ch)
+                z_idx = resolve_focus_planes(
+                    pos_gt,
+                    t_count=T,
+                    compute=fc,
+                    cache_dir=OmegaConf.select(config, "io.gt_cache_dir", default=None),
+                    pos_name=pos_name_pred,
+                )
             else:
                 frac = float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30))
                 z_idx = [slice_index(target[t], selection=sel, fraction=frac) for t in range(T)]
@@ -1514,7 +1530,15 @@ def save_metrics(config: DictConfig, pixel_metrics=None, mask_metrics=None, feat
 
 
 def _final_metrics_cache_valid(config: DictConfig) -> bool:
-    """Return True when the saved CSV/NPY caches can be reused."""
+    """Return True when the saved CSV/NPY caches can be reused.
+
+    Note: this check validates column *presence*, not the projection that produced
+    the values. ``feature_metrics.focus_slab`` changes PerCell/feature values without
+    changing columns, so toggling it on a save_dir that already holds full-stack
+    metrics requires ``force_recompute.final_metrics=true`` to refresh (every focus
+    campaign launcher passes it). Encoding a focus signature into the saved rows would
+    let this auto-detect — a follow-up.
+    """
     force = config.force_recompute
     if force.all or force.final_metrics:
         return False

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -85,6 +85,7 @@ class _CacheContext:
     slice_fraction: float = 0.30
     focus_channel_name: str | None = None
     focus_slab_enabled: bool = False
+    focus_estimator_params: dict[str, float] = field(default_factory=dict)
     nuclei_channel_name: str | None = None
     nuclei_plate_path: str | None = None
     iou_thresholds: list[float] = field(default_factory=lambda: list(DEFAULT_IOU_THRESHOLDS))
@@ -230,14 +231,29 @@ def init_cache_context(
     # preprocess_version — a toggle then auto-invalidates the deep caches via
     # _auto_invalidate_on_preprocess_version_mismatch. CP stays 3D, so its
     # identity is intentionally NOT tagged.
-    from dynacell.evaluation.focus import read_focus_slab_config
+    #
+    # The slab (and the slice_selection=focus instance plane) sit on the focus plane
+    # estimated from focus.{na_det,lambda_ill,pixel_size}; changing those params moves
+    # the plane, so fold the estimator signature into the deep tag and the resolved
+    # params onto the context (consumed by _instance_identity). Both are channel-
+    # independent, so one resolve covers both paths.
+    from dynacell.evaluation.focus import read_focus_compute_config, read_focus_slab_config
 
     slab_cfg = read_focus_slab_config(config)
-    if slab_cfg is not None:
-        focus_tag = f"+focusslab_h{slab_cfg.halfwidth}_{slab_cfg.channel_name}"
-        dinov3_preprocess_version = (dinov3_preprocess_version + focus_tag) if dinov3_preprocess_version else None
-        dynaclr_preprocess_version = (dynaclr_preprocess_version + focus_tag) if dynaclr_preprocess_version else None
-        celldino_preprocess_version = (celldino_preprocess_version + focus_tag) if celldino_preprocess_version else None
+    slice_selection = OmegaConf.select(config, "segmentation.slice_selection", default="frac")
+    focus_estimator_params: dict[str, float] = {}
+    if slab_cfg is not None or slice_selection == "focus":
+        fc = read_focus_compute_config(config)
+        focus_estimator_params = fc.estimator_params
+        if slab_cfg is not None:
+            focus_tag = f"+focusslab_h{slab_cfg.halfwidth}_{slab_cfg.channel_name}_{fc.estimator_sig}"
+            dinov3_preprocess_version = (dinov3_preprocess_version + focus_tag) if dinov3_preprocess_version else None
+            dynaclr_preprocess_version = (
+                (dynaclr_preprocess_version + focus_tag) if dynaclr_preprocess_version else None
+            )
+            celldino_preprocess_version = (
+                (celldino_preprocess_version + focus_tag) if celldino_preprocess_version else None
+            )
     # The GT nuclei seeds (cellpose_watershed) come from io.nuclei_gt_path when set
     # (a separate store, e.g. A549 H2B_*.ozx), else from the GT membrane plate
     # (io.gt_path, e.g. iPSC cell.zarr). Record the actual source in the cache
@@ -256,10 +272,11 @@ def init_cache_context(
         backend=OmegaConf.select(config, "segmentation.backend", default="supermodel"),
         compute_instance_ap=bool(OmegaConf.select(config, "compute_instance_ap", default=False)),
         dimension=OmegaConf.select(config, "segmentation.dimension", default="2d"),
-        slice_selection=OmegaConf.select(config, "segmentation.slice_selection", default="frac"),
+        slice_selection=slice_selection,
         slice_fraction=float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30)),
         focus_channel_name=OmegaConf.select(config, "segmentation.focus_channel_name", default=None),
         focus_slab_enabled=slab_cfg is not None,
+        focus_estimator_params=focus_estimator_params,
         nuclei_channel_name=OmegaConf.select(config, "segmentation.nuclei_channel_name", default=None),
         nuclei_plate_path=str(nuclei_plate_path) if nuclei_plate_path is not None else None,
         iou_thresholds=list(
@@ -732,9 +749,12 @@ def _instance_identity(ctx: _CacheContext) -> dict[str, Any]:
     }
     # slice_selection='focus' picks the 2D plane from this channel's focus estimate,
     # so it must be part of the identity (only when active, to leave frac/sharpest
-    # identities byte-stable). Analog of the backend fix in #445.
+    # identities byte-stable). Analog of the backend fix in #445. The plane also
+    # depends on the focus-compute params (na_det/lambda_ill/pixel_size), so record
+    # them too — otherwise a focus-param change reuses a stale in-focus plane.
     if ctx.slice_selection == "focus":
         identity["focus_channel_name"] = ctx.focus_channel_name
+        identity.update({f"focus_{k}": v for k, v in ctx.focus_estimator_params.items()})
     if ctx.backend == "cellpose_watershed":
         # Whole-cell labels also depend on the watershed params and the GT nuclei
         # seeds; record the GT nuclei (path, channel) so a pred-side identity

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -83,6 +83,8 @@ class _CacheContext:
     dimension: str = "2d"
     slice_selection: str = "frac"
     slice_fraction: float = 0.30
+    focus_channel_name: str | None = None
+    focus_slab_enabled: bool = False
     nuclei_channel_name: str | None = None
     nuclei_plate_path: str | None = None
     iou_thresholds: list[float] = field(default_factory=lambda: list(DEFAULT_IOU_THRESHOLDS))
@@ -256,6 +258,8 @@ def init_cache_context(
         dimension=OmegaConf.select(config, "segmentation.dimension", default="2d"),
         slice_selection=OmegaConf.select(config, "segmentation.slice_selection", default="frac"),
         slice_fraction=float(OmegaConf.select(config, "segmentation.slice_fraction", default=0.30)),
+        focus_channel_name=OmegaConf.select(config, "segmentation.focus_channel_name", default=None),
+        focus_slab_enabled=slab_cfg is not None,
         nuclei_channel_name=OmegaConf.select(config, "segmentation.nuclei_channel_name", default=None),
         nuclei_plate_path=str(nuclei_plate_path) if nuclei_plate_path is not None else None,
         iou_thresholds=list(
@@ -339,7 +343,10 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
     Missing tags (cached manifest pre-dates version tracking, or the kind
     isn't loaded for this run) are treated as "no constraint" — they do
     NOT trigger invalidation. Operators handle that bootstrap transition
-    explicitly via ``force_recompute.<side>_<kind>``.
+    explicitly via ``force_recompute.<side>_<kind>``. The one exception:
+    when ``ctx.focus_slab_enabled`` is set, an untagged entry is full-stack
+    crops that would be silently reused as focus-projected, so it IS
+    invalidated.
 
     Under ``io.require_complete_cache=true`` a known mismatch is escalated
     to a hard :class:`StaleCacheError` — the user opted out of recompute,
@@ -374,7 +381,13 @@ def _auto_invalidate_on_preprocess_version_mismatch(ctx: _CacheContext) -> None:
         if entry is None:
             continue
         cached_version = entry.get("preprocess_version")
-        if cached_version is None or cached_version == current_version:
+        if cached_version == current_version:
+            continue
+        # Pre-version-tracking entries (cached_version is None) are normally "no
+        # constraint" (bootstrap). Exception: when focus_slab is enabled this run,
+        # an untagged entry holds full-stack crops that must NOT be reused as if
+        # focus-projected — fall through to invalidation.
+        if cached_version is None and not ctx.focus_slab_enabled:
             continue
         if ctx.require_complete:
             raise StaleCacheError(
@@ -717,6 +730,11 @@ def _instance_identity(ctx: _CacheContext) -> dict[str, Any]:
         "slice_fraction": ctx.slice_fraction,
         **ctx.source_tag,
     }
+    # slice_selection='focus' picks the 2D plane from this channel's focus estimate,
+    # so it must be part of the identity (only when active, to leave frac/sharpest
+    # identities byte-stable). Analog of the backend fix in #445.
+    if ctx.slice_selection == "focus":
+        identity["focus_channel_name"] = ctx.focus_channel_name
     if ctx.backend == "cellpose_watershed":
         # Whole-cell labels also depend on the watershed params and the GT nuclei
         # seeds; record the GT nuclei (path, channel) so a pred-side identity

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -222,6 +222,21 @@ def init_cache_context(
     watershed_cfg = OmegaConf.select(config, "segmentation.watershed", default=None)
     cp_norm_cfg = OmegaConf.select(config, "feature_metrics.cp.norm", default=None)
     cp_glcm_cfg = OmegaConf.select(config, "feature_metrics.cp.glcm", default=None)
+
+    # When focus_slab is enabled the deep-feature crops project over an in-focus
+    # slab (not the full stack), so fold its signature into each extractor's
+    # preprocess_version — a toggle then auto-invalidates the deep caches via
+    # _auto_invalidate_on_preprocess_version_mismatch. CP stays 3D, so its
+    # identity is intentionally NOT tagged.
+    focus_slab_cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
+    if focus_slab_cfg is not None and bool(OmegaConf.select(focus_slab_cfg, "enabled", default=False)):
+        focus_tag = (
+            f"+focusslab_h{int(OmegaConf.select(focus_slab_cfg, 'halfwidth', default=2))}"
+            f"_{OmegaConf.select(focus_slab_cfg, 'channel_name', default='Phase3D')}"
+        )
+        dinov3_preprocess_version = (dinov3_preprocess_version + focus_tag) if dinov3_preprocess_version else None
+        dynaclr_preprocess_version = (dynaclr_preprocess_version + focus_tag) if dynaclr_preprocess_version else None
+        celldino_preprocess_version = (celldino_preprocess_version + focus_tag) if celldino_preprocess_version else None
     # The GT nuclei seeds (cellpose_watershed) come from io.nuclei_gt_path when set
     # (a separate store, e.g. A549 H2B_*.ozx), else from the GT membrane plate
     # (io.gt_path, e.g. iPSC cell.zarr). Record the actual source in the cache
@@ -1027,19 +1042,28 @@ def fov_deep_features(
     cell_segmentation_arr: np.ndarray,
     feature_extractor,
     kind: FeatureKind,
+    *,
+    z_slabs: list[slice | None] | None = None,
 ) -> list[np.ndarray]:
     """Return per-cell deep embeddings per timepoint for one FOV.
 
     The cache side is taken from ``ctx.side``. ``kind`` is ``"dinov3"``,
     ``"dynaclr"``, or ``"celldino"``; the cache key (model name or
-    checkpoint/weights hash) is pulled from *ctx*.
+    checkpoint/weights hash) is pulled from *ctx*. ``z_slabs`` (per-timepoint
+    in-focus slabs, GT-derived) restricts the projection; ``None`` = full stack.
     """
     return _fov_deep_features(
         ctx,
         pos_name=pos_name,
         image_arr=image_arr,
         kind=kind,
-        compute_fn=lambda t: deep_features(image_arr[t], cell_segmentation_arr[t], feature_extractor, ctx.patch_size),
+        compute_fn=lambda t: deep_features(
+            image_arr[t],
+            cell_segmentation_arr[t],
+            feature_extractor,
+            ctx.patch_size,
+            z_slab=None if z_slabs is None else z_slabs[t],
+        ),
     )
 
 
@@ -1357,8 +1381,14 @@ def precompute_deep_features(
     extractors: dict[FeatureKind, Any],
     *,
     flush_threshold: int = 256,
+    focus_slabs: dict[str, list[slice | None]] | None = None,
 ) -> None:
     """Batched precompute of deep features across all FOVs/timepoints.
+
+    ``focus_slabs`` maps ``pos_name`` to a per-timepoint in-focus slab list
+    (GT-derived, shared by every side); when provided, crops are projected over
+    that slab instead of the full stack. ``None`` (or a missing pos_name) =
+    full-stack projection.
 
     Iterates positions in lockstep across the configured sides, loads
     ``cell_seg`` once per position (shared across sides), loads each side's
@@ -1456,8 +1486,11 @@ def precompute_deep_features(
             ts_needed = work["ts_needed"]
             channel_index = pos.get_channel_index(side_channel_names[side])
             image = np.asarray(pos.data[:, channel_index])
+            pos_slabs = None if focus_slabs is None else focus_slabs.get(pos_name)
             for t in ts_needed:
-                crops = build_crops(image[t], cell_seg[t], ctx.patch_size)
+                crops = build_crops(
+                    image[t], cell_seg[t], ctx.patch_size, z_slab=None if pos_slabs is None else pos_slabs[t]
+                )
                 kinds_for_t = [k for k in extractors if t in needs[k]]
                 batchers[side].push(pos_name, t, crops, kinds_for_t)
 

--- a/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline_cache.py
@@ -228,12 +228,11 @@ def init_cache_context(
     # preprocess_version — a toggle then auto-invalidates the deep caches via
     # _auto_invalidate_on_preprocess_version_mismatch. CP stays 3D, so its
     # identity is intentionally NOT tagged.
-    focus_slab_cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
-    if focus_slab_cfg is not None and bool(OmegaConf.select(focus_slab_cfg, "enabled", default=False)):
-        focus_tag = (
-            f"+focusslab_h{int(OmegaConf.select(focus_slab_cfg, 'halfwidth', default=2))}"
-            f"_{OmegaConf.select(focus_slab_cfg, 'channel_name', default='Phase3D')}"
-        )
+    from dynacell.evaluation.focus import read_focus_slab_config
+
+    slab_cfg = read_focus_slab_config(config)
+    if slab_cfg is not None:
+        focus_tag = f"+focusslab_h{slab_cfg.halfwidth}_{slab_cfg.channel_name}"
         dinov3_preprocess_version = (dinov3_preprocess_version + focus_tag) if dinov3_preprocess_version else None
         dynaclr_preprocess_version = (dynaclr_preprocess_version + focus_tag) if dynaclr_preprocess_version else None
         celldino_preprocess_version = (celldino_preprocess_version + focus_tag) if celldino_preprocess_version else None

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -20,6 +20,7 @@ from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
+from dynacell.evaluation.focus import build_focus_slabs, write_focus_slice_metadata
 from dynacell.evaluation.metrics import build_crops
 from dynacell.evaluation.model_loader import LoadFlags, init_gt_cache_context, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
@@ -28,6 +29,19 @@ from dynacell.evaluation.pipeline_cache import (
     fov_cp_features,
     fov_masks,
 )
+
+
+def _focus_slabs(config: DictConfig, pos_gt, t_count: int) -> list[slice | None]:
+    """Per-timepoint in-focus slabs for a GT position, or ``[None]*t`` when disabled."""
+    cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
+    if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
+        return [None] * t_count
+    return build_focus_slabs(
+        pos_gt,
+        channel_name=str(OmegaConf.select(cfg, "channel_name", default="Phase3D")),
+        halfwidth=int(OmegaConf.select(cfg, "halfwidth", default=2)),
+        t_count=t_count,
+    )
 
 
 def precompute_gt_artifacts(config: DictConfig) -> None:
@@ -65,6 +79,25 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
     # produce no cache, so we surface it as an error).
     if build.celldino and config.feature_extractor.celldino.weights_path is None:
         raise ValueError("feature_extractor.celldino.weights_path is required when build.celldino=true")
+
+    # Focus metadata is written directly to the GT store (zattrs), not the
+    # artifact cache, and needs none of the models below — so do it first. The
+    # phase channel must exist in io.gt_path; packed .ozx stores are read-only
+    # (run against the unpacked OME-Zarr and repackage).
+    if build.focus:
+        pixel_size = config.focus.pixel_size
+        if pixel_size is None:
+            pixel_size = float(config.pixel_metrics.spacing[-1])
+        print(f"Writing focus_slice to {config.io.gt_path} (channel={config.focus.channel_name})")
+        stats = write_focus_slice_metadata(
+            str(config.io.gt_path),
+            channel_name=str(config.focus.channel_name),
+            na_det=float(config.focus.na_det),
+            lambda_ill=float(config.focus.lambda_ill),
+            pixel_size=float(pixel_size),
+            device=str(config.focus.device),
+        )
+        print(f"  focus_slice[{config.focus.channel_name}].dataset_statistics = {stats}")
 
     models = load_eval_models(
         config,
@@ -127,6 +160,7 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
                 gt_channel_index = pos_gt.get_channel_index(config.io.gt_channel_name)
                 target = np.asarray(pos_gt.data[:, gt_channel_index])
                 cell_segmentation = np.asarray(pos_seg.data[:, 0]) if pos_seg is not None else None
+                z_slabs = _focus_slabs(config, pos_gt, target.shape[0])
 
                 if build.masks:
                     fov_masks(cache_ctx, pos_name_gt, target, seg_model)
@@ -143,7 +177,7 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
                         kinds_for_t = [k for k in deep_extractors if t in needs[k]]
                         if not kinds_for_t:
                             continue
-                        crops = build_crops(target[t], cell_segmentation[t], cache_ctx.patch_size)
+                        crops = build_crops(target[t], cell_segmentation[t], cache_ctx.patch_size, z_slab=z_slabs[t])
                         batcher.push(pos_name_gt, t, crops, kinds_for_t)
 
                 flush_manifest(cache_ctx)

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -84,20 +84,21 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
     # artifact cache, and needs none of the models below — so do it first. The
     # phase channel must exist in io.gt_path; packed .ozx stores are read-only
     # (run against the unpacked OME-Zarr and repackage).
-    if build.focus:
-        pixel_size = config.focus.pixel_size
+    if OmegaConf.select(config, "build.focus", default=False):
+        focus_channel = str(OmegaConf.select(config, "focus.channel_name", default="Phase3D"))
+        pixel_size = OmegaConf.select(config, "focus.pixel_size", default=None)
         if pixel_size is None:
             pixel_size = float(config.pixel_metrics.spacing[-1])
-        print(f"Writing focus_slice to {config.io.gt_path} (channel={config.focus.channel_name})")
+        print(f"Writing focus_slice to {config.io.gt_path} (channel={focus_channel})")
         stats = write_focus_slice_metadata(
             str(config.io.gt_path),
-            channel_name=str(config.focus.channel_name),
-            na_det=float(config.focus.na_det),
-            lambda_ill=float(config.focus.lambda_ill),
+            channel_name=focus_channel,
+            na_det=float(OmegaConf.select(config, "focus.na_det", default=1.35)),
+            lambda_ill=float(OmegaConf.select(config, "focus.lambda_ill", default=0.450)),
             pixel_size=float(pixel_size),
-            device=str(config.focus.device),
+            device=str(OmegaConf.select(config, "focus.device", default="cpu")),
         )
-        print(f"  focus_slice[{config.focus.channel_name}].dataset_statistics = {stats}")
+        print(f"  focus_slice[{focus_channel}].dataset_statistics = {stats}")
 
     models = load_eval_models(
         config,

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -20,7 +20,12 @@ from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
-from dynacell.evaluation.focus import build_focus_slabs, read_focus_slab_config, write_focus_slice_metadata
+from dynacell.evaluation.focus import (
+    build_focus_slabs,
+    read_focus_compute_config,
+    read_focus_slab_config,
+    write_focus_slice_metadata,
+)
 from dynacell.evaluation.metrics import build_crops
 from dynacell.evaluation.model_loader import LoadFlags, init_gt_cache_context, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
@@ -31,12 +36,20 @@ from dynacell.evaluation.pipeline_cache import (
 )
 
 
-def _focus_slabs(config: DictConfig, pos_gt, t_count: int) -> list[slice | None]:
+def _focus_slabs(config: DictConfig, pos_gt, pos_name: str, t_count: int) -> list[slice | None]:
     """Per-timepoint in-focus slabs for a GT position, or ``[None]*t`` when disabled."""
     slab_cfg = read_focus_slab_config(config)
     if slab_cfg is None:
         return [None] * t_count
-    return build_focus_slabs(pos_gt, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=t_count)
+    fc = read_focus_compute_config(config, channel_name=slab_cfg.channel_name)
+    return build_focus_slabs(
+        pos_gt,
+        halfwidth=slab_cfg.halfwidth,
+        t_count=t_count,
+        compute=fc,
+        cache_dir=config.io.gt_cache_dir,
+        pos_name=pos_name,
+    )
 
 
 def precompute_gt_artifacts(config: DictConfig) -> None:
@@ -156,7 +169,7 @@ def precompute_gt_artifacts(config: DictConfig) -> None:
                 gt_channel_index = pos_gt.get_channel_index(config.io.gt_channel_name)
                 target = np.asarray(pos_gt.data[:, gt_channel_index])
                 cell_segmentation = np.asarray(pos_seg.data[:, 0]) if pos_seg is not None else None
-                z_slabs = _focus_slabs(config, pos_gt, target.shape[0])
+                z_slabs = _focus_slabs(config, pos_gt, pos_name_gt, target.shape[0])
 
                 if build.masks:
                     fov_masks(cache_ctx, pos_name_gt, target, seg_model)

--- a/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
+++ b/applications/dynacell/src/dynacell/evaluation/precompute_cli.py
@@ -20,7 +20,7 @@ from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
 from dynacell.evaluation._ref_hook import apply_dataset_ref
-from dynacell.evaluation.focus import build_focus_slabs, write_focus_slice_metadata
+from dynacell.evaluation.focus import build_focus_slabs, read_focus_slab_config, write_focus_slice_metadata
 from dynacell.evaluation.metrics import build_crops
 from dynacell.evaluation.model_loader import LoadFlags, init_gt_cache_context, load_eval_models
 from dynacell.evaluation.pipeline_cache import (
@@ -33,15 +33,10 @@ from dynacell.evaluation.pipeline_cache import (
 
 def _focus_slabs(config: DictConfig, pos_gt, t_count: int) -> list[slice | None]:
     """Per-timepoint in-focus slabs for a GT position, or ``[None]*t`` when disabled."""
-    cfg = OmegaConf.select(config, "feature_metrics.focus_slab", default=None)
-    if cfg is None or not bool(OmegaConf.select(cfg, "enabled", default=False)):
+    slab_cfg = read_focus_slab_config(config)
+    if slab_cfg is None:
         return [None] * t_count
-    return build_focus_slabs(
-        pos_gt,
-        channel_name=str(OmegaConf.select(cfg, "channel_name", default="Phase3D")),
-        halfwidth=int(OmegaConf.select(cfg, "halfwidth", default=2)),
-        t_count=t_count,
-    )
+    return build_focus_slabs(pos_gt, channel_name=slab_cfg.channel_name, halfwidth=slab_cfg.halfwidth, t_count=t_count)
 
 
 def precompute_gt_artifacts(config: DictConfig) -> None:

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
@@ -89,33 +89,6 @@ def slice_index(memb_vol: np.ndarray, *, selection: str = "frac", fraction: floa
     raise ValueError(f"Unknown slice_selection: {selection!r} (expected 'frac' or 'sharpest').")
 
 
-def focus_slab(memb_vol: np.ndarray, *, halfwidth: int, selection: str = "frac", fraction: float = 0.30) -> slice:
-    """Return an in-focus z-slab centered on :func:`slice_index`.
-
-    Builds a ``slice`` of width ``2*halfwidth + 1`` planes centered on the plane
-    :func:`slice_index` would pick, clipped to ``[0, Z)``. Reused to restrict a
-    max-Z projection (deep-feature crops, per-cell SSIM) to the in-focus band so
-    the projection is not dominated by out-of-focus caps — and so those tracks
-    share the plane the 2-D instance segmentation already selects.
-
-    Parameters
-    ----------
-    memb_vol : numpy.ndarray
-        3-D ``(Z, Y, X)`` reference volume (GT, so GT and prediction share the
-        slab). ``selection``/``fraction`` are forwarded to :func:`slice_index`.
-    halfwidth : int
-        Planes on each side of the center; ``0`` reproduces a single-slice pick.
-
-    Returns
-    -------
-    slice
-        ``slice(z_start, z_end)`` over the Z axis.
-    """
-    z0 = slice_index(memb_vol, selection=selection, fraction=fraction)
-    z = memb_vol.shape[0]
-    return slice(max(0, z0 - halfwidth), min(z, z0 + halfwidth + 1))
-
-
 def _relabel_sequential_device(labels):
     """Relabel a (possibly device) integer label image to a dense ``1..K`` uint16."""
     xp = get_array_module(labels)

--- a/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
+++ b/applications/dynacell/src/dynacell/evaluation/segmentation_whole_cell.py
@@ -89,6 +89,33 @@ def slice_index(memb_vol: np.ndarray, *, selection: str = "frac", fraction: floa
     raise ValueError(f"Unknown slice_selection: {selection!r} (expected 'frac' or 'sharpest').")
 
 
+def focus_slab(memb_vol: np.ndarray, *, halfwidth: int, selection: str = "frac", fraction: float = 0.30) -> slice:
+    """Return an in-focus z-slab centered on :func:`slice_index`.
+
+    Builds a ``slice`` of width ``2*halfwidth + 1`` planes centered on the plane
+    :func:`slice_index` would pick, clipped to ``[0, Z)``. Reused to restrict a
+    max-Z projection (deep-feature crops, per-cell SSIM) to the in-focus band so
+    the projection is not dominated by out-of-focus caps — and so those tracks
+    share the plane the 2-D instance segmentation already selects.
+
+    Parameters
+    ----------
+    memb_vol : numpy.ndarray
+        3-D ``(Z, Y, X)`` reference volume (GT, so GT and prediction share the
+        slab). ``selection``/``fraction`` are forwarded to :func:`slice_index`.
+    halfwidth : int
+        Planes on each side of the center; ``0`` reproduces a single-slice pick.
+
+    Returns
+    -------
+    slice
+        ``slice(z_start, z_end)`` over the Z axis.
+    """
+    z0 = slice_index(memb_vol, selection=selection, fraction=fraction)
+    z = memb_vol.shape[0]
+    return slice(max(0, z0 - halfwidth), min(z, z0 + halfwidth + 1))
+
+
 def _relabel_sequential_device(labels):
     """Relabel a (possibly device) integer label image to a dense ``1..K`` uint16."""
     xp = get_array_module(labels)

--- a/applications/dynacell/tests/test_focus.py
+++ b/applications/dynacell/tests/test_focus.py
@@ -130,5 +130,23 @@ def test_read_focus_slab_config_rejects_negative_halfwidth():
     assert read_focus_slab_config(ok).halfwidth == 0
 
 
+def test_per_cell_similarity_z_slab_restricts_and_changes_outcome():
+    """z_slab slices predict/target/seg consistently, raising per-cell PCC toward the in-focus band."""
+    from dynacell.evaluation.metrics import per_cell_similarity
+
+    rng = np.random.default_rng(0)
+    z, y, x = 12, 48, 48
+    target = rng.normal(size=(z, y, x)).astype(np.float32)
+    predict = rng.normal(size=(z, y, x)).astype(np.float32)  # uncorrelated everywhere ...
+    predict[4:8] = target[4:8]  # ... except the in-focus band, where pred == target (PCC ≈ 1)
+    seg = np.zeros((z, y, x), dtype=np.int32)
+    seg[:, 10:38, 10:38] = 1  # one cell spanning all z
+    kw = dict(metrics=("pcc",), reduce=("mean",), use_gpu=False)
+    full = per_cell_similarity(predict, target, seg, **kw)
+    slab = per_cell_similarity(predict, target, seg, z_slab=slice(4, 8), **kw)
+    assert slab["PerCell_PCC_mean"] > full["PerCell_PCC_mean"]
+    assert slab["PerCell_PCC_mean"] > 0.9
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/applications/dynacell/tests/test_focus.py
+++ b/applications/dynacell/tests/test_focus.py
@@ -1,0 +1,120 @@
+"""Integration tests for focus-plane resolution (compute-at-eval-time + cache)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from iohub.ngff import open_ome_zarr
+
+from dynacell.evaluation.focus import (
+    FOCUS_FIELD,
+    FocusComputeConfig,
+    build_focus_slabs,
+    focus_slab_from_plane,
+    resolve_focus_planes,
+    write_focus_slice_metadata,
+)
+
+NA_DET = 1.35
+LAMBDA_ILL = 0.450
+PIXEL_SIZE = 0.1494
+
+
+def _compute(channel_name="Phase3D", **overrides):
+    params = dict(channel_name=channel_name, na_det=NA_DET, lambda_ill=LAMBDA_ILL, pixel_size=PIXEL_SIZE, device="cpu")
+    params.update(overrides)
+    return FocusComputeConfig(**params)
+
+
+def _make_store(path: Path, *, z: int = 16, focus_z=(5, 9), t: int = 2) -> None:
+    """Two positions, T=t, one Phase3D channel, sharp texture band at a per-pos plane."""
+    rng = np.random.default_rng(0)
+    with open_ome_zarr(str(path), layout="hcs", mode="w", channel_names=["Phase3D"]) as plate:
+        for col, fz in enumerate(focus_z):
+            pos = plate.create_position("0", str(col), "0")
+            data = rng.normal(0, 0.05, size=(t, 1, z, 96, 96)).astype(np.float32)
+            for ti in range(t):
+                for zi in range(z):
+                    amp = float(np.exp(-((zi - fz) ** 2) / 2.0))
+                    data[ti, 0, zi] += amp * rng.normal(0, 1.0, size=(96, 96)).astype(np.float32)
+            pos.create_image("0", data)
+
+
+def _resolve(pos, name, t, cache_dir, **overrides):
+    return resolve_focus_planes(pos, t_count=t, compute=_compute(**overrides), cache_dir=cache_dir, pos_name=name)
+
+
+def test_compute_then_cache_then_hit(tmp_path):
+    """No zattrs -> compute from Phase3D + persist; second call hits the cache file."""
+    store = tmp_path / "s.zarr"
+    cache = tmp_path / "gt_cache"
+    _make_store(store, z=16, focus_z=(5, 9), t=2)
+    with open_ome_zarr(str(store), mode="r") as plate:
+        name, pos = next(iter(plate.positions()))
+        planes = _resolve(pos, name, 2, cache)
+        assert len(planes) == 2
+        assert all(0 <= p < 16 for p in planes)
+        # the sharp band sits near z=5 for this first position
+        assert abs(planes[0] - 5) <= 2
+        cache_file = cache / "focus_planes" / "Phase3D" / f"{name.replace('/', '__')}.json"
+        assert cache_file.is_file()
+        # second call returns identical planes (from cache; band content unchanged)
+        assert _resolve(pos, name, 2, cache) == planes
+
+
+def test_param_mismatch_recomputes(tmp_path):
+    """A different pixel_size must not reuse a cache entry written for another param set."""
+    store = tmp_path / "s.zarr"
+    cache = tmp_path / "gt_cache"
+    _make_store(store, z=16, focus_z=(8, 8), t=1)
+    with open_ome_zarr(str(store), mode="r") as plate:
+        name, pos = next(iter(plate.positions()))
+        _resolve(pos, name, 1, cache)
+        cache_file = cache / "focus_planes" / "Phase3D" / f"{name.replace('/', '__')}.json"
+        before = cache_file.read_text()
+        _resolve(pos, name, 1, cache, pixel_size=0.250)  # different param -> overwrite
+        assert cache_file.read_text() != before
+
+
+def test_zattrs_take_precedence_over_cache(tmp_path):
+    """Precomputed focus_slice zattrs win over both the cache and a fresh compute."""
+    store = tmp_path / "s.zarr"
+    cache = tmp_path / "gt_cache"
+    _make_store(store, z=16, focus_z=(5, 9), t=2)
+    write_focus_slice_metadata(
+        str(store), channel_name="Phase3D", na_det=NA_DET, lambda_ill=LAMBDA_ILL, pixel_size=PIXEL_SIZE
+    )
+    with open_ome_zarr(str(store), mode="r") as plate:
+        name, pos = next(iter(plate.positions()))
+        assert FOCUS_FIELD in pos.zattrs
+        planes = _resolve(pos, name, 2, cache)
+        # came from zattrs, so no cache file is written
+        assert not (cache / "focus_planes" / "Phase3D" / f"{name.replace('/', '__')}.json").is_file()
+        assert len(planes) == 2
+
+
+def test_build_focus_slabs_centers_and_clips(tmp_path):
+    """Slabs are 2*halfwidth+1 planes centered on the focus plane, clipped to [0, Z)."""
+    store = tmp_path / "s.zarr"
+    cache = tmp_path / "gt_cache"
+    _make_store(store, z=16, focus_z=(1, 1), t=1)  # focus near the edge -> clipping
+    with open_ome_zarr(str(store), mode="r") as plate:
+        name, pos = next(iter(plate.positions()))
+        slabs = build_focus_slabs(pos, halfwidth=2, t_count=1, compute=_compute(), cache_dir=cache, pos_name=name)
+        assert len(slabs) == 1
+        sl = slabs[0]
+        assert sl.start == 0  # clipped at the low edge
+        assert sl.stop <= 16
+
+
+def test_focus_slab_from_plane_pure():
+    assert focus_slab_from_plane(10, 48, 2) == slice(8, 13)
+    assert focus_slab_from_plane(0, 48, 2) == slice(0, 3)
+    assert focus_slab_from_plane(47, 48, 2) == slice(45, 48)
+    assert focus_slab_from_plane(10, 48, 0) == slice(10, 11)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/applications/dynacell/tests/test_focus.py
+++ b/applications/dynacell/tests/test_focus.py
@@ -116,5 +116,19 @@ def test_focus_slab_from_plane_pure():
     assert focus_slab_from_plane(10, 48, 0) == slice(10, 11)
 
 
+def test_read_focus_slab_config_rejects_negative_halfwidth():
+    """A negative halfwidth must fail early (it yields an empty slab → max-Z crash)."""
+    from omegaconf import OmegaConf
+
+    from dynacell.evaluation.focus import read_focus_slab_config
+
+    bad = OmegaConf.create({"feature_metrics": {"focus_slab": {"enabled": True, "halfwidth": -1}}})
+    with pytest.raises(ValueError, match="halfwidth must be >= 0"):
+        read_focus_slab_config(bad)
+    # halfwidth=0 is valid (single in-focus plane)
+    ok = OmegaConf.create({"feature_metrics": {"focus_slab": {"enabled": True, "halfwidth": 0}}})
+    assert read_focus_slab_config(ok).halfwidth == 0
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/applications/dynacell/tests/test_pipeline_cache.py
+++ b/applications/dynacell/tests/test_pipeline_cache.py
@@ -23,6 +23,7 @@ from dynacell.evaluation.cache import (  # noqa: E402
     write_mask,
 )
 from dynacell.evaluation.pipeline_cache import (  # noqa: E402
+    _instance_identity,
     _resolve_force,
     flush_manifest,
     fov_cp_features,
@@ -478,6 +479,54 @@ def test_init_cache_cp_glcm_levels_ignored_when_glcm_disabled(tmp_path: Path) ->
         ctx = init_cache_context(cfg, side="gt")
     assert ctx.force["gt_cp"] is False
     assert not any("artifact param mismatch" in str(w.message) and "cp_features" in str(w.message) for w in caught)
+
+
+def _focus_config(**focus_overrides: Any):
+    """A ``_make_config`` with focus_slab + slice_selection=focus turned on."""
+    focus = {"na_det": 1.35, "lambda_ill": 0.450, "pixel_size": 0.1494, "device": "cpu"}
+    focus.update(focus_overrides)
+    return _make_config(
+        **{
+            "feature_metrics.focus_slab": {"enabled": True, "halfwidth": 2, "channel_name": "Phase3D"},
+            "segmentation": {"slice_selection": "focus", "focus_channel_name": "Phase3D"},
+            "focus": focus,
+        }
+    )
+
+
+def test_focus_params_fold_into_deep_tag_and_instance_identity() -> None:
+    """Focus-compute params gate the in-focus plane, so they must sit in the cache keys.
+
+    The deep-feature ``preprocess_version`` gets a ``+focusslab_h{h}_{ch}_{sig}`` tag and
+    the ``slice_selection=focus`` instance identity records the params; a ``pixel_size``
+    change then alters both, forcing a recompute instead of silently reusing stale planes.
+    """
+    ctx = init_cache_context(
+        _focus_config(), side="gt", dinov3_model_name="dinov3_vits16", dinov3_preprocess_version="v1"
+    )
+    assert ctx.dinov3_preprocess_version.startswith("v1+focusslab_h2_Phase3D_")
+    ident = _instance_identity(ctx)
+    assert ident["focus_channel_name"] == "Phase3D"
+    assert ident["focus_na_det"] == 1.35
+    assert ident["focus_pixel_size"] == 0.1494
+
+    # A pixel_size override moves the plane -> the deep tag and instance identity both change.
+    ctx2 = init_cache_context(
+        _focus_config(pixel_size=0.250), side="gt", dinov3_model_name="dinov3_vits16", dinov3_preprocess_version="v1"
+    )
+    assert ctx2.dinov3_preprocess_version != ctx.dinov3_preprocess_version
+    assert _instance_identity(ctx2)["focus_pixel_size"] == 0.250
+
+
+def test_focus_off_leaves_tag_and_identity_untagged() -> None:
+    """With focus disabled (the default), no focus tag or focus keys appear anywhere."""
+    ctx = init_cache_context(
+        _make_config(), side="gt", dinov3_model_name="dinov3_vits16", dinov3_preprocess_version="v1"
+    )
+    assert ctx.dinov3_preprocess_version == "v1"
+    ident = _instance_identity(ctx)
+    assert "focus_channel_name" not in ident
+    assert not any(k.startswith("focus_") for k in ident)
 
 
 def test_fov_gt_masks_cache_miss_computes_and_writes(tmp_path: Path, monkeypatch) -> None:

--- a/applications/dynacell/tools/run_celldiff_r2_a549trained_evals.slurm
+++ b/applications/dynacell/tools/run_celldiff_r2_a549trained_evals.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Eval campaign: celldiff_r2 a549-trained model evals + nucleus celldiff_r2_iterative A549 rerun.
+# Runs immediately — all prediction zarrs are present.
+#
+# Array index → grouped leaf mapping:
+#   0: er_celldiff_r2_a549trained           (iPSC + A549 sec61b denv/mock/zikv)
+#   1: membrane_celldiff_r2_a549trained     (iPSC + A549 membrane denv)
+#   2: nucleus_celldiff_r2_a549trained      (iPSC only)
+#   3: mitochondria_celldiff_r2_a549trained (iPSC only)
+#   4: nucleus_celldiff_r2_iterative_a549_rerun (A549 nucleus denv/mock/zikv — rerun of failed campaign task 6)
+#
+#SBATCH --job-name=celldiff-r2-a549tr-eval
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --constraint="a100|h100|h200"
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=256G
+#SBATCH --time=48:00:00
+#SBATCH --partition=gpu
+#SBATCH --array=0-4
+#SBATCH --output=/hpc/mydata/alex.kalinin/logs/reeval/%x_%A_%a.out
+
+set -euo pipefail
+
+LEAVES=(
+  grouped/er_celldiff_r2_a549trained/eval_grouped
+  grouped/membrane_celldiff_r2_a549trained/eval_grouped
+  grouped/nucleus_celldiff_r2_a549trained/eval_grouped
+  grouped/mitochondria_celldiff_r2_a549trained/eval_grouped
+  grouped/nucleus_celldiff_r2_iterative_a549_rerun/eval_grouped
+)
+
+LEAF="${LEAVES[${SLURM_ARRAY_TASK_ID}]}"
+echo "[celldiff-r2-a549tr-eval] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
+echo "[celldiff-r2-a549tr-eval] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1)"
+
+export DYNACELL_THREADS_PER_WORKER=32
+
+cd /hpc/mydata/alex.kalinin/VisCy
+# GLCM + focus_slab (see run_reeval_campaign.slurm for rationale + the focus_slice
+# PREREQUISITE: write it with precompute-gt build.focus / repackage A549 .ozx first).
+exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
+  feature_metrics.cp.glcm.enabled=true \
+  feature_metrics.focus_slab.enabled=true \
+  feature_metrics.focus_slab.halfwidth=2 \
+  force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_celldiff_r2_a549trained_evals.slurm
+++ b/applications/dynacell/tools/run_celldiff_r2_a549trained_evals.slurm
@@ -35,13 +35,18 @@ LEAF="${LEAVES[${SLURM_ARRAY_TASK_ID}]}"
 echo "[celldiff-r2-a549tr-eval] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
 echo "[celldiff-r2-a549tr-eval] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1)"
 
-export DYNACELL_THREADS_PER_WORKER=32
+# Derive the thread cap from the allocation (never hardcode — matches the #429 fix).
+export DYNACELL_THREADS_PER_WORKER=${SLURM_CPUS_PER_TASK:-32}
 
 cd /hpc/mydata/alex.kalinin/VisCy
-# GLCM + focus_slab (see run_reeval_campaign.slurm for rationale + the focus_slice
-# PREREQUISITE: write it with precompute-gt build.focus / repackage A549 .ozx first).
+# GLCM + focus (compute-at-eval-time: the in-focus plane is read from focus_slice
+# zattrs when present, else computed from Phase3D and cached in io.gt_cache_dir, so
+# no .ozx repackaging is needed). focus_slab=deep-feature/per-cell ±2 max-proj;
+# slice_selection=focus=2D instance seg on the in-focus plane (was frac=0.30).
+# NOTE: superseded by tools/run_focus_campaign.slurm (these leaves run in its phase 2).
 exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
   feature_metrics.cp.glcm.enabled=true \
   feature_metrics.focus_slab.enabled=true \
   feature_metrics.focus_slab.halfwidth=2 \
+  segmentation.slice_selection=focus \
   force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_celldiff_r2_a549trained_evals_deferred.slurm
+++ b/applications/dynacell/tools/run_celldiff_r2_a549trained_evals_deferred.slurm
@@ -32,13 +32,16 @@ LEAF="${LEAVES[${SLURM_ARRAY_TASK_ID}]}"
 echo "[celldiff-r2-a549tr-eval-def] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
 echo "[celldiff-r2-a549tr-eval-def] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1)"
 
-export DYNACELL_THREADS_PER_WORKER=32
+# Derive the thread cap from the allocation (never hardcode — matches the #429 fix).
+export DYNACELL_THREADS_PER_WORKER=${SLURM_CPUS_PER_TASK:-32}
 
 cd /hpc/mydata/alex.kalinin/VisCy
-# GLCM + focus_slab (see run_reeval_campaign.slurm for rationale + the focus_slice
-# PREREQUISITE: write it with precompute-gt build.focus / repackage A549 .ozx first).
+# GLCM + focus (compute-at-eval-time; no .ozx repackaging needed — see
+# run_celldiff_r2_a549trained_evals.slurm). slice_selection=focus = 2D instance
+# seg on the in-focus plane. NOTE: superseded by tools/run_focus_campaign.slurm.
 exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
   feature_metrics.cp.glcm.enabled=true \
   feature_metrics.focus_slab.enabled=true \
   feature_metrics.focus_slab.halfwidth=2 \
+  segmentation.slice_selection=focus \
   force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_celldiff_r2_a549trained_evals_deferred.slurm
+++ b/applications/dynacell/tools/run_celldiff_r2_a549trained_evals_deferred.slurm
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Eval campaign: celldiff_r2 a549-trained on A549 (membrane/nucleus/mito) — deferred.
+# Scheduled with --dependency afterok:33213763:33213764 to wait for all
+# CELLDIFF_R2_A549TR_g0 + g1 predict arrays to complete.
+#
+# Array index → grouped leaf mapping:
+#   0: membrane_celldiff_r2_a549trained_later     (A549 mock + zikv)
+#   1: nucleus_celldiff_r2_a549trained_later      (A549 denv/mock/zikv)
+#   2: mitochondria_celldiff_r2_a549trained_later (A549 denv/mock/zikv)
+#
+#SBATCH --job-name=celldiff-r2-a549tr-eval-def
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --constraint="a100|h100|h200"
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=256G
+#SBATCH --time=48:00:00
+#SBATCH --partition=gpu
+#SBATCH --array=0-2
+#SBATCH --output=/hpc/mydata/alex.kalinin/logs/reeval/%x_%A_%a.out
+
+set -euo pipefail
+
+LEAVES=(
+  grouped/membrane_celldiff_r2_a549trained_later/eval_grouped
+  grouped/nucleus_celldiff_r2_a549trained_later/eval_grouped
+  grouped/mitochondria_celldiff_r2_a549trained_later/eval_grouped
+)
+
+LEAF="${LEAVES[${SLURM_ARRAY_TASK_ID}]}"
+echo "[celldiff-r2-a549tr-eval-def] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
+echo "[celldiff-r2-a549tr-eval-def] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1)"
+
+export DYNACELL_THREADS_PER_WORKER=32
+
+cd /hpc/mydata/alex.kalinin/VisCy
+# GLCM + focus_slab (see run_reeval_campaign.slurm for rationale + the focus_slice
+# PREREQUISITE: write it with precompute-gt build.focus / repackage A549 .ozx first).
+exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
+  feature_metrics.cp.glcm.enabled=true \
+  feature_metrics.focus_slab.enabled=true \
+  feature_metrics.focus_slab.halfwidth=2 \
+  force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_focus_campaign.slurm
+++ b/applications/dynacell/tools/run_focus_campaign.slurm
@@ -26,6 +26,11 @@
 #   feature_metrics.focus_slab.halfwidth=2       — max-proj over the in-focus ±2 slab
 #   segmentation.slice_selection=focus           — 2D instance seg on the in-focus
 #                                                  plane (was frac=0.30)
+#   force_recompute.{gt_cp,pred_cp}=true         — recompute CP fresh: some iPSC
+#                                                  caches hold a stale wider CP
+#                                                  schema (58 vs current 22 cols)
+#                                                  that isn't auto-invalidated and
+#                                                  fails the cross-FOV concat
 #   force_recompute.final_metrics=true           — re-aggregate the CSV/NPY
 # The focus plane is read from focus_slice zattrs when present (iPSC) else computed
 # from Phase3D and cached in io.gt_cache_dir (A549 published .ozx stay byte-identical).
@@ -110,4 +115,6 @@ exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
   feature_metrics.focus_slab.enabled=true \
   feature_metrics.focus_slab.halfwidth=2 \
   segmentation.slice_selection=focus \
+  force_recompute.gt_cp=true \
+  force_recompute.pred_cp=true \
   force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_focus_campaign.slurm
+++ b/applications/dynacell/tools/run_focus_campaign.slurm
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Focus-aware re-eval campaign (PR #468). Two phases, submitted with a
+# dependency by tools/submit_focus_campaign.sh:
+#
+#   PHASE 1 (gtwarm): the 4 *_ipsc_trained grouped leaves. Each tests its
+#     organelle on all 3 A549 conditions (denv/mock/zikv) + iPSC, so the four
+#     collectively PRODUCE every GT-side cache the campaign needs — focus planes
+#     (computed from Phase3D, cached in io.gt_cache_dir), GLCM-enriched CP, the
+#     focus-slab GT deep features, organelle masks, and the in-focus instance
+#     plane. Different organelles use distinct gt_cache_dirs, so the four run
+#     concurrently with no contention.
+#   PHASE 2 (eval): the remaining 16 leaves (joint + a549_trained +
+#     celldiff_r2_a549trained). They only READ the now-warm GT caches (writing
+#     just their own per-model pred caches + final metrics), so they fan out
+#     fully in parallel — the GT cache is produced once (phase 1) then hit.
+#
+# Each array task runs 2 evals on its single GPU (backgrounded), splitting
+# cpus-per-task between them. Time limit is 12 h to clear the cluster
+# maintenance window; fault isolation is per task.
+#
+# Focus overrides applied to every leaf (compute-at-eval-time, Option A):
+#   feature_metrics.cp.glcm.enabled=true        — Haralick texture (CP recompute)
+#   feature_metrics.focus_slab.enabled=true     — deep-feature crops + per-cell
+#   feature_metrics.focus_slab.halfwidth=2       — max-proj over the in-focus ±2 slab
+#   segmentation.slice_selection=focus           — 2D instance seg on the in-focus
+#                                                  plane (was frac=0.30)
+#   force_recompute.final_metrics=true           — re-aggregate the CSV/NPY
+# The focus plane is read from focus_slice zattrs when present (iPSC) else computed
+# from Phase3D and cached in io.gt_cache_dir (A549 published .ozx stay byte-identical).
+#
+# Usage (via the wrapper, which wires the afterok dependency + array sizes):
+#   tools/submit_focus_campaign.sh
+# Or by hand:
+#   J1=$(sbatch --parsable --array=0-1%2 tools/run_focus_campaign.slurm gtwarm)
+#   sbatch --dependency=afterok:$J1 --array=0-7%8 tools/run_focus_campaign.slurm eval
+#
+#SBATCH --job-name=focus_reeval
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --constraint="a100|h100|h200"
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=256G
+#SBATCH --time=12:00:00
+#SBATCH --partition=gpu
+#SBATCH --output=/hpc/mydata/alex.kalinin/logs/reeval/%x_%A_%a.out
+
+set -uo pipefail
+
+PHASE=${1:?"usage: run_focus_campaign.slurm <gtwarm|eval>"}
+
+# Phase 1 produces all GT caches; phase 2 reads them. Leaf order within a phase
+# is paired (2 per task); pairs mix organelles so co-scheduled evals touch
+# distinct gt_cache dirs.
+case "$PHASE" in
+  gtwarm)
+    LEAVES=(
+      grouped/er_ipsc_trained/eval_grouped
+      grouped/mitochondria_ipsc_trained/eval_grouped
+      grouped/nucleus_ipsc_trained/eval_grouped
+      grouped/membrane_ipsc_trained/eval_grouped
+    )
+    ;;
+  eval)
+    LEAVES=(
+      grouped/er_joint/eval_grouped
+      grouped/mitochondria_joint/eval_grouped
+      grouped/er_a549_trained/eval_grouped
+      grouped/mitochondria_a549_trained/eval_grouped
+      grouped/nucleus_joint/eval_grouped
+      grouped/membrane_joint/eval_grouped
+      grouped/nucleus_a549_trained/eval_grouped
+      grouped/membrane_a549_trained/eval_grouped
+      grouped/er_celldiff_r2_a549trained/eval_grouped
+      grouped/mitochondria_celldiff_r2_a549trained/eval_grouped
+      grouped/nucleus_celldiff_r2_a549trained/eval_grouped
+      grouped/membrane_celldiff_r2_a549trained/eval_grouped
+      grouped/nucleus_celldiff_r2_iterative_a549_rerun/eval_grouped
+      grouped/mitochondria_celldiff_r2_a549trained_later/eval_grouped
+      grouped/nucleus_celldiff_r2_a549trained_later/eval_grouped
+      grouped/membrane_celldiff_r2_a549trained_later/eval_grouped
+    )
+    ;;
+  *)
+    echo "Unknown phase '$PHASE' (expected gtwarm|eval)" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "${SLURM_ARRAY_TASK_ID:-}" ]]; then
+  echo "SLURM_ARRAY_TASK_ID unset — launch via sbatch --array (see submit_focus_campaign.sh)." >&2
+  exit 2
+fi
+
+# Two leaves per task (this GPU runs both concurrently). Split CPUs so the two
+# backgrounded processes don't oversubscribe BLAS/OMP. Matches the #429 fix:
+# derive threads from SLURM_CPUS_PER_TASK, never hardcode.
+I0=$((SLURM_ARRAY_TASK_ID * 2))
+I1=$((I0 + 1))
+LEAF_A="${LEAVES[$I0]:-}"
+LEAF_B="${LEAVES[$I1]:-}"
+export DYNACELL_THREADS_PER_WORKER=$(( ${SLURM_CPUS_PER_TASK:-32} / 2 ))
+
+echo "[focus_reeval/$PHASE] task ${SLURM_ARRAY_TASK_ID}: A=${LEAF_A} B=${LEAF_B}"
+echo "[focus_reeval/$PHASE] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1) threads/eval=${DYNACELL_THREADS_PER_WORKER}"
+
+cd /hpc/mydata/alex.kalinin/VisCy
+
+run_leaf() {
+  local leaf="$1"
+  [[ -z "$leaf" ]] && return 0
+  uv run dynacell evaluate-grouped "leaf=${leaf}" \
+    feature_metrics.cp.glcm.enabled=true \
+    feature_metrics.focus_slab.enabled=true \
+    feature_metrics.focus_slab.halfwidth=2 \
+    segmentation.slice_selection=focus \
+    force_recompute.final_metrics=true
+}
+
+rc=0
+run_leaf "$LEAF_A" & PID_A=$!
+run_leaf "$LEAF_B" & PID_B=$!
+wait $PID_A || { echo "[focus_reeval] leaf A failed: ${LEAF_A}" >&2; rc=1; }
+[[ -n "$LEAF_B" ]] && { wait $PID_B || { echo "[focus_reeval] leaf B failed: ${LEAF_B}" >&2; rc=1; }; }
+exit $rc

--- a/applications/dynacell/tools/run_focus_campaign.slurm
+++ b/applications/dynacell/tools/run_focus_campaign.slurm
@@ -52,7 +52,7 @@
 #SBATCH --partition=gpu
 #SBATCH --output=/hpc/mydata/alex.kalinin/logs/reeval/%x_%A_%a.out
 
-set -uo pipefail
+set -euo pipefail
 
 PHASE=${1:?"usage: run_focus_campaign.slurm <gtwarm|eval>"}
 

--- a/applications/dynacell/tools/run_focus_campaign.slurm
+++ b/applications/dynacell/tools/run_focus_campaign.slurm
@@ -67,6 +67,11 @@ case "$PHASE" in
     )
     ;;
   eval)
+    # joint + a549_trained buckets only. The dedicated *_celldiff_r2_a549trained{,_later}
+    # and *_celldiff_r2_iterative_a549_rerun buckets are DROPPED: they duplicate the
+    # celldiff_r2 conditions already covered by these a549_trained buckets (and by the
+    # phase-1 ipsc_trained buckets for the iterative variant), and writing the same
+    # per-condition save_dir concurrently raised zarr ContainsGroupError.
     LEAVES=(
       grouped/er_joint/eval_grouped
       grouped/mitochondria_joint/eval_grouped
@@ -76,14 +81,6 @@ case "$PHASE" in
       grouped/membrane_joint/eval_grouped
       grouped/nucleus_a549_trained/eval_grouped
       grouped/membrane_a549_trained/eval_grouped
-      grouped/er_celldiff_r2_a549trained/eval_grouped
-      grouped/mitochondria_celldiff_r2_a549trained/eval_grouped
-      grouped/nucleus_celldiff_r2_a549trained/eval_grouped
-      grouped/membrane_celldiff_r2_a549trained/eval_grouped
-      grouped/nucleus_celldiff_r2_iterative_a549_rerun/eval_grouped
-      grouped/mitochondria_celldiff_r2_a549trained_later/eval_grouped
-      grouped/nucleus_celldiff_r2_a549trained_later/eval_grouped
-      grouped/membrane_celldiff_r2_a549trained_later/eval_grouped
     )
     ;;
   *)

--- a/applications/dynacell/tools/run_focus_campaign.slurm
+++ b/applications/dynacell/tools/run_focus_campaign.slurm
@@ -14,9 +14,11 @@
 #     just their own per-model pred caches + final metrics), so they fan out
 #     fully in parallel — the GT cache is produced once (phase 1) then hit.
 #
-# Each array task runs 2 evals on its single GPU (backgrounded), splitting
-# cpus-per-task between them. Time limit is 12 h to clear the cluster
-# maintenance window; fault isolation is per task.
+# Each array task runs ONE eval on its single GPU. (Earlier 2-evals/GPU was too
+# slow on the 40 GB A100 — GPU time-slicing ~doubled each eval's wall time, so a
+# 2-leaf task ran >11 h without finishing. With a free cluster, 1 eval/GPU across
+# many GPUs completes far sooner.) Time limit 14 h, well inside the maintenance
+# reservation (gpu-* reserved 2026-06-12 ~09:05); fault isolation is per task.
 #
 # Focus overrides applied to every leaf (compute-at-eval-time, Option A):
 #   feature_metrics.cp.glcm.enabled=true        — Haralick texture (CP recompute)
@@ -28,11 +30,11 @@
 # The focus plane is read from focus_slice zattrs when present (iPSC) else computed
 # from Phase3D and cached in io.gt_cache_dir (A549 published .ozx stay byte-identical).
 #
-# Usage (via the wrapper, which wires the afterok dependency + array sizes):
+# Usage (via the wrapper, which wires the afterany dependency + array sizes):
 #   tools/submit_focus_campaign.sh
-# Or by hand:
-#   J1=$(sbatch --parsable --array=0-1%2 tools/run_focus_campaign.slurm gtwarm)
-#   sbatch --dependency=afterok:$J1 --array=0-7%8 tools/run_focus_campaign.slurm eval
+# Or by hand (one leaf per task):
+#   J1=$(sbatch --parsable --array=0-3 tools/run_focus_campaign.slurm gtwarm)
+#   sbatch --dependency=afterany:$J1 --array=0-15%16 tools/run_focus_campaign.slurm eval
 #
 #SBATCH --job-name=focus_reeval
 #SBATCH --nodes=1
@@ -41,7 +43,7 @@
 #SBATCH --constraint="a100|h100|h200"
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=256G
-#SBATCH --time=12:00:00
+#SBATCH --time=14:00:00
 #SBATCH --partition=gpu
 #SBATCH --output=/hpc/mydata/alex.kalinin/logs/reeval/%x_%A_%a.out
 
@@ -49,9 +51,7 @@ set -uo pipefail
 
 PHASE=${1:?"usage: run_focus_campaign.slurm <gtwarm|eval>"}
 
-# Phase 1 produces all GT caches; phase 2 reads them. Leaf order within a phase
-# is paired (2 per task); pairs mix organelles so co-scheduled evals touch
-# distinct gt_cache dirs.
+# Phase 1 produces all GT caches; phase 2 reads them. One leaf per array task.
 case "$PHASE" in
   gtwarm)
     LEAVES=(
@@ -92,34 +92,22 @@ if [[ -z "${SLURM_ARRAY_TASK_ID:-}" ]]; then
   exit 2
 fi
 
-# Two leaves per task (this GPU runs both concurrently). Split CPUs so the two
-# backgrounded processes don't oversubscribe BLAS/OMP. Matches the #429 fix:
-# derive threads from SLURM_CPUS_PER_TASK, never hardcode.
-I0=$((SLURM_ARRAY_TASK_ID * 2))
-I1=$((I0 + 1))
-LEAF_A="${LEAVES[$I0]:-}"
-LEAF_B="${LEAVES[$I1]:-}"
-export DYNACELL_THREADS_PER_WORKER=$(( ${SLURM_CPUS_PER_TASK:-32} / 2 ))
+# One leaf per task on the full GPU. Threads from the allocation (#429 fix).
+LEAF="${LEAVES[$SLURM_ARRAY_TASK_ID]:-}"
+if [[ -z "$LEAF" ]]; then
+  echo "No leaf at array index ${SLURM_ARRAY_TASK_ID} for phase ${PHASE}" >&2
+  exit 2
+fi
+export DYNACELL_THREADS_PER_WORKER=${SLURM_CPUS_PER_TASK:-32}
 
-echo "[focus_reeval/$PHASE] task ${SLURM_ARRAY_TASK_ID}: A=${LEAF_A} B=${LEAF_B}"
-echo "[focus_reeval/$PHASE] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1) threads/eval=${DYNACELL_THREADS_PER_WORKER}"
+echo "[focus_reeval/$PHASE] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
+echo "[focus_reeval/$PHASE] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1) threads=${DYNACELL_THREADS_PER_WORKER}"
 
 cd /hpc/mydata/alex.kalinin/VisCy
 
-run_leaf() {
-  local leaf="$1"
-  [[ -z "$leaf" ]] && return 0
-  uv run dynacell evaluate-grouped "leaf=${leaf}" \
-    feature_metrics.cp.glcm.enabled=true \
-    feature_metrics.focus_slab.enabled=true \
-    feature_metrics.focus_slab.halfwidth=2 \
-    segmentation.slice_selection=focus \
-    force_recompute.final_metrics=true
-}
-
-rc=0
-run_leaf "$LEAF_A" & PID_A=$!
-run_leaf "$LEAF_B" & PID_B=$!
-wait $PID_A || { echo "[focus_reeval] leaf A failed: ${LEAF_A}" >&2; rc=1; }
-[[ -n "$LEAF_B" ]] && { wait $PID_B || { echo "[focus_reeval] leaf B failed: ${LEAF_B}" >&2; rc=1; }; }
-exit $rc
+exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
+  feature_metrics.cp.glcm.enabled=true \
+  feature_metrics.focus_slab.enabled=true \
+  feature_metrics.focus_slab.halfwidth=2 \
+  segmentation.slice_selection=focus \
+  force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_reeval_campaign.slurm
+++ b/applications/dynacell/tools/run_reeval_campaign.slurm
@@ -51,4 +51,21 @@ echo "[reeval] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,n
 export DYNACELL_THREADS_PER_WORKER=32
 
 cd /hpc/mydata/alex.kalinin/VisCy
-exec uv run dynacell evaluate-grouped "leaf=${LEAF}"
+# GLCM Haralick texture recompute: glcm.enabled flips the cp_features cache
+# identity (cp_glcm_enabled false->true) so only the CP artifact auto-invalidates
+# and recomputes on GPU; deep-feature / mask / instance caches are untouched.
+# force_recompute.final_metrics re-aggregates the saved CSV/NPY from the enriched
+# CP cache (it is reused on file-existence alone otherwise). final_metrics=true is
+# also baked into the leaves' _BASE_OVERLAY; repeated here so the recompute intent
+# is explicit at the launch site.
+# focus_slab restricts the 2D deep-feature / per-cell projection to an in-focus
+# slab centered on the GT phase focus plane (h=2 -> 5 planes), keeping the MIP off
+# the out-of-focus caps. PREREQUISITE: focus_slice zattrs must already exist in
+# every GT store this campaign touches -- write them with `dynacell precompute-gt
+# build.focus=true` (writable .zarr) and repackage the A549 .ozx with the metadata.
+# Without it the eval fails loud (no silent full-stack fallback).
+exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
+  feature_metrics.cp.glcm.enabled=true \
+  feature_metrics.focus_slab.enabled=true \
+  feature_metrics.focus_slab.halfwidth=2 \
+  force_recompute.final_metrics=true

--- a/applications/dynacell/tools/run_reeval_campaign.slurm
+++ b/applications/dynacell/tools/run_reeval_campaign.slurm
@@ -47,8 +47,9 @@ echo "[reeval] task ${SLURM_ARRAY_TASK_ID}: leaf=${LEAF}"
 echo "[reeval] node=$(hostname) gpu=$(nvidia-smi --query-gpu=name --format=csv,noheader,nounits | head -1)"
 
 # Pre-set BLAS / OpenBLAS / OMP thread caps before any C-extension loads.
-# Matches dynacell/CLAUDE.md "Eval runtime / parallelism" guidance.
-export DYNACELL_THREADS_PER_WORKER=32
+# Matches dynacell/CLAUDE.md "Eval runtime / parallelism" guidance. Derive from
+# the allocation rather than hardcoding (matches the #429 fix).
+export DYNACELL_THREADS_PER_WORKER=${SLURM_CPUS_PER_TASK:-32}
 
 cd /hpc/mydata/alex.kalinin/VisCy
 # GLCM Haralick texture recompute: glcm.enabled flips the cp_features cache
@@ -60,12 +61,14 @@ cd /hpc/mydata/alex.kalinin/VisCy
 # is explicit at the launch site.
 # focus_slab restricts the 2D deep-feature / per-cell projection to an in-focus
 # slab centered on the GT phase focus plane (h=2 -> 5 planes), keeping the MIP off
-# the out-of-focus caps. PREREQUISITE: focus_slice zattrs must already exist in
-# every GT store this campaign touches -- write them with `dynacell precompute-gt
-# build.focus=true` (writable .zarr) and repackage the A549 .ozx with the metadata.
-# Without it the eval fails loud (no silent full-stack fallback).
+# the out-of-focus caps. slice_selection=focus picks the in-focus plane for 2D
+# instance seg (was frac=0.30). The plane is read from focus_slice zattrs when
+# present (iPSC) else computed from Phase3D and cached in io.gt_cache_dir -- so the
+# published A549 .ozx need no repackaging (compute-at-eval-time, PR #468 Option A).
+# NOTE: superseded by tools/run_focus_campaign.slurm (two-phase, 2 evals/GPU, 12h).
 exec uv run dynacell evaluate-grouped "leaf=${LEAF}" \
   feature_metrics.cp.glcm.enabled=true \
   feature_metrics.focus_slab.enabled=true \
   feature_metrics.focus_slab.halfwidth=2 \
+  segmentation.slice_selection=focus \
   force_recompute.final_metrics=true

--- a/applications/dynacell/tools/submit_focus_campaign.sh
+++ b/applications/dynacell/tools/submit_focus_campaign.sh
@@ -1,26 +1,27 @@
 #!/bin/bash
 # Submit the two-phase focus-aware re-eval campaign (PR #468).
 #
-#   Phase 1 (gtwarm): 4 *_ipsc_trained leaves -> 2 tasks (2 evals/GPU). Produces
+#   Phase 1 (gtwarm): 4 *_ipsc_trained leaves -> 4 tasks (1 eval/GPU). Produces
 #     every GT-side cache (focus / GLCM-CP / focus-slab GT deep features / masks /
 #     in-focus instance plane).
-#   Phase 2 (eval): 16 leaves -> 8 tasks (2 evals/GPU). Reads the warm GT caches,
+#   Phase 2 (eval): 16 leaves -> 16 tasks (1 eval/GPU). Reads the warm GT caches,
 #     so it fans out fully in parallel. Gated on phase 1 with afterany (phase 2 can
 #     self-heal any un-warmed GT via compute-at-eval-time, so a single phase-1
 #     failure must not block the whole fan-out).
 #
-# Cluster is free + maintenance in ~12 h -> 12 h job limit, max concurrency.
+# 1 eval/GPU (2/GPU was too slow on 40 GB A100); free cluster -> wide fan-out.
+# 14 h job limit, inside the maintenance reservation (gpu-* reserved 06-12 ~09:05).
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LAUNCHER="${HERE}/run_focus_campaign.slurm"
 mkdir -p /hpc/mydata/alex.kalinin/logs/reeval
 
-J1=$(sbatch --parsable --array=0-1%2 "$LAUNCHER" gtwarm)
-echo "Phase 1 (gtwarm) submitted: array job $J1 (2 tasks, 4 ipsc_trained leaves)"
+J1=$(sbatch --parsable --array=0-3 "$LAUNCHER" gtwarm)
+echo "Phase 1 (gtwarm) submitted: array job $J1 (4 tasks = 4 ipsc_trained leaves, 1 eval/GPU)"
 
-J2=$(sbatch --parsable --dependency=afterany:"$J1" --array=0-7%8 "$LAUNCHER" eval)
-echo "Phase 2 (eval) submitted:   array job $J2 (8 tasks, 16 leaves) — afterany:$J1"
+J2=$(sbatch --parsable --dependency=afterany:"$J1" --array=0-15%16 "$LAUNCHER" eval)
+echo "Phase 2 (eval) submitted:   array job $J2 (16 tasks = 16 leaves, 1 eval/GPU) — afterany:$J1"
 
 echo
 echo "Watch:   squeue -j ${J1},${J2} -o '%.18i %.9P %.20j %.8T %.10M %.6D %R'"

--- a/applications/dynacell/tools/submit_focus_campaign.sh
+++ b/applications/dynacell/tools/submit_focus_campaign.sh
@@ -4,7 +4,7 @@
 #   Phase 1 (gtwarm): 4 *_ipsc_trained leaves -> 4 tasks (1 eval/GPU). Produces
 #     every GT-side cache (focus / GLCM-CP / focus-slab GT deep features / masks /
 #     in-focus instance plane).
-#   Phase 2 (eval): 16 leaves -> 16 tasks (1 eval/GPU). Reads the warm GT caches,
+#   Phase 2 (eval): 8 leaves -> 8 tasks (1 eval/GPU). Reads the warm GT caches,
 #     so it fans out fully in parallel. Gated on phase 1 with afterany (phase 2 can
 #     self-heal any un-warmed GT via compute-at-eval-time, so a single phase-1
 #     failure must not block the whole fan-out).
@@ -20,8 +20,8 @@ mkdir -p /hpc/mydata/alex.kalinin/logs/reeval
 J1=$(sbatch --parsable --array=0-3 "$LAUNCHER" gtwarm)
 echo "Phase 1 (gtwarm) submitted: array job $J1 (4 tasks = 4 ipsc_trained leaves, 1 eval/GPU)"
 
-J2=$(sbatch --parsable --dependency=afterany:"$J1" --array=0-15%16 "$LAUNCHER" eval)
-echo "Phase 2 (eval) submitted:   array job $J2 (16 tasks = 16 leaves, 1 eval/GPU) — afterany:$J1"
+J2=$(sbatch --parsable --dependency=afterany:"$J1" --array=0-7 "$LAUNCHER" eval)
+echo "Phase 2 (eval) submitted:   array job $J2 (8 tasks = 8 leaves, 1 eval/GPU) — afterany:$J1"
 
 echo
 echo "Watch:   squeue -j ${J1},${J2} -o '%.18i %.9P %.20j %.8T %.10M %.6D %R'"

--- a/applications/dynacell/tools/submit_focus_campaign.sh
+++ b/applications/dynacell/tools/submit_focus_campaign.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Submit the two-phase focus-aware re-eval campaign (PR #468).
+#
+#   Phase 1 (gtwarm): 4 *_ipsc_trained leaves -> 2 tasks (2 evals/GPU). Produces
+#     every GT-side cache (focus / GLCM-CP / focus-slab GT deep features / masks /
+#     in-focus instance plane).
+#   Phase 2 (eval): 16 leaves -> 8 tasks (2 evals/GPU). Reads the warm GT caches,
+#     so it fans out fully in parallel. Gated on phase 1 with afterany (phase 2 can
+#     self-heal any un-warmed GT via compute-at-eval-time, so a single phase-1
+#     failure must not block the whole fan-out).
+#
+# Cluster is free + maintenance in ~12 h -> 12 h job limit, max concurrency.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER="${HERE}/run_focus_campaign.slurm"
+mkdir -p /hpc/mydata/alex.kalinin/logs/reeval
+
+J1=$(sbatch --parsable --array=0-1%2 "$LAUNCHER" gtwarm)
+echo "Phase 1 (gtwarm) submitted: array job $J1 (2 tasks, 4 ipsc_trained leaves)"
+
+J2=$(sbatch --parsable --dependency=afterany:"$J1" --array=0-7%8 "$LAUNCHER" eval)
+echo "Phase 2 (eval) submitted:   array job $J2 (8 tasks, 16 leaves) — afterany:$J1"
+
+echo
+echo "Watch:   squeue -j ${J1},${J2} -o '%.18i %.9P %.20j %.8T %.10M %.6D %R'"
+echo "Logs:    /hpc/mydata/alex.kalinin/logs/reeval/focus_reeval_*"

--- a/uv.lock
+++ b/uv.lock
@@ -1340,6 +1340,7 @@ eval = [
     { name = "torch-fidelity" },
     { name = "tqdm" },
     { name = "transformers" },
+    { name = "waveorder" },
 ]
 eval-gpu = [
     { name = "cucim-cu13" },
@@ -1407,6 +1408,7 @@ requires-dist = [
     { name = "viscy-transforms", editable = "packages/viscy-transforms" },
     { name = "viscy-utils", editable = "packages/viscy-utils" },
     { name = "wandb", marker = "extra == 'wandb'" },
+    { name = "waveorder", marker = "extra == 'eval'", git = "https://github.com/mehta-lab/waveorder.git?branch=main" },
 ]
 provides-extras = ["eval", "eval-gpu", "preprocess", "report", "wandb"]
 
@@ -2236,9 +2238,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/8a/da01e20f823449c5b29337f5826153de5d88b5eb2637c8c8bbb5154ba681/imagecodecs-2026.5.10-cp314-cp314t-win32.whl", hash = "sha256:7189cb0919d2bd4e93be92c93b418be14997586bef3964a8ed40794a4a5ffff2", size = 16992026, upload-time = "2026-05-10T23:45:35.32Z" },
     { url = "https://files.pythonhosted.org/packages/b5/02/6c890895edb5b9ea47966085d6b67d2b2f28f9e9febe79b9fbdafb683486/imagecodecs-2026.5.10-cp314-cp314t-win_amd64.whl", hash = "sha256:78ce31baa9f5c38d269650bc18a9d904f63b0af07bb64e17e1a68d9fe9d16b39", size = 20991939, upload-time = "2026-05-10T23:45:39.19Z" },
     { url = "https://files.pythonhosted.org/packages/f6/51/307ae581e90e68a51cadfa6a1b2a211ae37ad9b9089ea00ac9fda1921324/imagecodecs-2026.5.10-cp314-cp314t-win_arm64.whl", hash = "sha256:7f429cab8f5cac312b992e3c2e78c17bde86421d81ded487ba1e80a66bbb2393", size = 16517632, upload-time = "2026-05-10T23:45:42.246Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c3/889bf8604e1b64f771c93ea2576df21a4e069dca54ebe615d794e411c954/imagecodecs-2026.5.10-cp315-cp315t-win32.whl", hash = "sha256:7d7a63566eaf38ff3535723909a17dcd548af25236e7d89496bc8b4ac4041c04", size = 16989140, upload-time = "2026-05-10T23:52:20.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/14/83168813ad79231c91e31ed20c37ac1d712d1ef434fee70e00f0f52d77b2/imagecodecs-2026.5.10-cp315-cp315t-win_amd64.whl", hash = "sha256:40a22aebc4575742b86e8f1465f4d357c3b18f4c07b58fc17f6bf96d48ab5477", size = 20985176, upload-time = "2026-05-10T23:52:23.876Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/a4/7eb6200e1bb72fd9b2a62d8a1734a5460fba72db0d40aa7bf0302284a0b3/imagecodecs-2026.5.10-cp315-cp315t-win_arm64.whl", hash = "sha256:06cea6c5f94ad5df835f908306eeb251b82118bf165f28e6331221a9a4976e66", size = 16511700, upload-time = "2026-05-10T23:52:27.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Make the dynacell eval's 2D projection **focus-aware**: instead of max-Z projecting (or fractional-slice picking) the full stack, center the 2D reduction on the **in-focus plane**, estimated per-FOV from the phase channel. Two opt-in knobs, both **default to current behavior**.

## Why

On A549 the stacks are Z=48 and the in-focus band is ~5 planes. The current full-volume MIP folds the out-of-focus membrane caps into the projection, filling cells into a structureless blob ("one object, no background" — the same degeneracy the instance-seg `frac=0.30` slice avoids). Measured on A549 membrane (`memb_celldiff_r2_a549trained_denv`, 48 cells / 12 FOVs):

| reduction | per-cell PCC | per-cell SSIM |
|---|---|---|
| full-volume MIP (current) | +0.630 | +0.149 |
| in-focus slab (phase focus, h=2) | +0.548 | **+0.304** |

The full MIP **inflates** GT-vs-pred PCC via shared out-of-focus haze and **deflates** SSIM; the in-focus slab roughly doubles structural agreement. A focus-finder comparison showed the membrane-variance `sharpest` method centers ~2–4 planes too shallow (into the haze), while waveorder phase focus lands in the eyeballed in-focus band; phase focus varies z=11–21 across FOVs (so a fixed fraction is structurally wrong). A width sweep at the phase center peaks at **h=1–2 (3–5 planes)**.

## How

- **`dynacell.evaluation.focus`** (new): `estimate_focus_plane` (via `waveorder.focus_from_transverse_band` — the estimator `qc.FocusSliceMetric` wraps, used directly to avoid an `applications/ → applications/` dep on `qc`), `write_focus_slice_metadata` (writes `focus_slice` zattrs in the **same schema DynaCLR's `z_range="auto"` reads**), and `read_focus_plane` / `focus_slab_from_plane` / `build_focus_slabs` readers.
- **`precompute-gt build.focus`**: writes `focus_slice` to the GT store (phase channel), plus a `focus:` config block (NA/λ/pixel/channel/device). Opens `r+` — packed `.ozx` must be repackaged after writing.
- **`feature_metrics.focus_slab` {enabled, halfwidth, channel_name}** (default off): restricts the deep-feature crops (`build_crops`) and per-cell similarity (`per_cell_similarity`) to a `2·halfwidth+1` slab centered on the GT focus plane. Slab is GT-derived and applied to the prediction (slice-by-slice). Threaded through `fov_deep_features`, the batched warm pass (`precompute_deep_features`, keyed by `pos_name` so the cache isn't poisoned), and `_fov_pred_features_per_t`. Enabling it folds a signature into each deep-feature `preprocess_version` so embedding caches auto-invalidate. **CP regionprops stay 3D** (intentionally untagged).
- **`segmentation.slice_selection=focus`**: the 2D instance-seg picker uses the in-focus plane per FOV (single slice, no slab) instead of `frac=0.30`.

## Validation

- Phase present in every GT store checked (A549 `.ozx`, iPSC `cell.zarr`, `SEC61B.zarr`, `TOMM20.zarr`) → focus covers all organelles.
- Writer smoke-tested on a synthetic store: recovered planted focus planes exactly, schema round-trips.
- Wiring smoke: imports clean, `build_focus_slabs` + `build_crops(z_slab=...)` parity verified.
- 10 precompute tests pass; ruff + repo pre-commit clean.

## Caveats / follow-ups

- Enabling `focus_slab`/`slice_selection=focus` **requires `focus_slice` metadata** in the GT stores (run `precompute-gt build.focus` first; repackage `.ozx`).
- Switching the reduction changes published numbers and invalidates the deep-feature caches (recompute expected).
- Campaign-config wiring + a one-leaf A40 integration run are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
