### PR TITLE
feat(dynacell/tools): canonical artifact-path migration + config codemod

### DIFF
--- a/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_cytolandft/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_cytolandft/a549_mantis/train.yml
@@ -48,6 +48,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_cytolandft/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_cytolandft/ipsc_confocal/train.yml
@@ -48,6 +48,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_infectionft_dynacellft/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_infectionft_dynacellft/a549_mantis/train.yml
@@ -48,6 +48,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_infectionft_dynacellft/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_dual_nucl_memb/vscyto3d_infectionft_dynacellft/ipsc_confocal/train.yml
@@ -48,6 +48,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_SEC61B_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/epoch=19-step=66240-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/epoch=19-step=66240-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_SEC61B_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_SEC61B_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/epoch=19-step=66240-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_celldiff_r2_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_SEC61B_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints/epoch=19-step=66240-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_A549_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,7 +29,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2/checkpoints
 
 data:
   init_args:
@@ -39,4 +39,4 @@ data:
 
 launcher:
   job_name: CELLDiff_A549_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_iterative__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_iterative__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_celldiff_r2_iterative__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_celldiff_r2_denoise.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_denoise/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_DN
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_denoise/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_celldiff_r2_iterative.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_ITER
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_iterative/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/epoch=19-step=108160.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_celldiff_r2_sliding_window.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_sliding_window/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_SEC61B_SW
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2_sliding_window/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_iPSC_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,8 +29,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2/checkpoints
 
 launcher:
   job_name: CELLDiff_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_celldiff_r2_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_SEC61B_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/epoch=19-step=176560-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/epoch=19-step=176560-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_celldiff_r2_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_SEC61B_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_celldiff_r2_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_SEC61B_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/epoch=19-step=176560-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/sec61b_celldiff_r2.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_SEC61B_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/celldiff_r2/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints/epoch=19-step=176560-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_JOINT_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -39,7 +39,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). Factored as a YAML anchor so the joint leaf stays auditable;
@@ -140,7 +140,7 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train_smoke.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train_smoke.yml
@@ -138,4 +138,4 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_SEC61B_SMOKE
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/smoke
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/smoke

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train_smoke_4gpu.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/celldiff/joint_ipsc_confocal_a549_mantis/train_smoke_4gpu.yml
@@ -155,4 +155,4 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_SEC61B_SMOKE_4GPU
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2/smoke_4gpu
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/celldiff_r2/smoke_4gpu

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=106-step=18404.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=106-step=18404.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=106-step=18404.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=106-step=18404.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=132-step=22876.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_pretrained_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_A549_SEC61B_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,7 +42,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained/checkpoints
 
 data:
   init_args:
@@ -52,4 +52,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_A549_SEC61B_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=123-step=32736.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=123-step=32736.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=123-step=32736.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -26,7 +26,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -25,7 +25,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=123-step=32736.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_pretrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -25,7 +25,7 @@ model:
     # ep 123 / val_loss 0.40979 (49-epoch plateau, scancelled at 3d 1h elapsed).
     # Hardlink alias at run_root; the underlying checkpoints/epoch=123-step=32736.ckpt
     # is also preserved in checkpoints_frozen_ep123_20260501_004946/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500/best_ep123_val0.40979.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_iPSC_SEC61B_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,8 +42,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_SEC61B_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=117-step=51094-v1.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=117-step=51094-v1.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=117-step=51094-v1.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # ckpt lives under the _ws8500 training-output subdir; config namespace
     # uses fcmae_vscyto3d_pretrained (no _ws8500 suffix) for consistency with
     # iPSC + a549 single-set predict configs.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
 
 data:
   init_args:
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_pretrained_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_SEC61B_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # ckpt lives under the _ws8500 training-output subdir; config namespace
     # uses fcmae_vscyto3d_pretrained (no _ws8500 suffix) for consistency with
     # iPSC + a549 single-set predict configs.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=48496.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints/epoch=117-step=51094-v1.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_JOINT_SEC61B_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,7 +57,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -151,4 +151,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_JOINT_SEC61B_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=132-step=22876.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints/epoch=137-step=23736.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_scratch_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -23,7 +23,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_A549_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -34,7 +34,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch/checkpoints
 
 data:
   init_args:
@@ -44,4 +44,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_A549_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -31,6 +31,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch/checkpoints/epoch=122-step=32472.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_scratch.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -31,6 +31,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -23,7 +23,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_iPSC_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -34,8 +34,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=99-step=43300.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=99-step=43300.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fcmae_vscyto3d_scratch_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=99-step=43300.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fcmae_vscyto3d_scratch_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_SEC61B_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=75-step=32908.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints/epoch=99-step=43300.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_JOINT_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -139,4 +139,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_JOINT_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,41 @@
+# fnet3d_paper predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/fnet3d_paper_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_denv
+  model_name: fnet3d_paper
+  experiment_id: er__a549_mantis__fnet3d_paper__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper/checkpoints/epoch=350-step=185679.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__denv/prediction.zarr
+
+launcher:
+  job_name: FNet3DPaper_PRED_SEC61B_A549TR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,41 @@
+# fnet3d_paper predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/fnet3d_paper_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_mock
+  model_name: fnet3d_paper
+  experiment_id: er__a549_mantis__fnet3d_paper__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper/checkpoints/epoch=350-step=185679.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__mock/prediction.zarr
+
+launcher:
+  job_name: FNet3DPaper_PRED_SEC61B_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,41 @@
+# fnet3d_paper predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/fnet3d_paper_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: fnet3d_paper
+  experiment_id: er__a549_mantis__fnet3d_paper__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper/checkpoints/epoch=350-step=185679.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: FNet3DPaper_PRED_SEC61B_A549TR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,41 @@
+# fnet3d_paper predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/fnet3d_paper_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: fnet3d_paper
+  experiment_id: er__a549_mantis__fnet3d_paper__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper/checkpoints/epoch=350-step=185679.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/ipsc/prediction.zarr
+
+launcher:
+  job_name: FNet3DPaper_PRED_SEC61B_A549TR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/train.yml
@@ -29,6 +29,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/a549_mantis/train.yml
@@ -21,7 +21,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_A549_SEC61B_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -32,7 +32,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper/checkpoints
 
 data:
   init_args:
@@ -42,7 +42,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_A549_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/sec61b/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~75 GB for SEC61B_all alone (single-set); 512G gives

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper/checkpoints/epoch=183-step=134688.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fnet3d_paper.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/train.yml
@@ -29,6 +29,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/ipsc_confocal/train.yml
@@ -21,7 +21,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_iPSC_SEC61B_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -32,8 +32,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/sec61b/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet3d_paper

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=125-step=159012.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=125-step=159012.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=125-step=159012.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_fnet3d_paper_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=125-step=159012.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints/epoch=106-step=135034.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_fnet3d_paper_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_SEC61B_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/fnet3d_paper/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_JOINT_SEC61B_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -115,7 +115,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_JOINT_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet3d_paper
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=64980.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__denv/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_A549TR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=64980.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__mock/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__a549_mantis__pix2pix3d_unetvit__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=64980.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_A549TR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: er__a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=64980.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/ipsc/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_SEC61B_A549TR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_A549_SEC61B_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,7 +40,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit/checkpoints
 
 data:
   init_args:
@@ -50,7 +50,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_A549_SEC61B_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=102752.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=102752.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=102752.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=102752.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=102752.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=102752.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_pix2pix3d_unetvit__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=102752.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/pix2pix3d_unetvit/checkpoints/epoch=37-step=102752.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_SEC61B
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu.yml
@@ -41,6 +41,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
@@ -41,6 +41,8 @@ trainer:
         # the inference path (predict_step uses _inference_generator which
         # prefers EMA when available).
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit/checkpoints/epoch=25-step=114036.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit/checkpoints/epoch=25-step=114036.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit/checkpoints/epoch=25-step=114036.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/sec61b_pix2pix3d_unetvit__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit/checkpoints/epoch=25-step=114036.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/sec61b_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_SEC61B_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/pix2pix3d_unetvit/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -49,6 +49,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -41,7 +41,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_JOINT_SEC61B_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -52,7 +52,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). `_`-prefixed top-level keys are stripped by load_composed_config
@@ -150,7 +150,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_SEC61B_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_denv
+  model_name: unetvit3d
+  experiment_id: er__a549_mantis__unetvit3d__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d/checkpoints/epoch=11-step=40392.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__denv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_A549TR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_mock
+  model_name: unetvit3d
+  experiment_id: er__a549_mantis__unetvit3d__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d/checkpoints/epoch=11-step=40392.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__mock/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: unetvit3d
+  experiment_id: er__a549_mantis__unetvit3d__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d/checkpoints/epoch=11-step=40392.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_A549TR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: unetvit3d
+  experiment_id: er__a549_mantis__unetvit3d__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d/checkpoints/epoch=11-step=40392.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/ipsc/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_A549TR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_A549_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,7 +30,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d/checkpoints
 
 data:
   init_args:
@@ -40,4 +40,4 @@ data:
 
 launcher:
   job_name: UNetViT3D_A549_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/sec61b/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/unetvit3d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_unetvit3d__sec61b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_SEC61B_ON_A549_sec61b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/epoch=19-step=108160.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_unetvit3d__sec61b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_SEC61B_ON_A549_sec61b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/epoch=19-step=108160.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/sec61b_unetvit3d__sec61b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_SEC61B_ON_A549_sec61b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/epoch=19-step=108160.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/sec61b_unetvit3d.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_SEC61B
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints/epoch=19-step=108160.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_iPSC_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,8 +30,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d/checkpoints
 
 launcher:
   job_name: UNetViT3D_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/sec61b/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/unetvit3d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_denv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_denv
+  model_name: unetvit3d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_sec61b_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d/checkpoints/epoch=19-step=176560.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__denv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_JOINTTR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_mock.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_mock
+  model_name: unetvit3d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_sec61b_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d/checkpoints/epoch=19-step=176560.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__mock/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_JOINTTR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_sec61b_zikv.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_sec61b_zikv
+  model_name: unetvit3d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_sec61b_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d/checkpoints/epoch=19-step=176560.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_JOINTTR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: er (SEC61B) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: unetvit3d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__unetvit3d__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d/checkpoints/epoch=19-step=176560.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/ipsc/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_SEC61B_JOINTTR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/er/unetvit3d/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_JOINT_SEC61B
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,7 +40,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). Factored as a YAML anchor so the joint leaf stays auditable.
@@ -143,7 +143,7 @@ data:
 
 launcher:
   job_name: UNetViT3D_JOINT_SEC61B
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/sec61b/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/unetvit3d
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/a549_mantis/train.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/ipsc_confocal/train.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/unext2/joint_ipsc_confocal_a549_mantis/train.yml
@@ -45,6 +45,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_MEMB_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_MEMB_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_MEMB_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_celldiff_r2_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_MEMB_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_A549_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,7 +29,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2/checkpoints
 
 data:
   init_args:
@@ -39,4 +39,4 @@ data:
 
 launcher:
   job_name: CELLDiff_A549_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_iterative_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_iterative_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_celldiff_r2_iterative_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_celldiff_r2_denoise.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_denoise/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_DN
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_denoise/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_celldiff_r2_iterative.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_ITER
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_iterative/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_celldiff_r2_sliding_window.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_sliding_window/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_MEMB_SW
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2_sliding_window/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_iPSC_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,8 +29,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2/checkpoints
 
 launcher:
   job_name: CELLDiff_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_celldiff_r2_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_celldiff_r2_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_celldiff_r2_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/memb_celldiff_r2.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_MEMB_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/celldiff_r2/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
@@ -33,7 +33,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_JOINT_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -43,7 +43,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -130,7 +130,7 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/celldiff_r2
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=121-step=26474.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
 
 data:
   init_args:
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
 
 data:
   init_args:
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=121-step=26474.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
 
 data:
   init_args:
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -27,7 +27,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=121-step=26474.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_pretrained_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=154-step=33635.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=121-step=26474.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -57,6 +57,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -49,7 +49,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_A549_Membrane
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -60,8 +60,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_A549_Membrane
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=189-step=59280.ckpt
 
 data:
   init_args:
@@ -34,8 +34,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_pretrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_iPSC_Membrane
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,8 +57,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_Membrane
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_pretrained_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained/checkpoints/epoch=111-step=59360.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_pretrained_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_MEMB_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_pretrained/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_JOINT_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,7 +57,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -151,4 +151,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_JOINT_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=119-step=26040.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_scratch_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -41,7 +41,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_A549_Membrane
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -52,8 +52,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_A549_Membrane
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -49,6 +49,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -51,8 +51,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=136-step=42744.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -51,8 +51,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=136-step=42744.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -51,8 +51,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -34,7 +34,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=136-step=42744.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=136-step=42744.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # by 4.3%; prefer the pretrained predict configs for downstream eval.
     # Hardlink alias at run_root; underlying epoch=136-step=42744.ckpt also
     # preserved in checkpoints_frozen_ep136_20260501_005505/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/best_ep136_val0.39590.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_scratch.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -38,7 +38,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_iPSC_Membrane
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -49,8 +49,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_Membrane
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -46,6 +46,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fcmae_vscyto3d_scratch_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch/checkpoints/epoch=112-step=59890.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fcmae_vscyto3d_scratch_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_MEMB_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fcmae_vscyto3d_scratch/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_JOINT_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -139,4 +139,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_JOINT_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper/checkpoints/epoch=281-step=191760.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fnet3d_paper_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/train.yml
@@ -53,7 +53,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_A549_MEMB_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -64,11 +64,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_A549_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/memb/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~75 GB for CAAX_all alone (single-set); 512G gives

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/a549_mantis/train.yml
@@ -61,6 +61,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper/checkpoints/epoch=181-step=157612.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fnet3d_paper.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/train.yml
@@ -58,6 +58,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/ipsc_confocal/train.yml
@@ -50,7 +50,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_iPSC_MEMB_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -61,11 +61,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/memb/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet3d_paper
   # cell.zarr-backed preload (same plate as nucleus) puts MaxVMSize over
   # the shared 256G cap; bump to match nucleus.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_fnet3d_paper_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper/checkpoints/epoch=116-step=180882.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_fnet3d_paper_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_MEMB_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/fnet3d_paper/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_JOINT_MEMB_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -115,7 +115,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_JOINT_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~185 GB for joint cell.zarr + CAAX_all; 512G gives

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ model:
   init_args:
     # Best loss/validate_ema checkpoint of the modernized Run-D 40ep A549
     # membrane run (job 33674784, best at epoch 37, validate_ema=0.3792).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=82080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit/checkpoints/epoch=37-step=82080.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit_a549trained__caax_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_MEMB_caax_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ model:
   init_args:
     # Best loss/validate_ema checkpoint of the modernized Run-D 40ep A549
     # membrane run (job 33674784, best at epoch 37, validate_ema=0.3792).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=82080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit/checkpoints/epoch=37-step=82080.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit_a549trained__caax_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_MEMB_caax_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ model:
   init_args:
     # Best loss/validate_ema checkpoint of the modernized Run-D 40ep A549
     # membrane run (job 33674784, best at epoch 37, validate_ema=0.3792).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=82080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit/checkpoints/epoch=37-step=82080.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit_a549trained__caax_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_MEMB_caax_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ model:
     # membrane run (job 33674784 / wandb 20260604-221028, best at epoch 37,
     # validate_ema=0.3792). iPSC keys membrane as `membrane`, so no
     # dataset_ref override is needed here (unlike the A549 test leaves).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=37-step=82080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit/checkpoints/epoch=37-step=82080.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_pix2pix3d_unetvit_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_MEMB_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_A549_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,7 +40,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit/checkpoints
 
 data:
   init_args:
@@ -50,7 +50,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_A549_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=25-step=83200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit/checkpoints/epoch=25-step=83200.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=25-step=83200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit/checkpoints/epoch=25-step=83200.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=25-step=83200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit/checkpoints/epoch=25-step=83200.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_pix2pix3d_unetvit__caax_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_MEMB_ON_A549_caax_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=25-step=83200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit/checkpoints/epoch=25-step=83200.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_MEMB
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_iPSC_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,11 +40,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit/checkpoints
 
 launcher:
   job_name: pix2pix3d_unetvit_iPSC_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/epoch=35-step=192960.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/epoch=35-step=192960.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/epoch=35-step=192960.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/memb_pix2pix3d_unetvit__caax_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_A549_caax_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/memb_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_MEMB_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/pix2pix3d_unetvit/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints/epoch=35-step=192960.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_JOINT_MEMB
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,7 +42,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). `_`-prefixed top-level keys are stripped by load_composed_config
@@ -140,7 +140,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_MEMB
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; default 256G
   # is too tight for the iPSC marker store + A549 pool + worker overhead.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -41,7 +41,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_JOINT_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -52,7 +52,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). `_`-prefixed top-level keys are stripped by load_composed_config
@@ -150,7 +150,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_MEMB_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -49,6 +49,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_unetvit3d_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_MEMB_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/epoch=18-step=121600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_unetvit3d_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_MEMB_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/epoch=18-step=121600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/memb_unetvit3d_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_MEMB_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/epoch=18-step=121600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/epoch=18-step=121600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/memb/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/memb_unetvit3d.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_MEMB
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/membrane/unetvit3d/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -41,6 +41,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_TOMM20_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/epoch=19-step=64800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_TOMM20_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/epoch=19-step=64800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_TOMM20_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/epoch=19-step=64800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_celldiff_r2_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_TOMM20_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints/epoch=19-step=64800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_A549_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,7 +29,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2/checkpoints
 
 data:
   init_args:
@@ -39,4 +39,4 @@ data:
 
 launcher:
   job_name: CELLDiff_A549_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_iterative__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_iterative__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_celldiff_r2_iterative__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_celldiff_r2_denoise.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_denoise/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_DN
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_denoise/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_celldiff_r2_iterative.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_ITER
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_iterative/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_celldiff_r2_sliding_window.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_sliding_window/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_TOMM20_SW
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2_sliding_window/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_iPSC_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,8 +29,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2/checkpoints
 
 launcher:
   job_name: CELLDiff_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/epoch=19-step=192800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_celldiff_r2_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_TOMM20_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_celldiff_r2_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_TOMM20_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/epoch=19-step=192800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/epoch=19-step=192800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_celldiff_r2_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_TOMM20_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/tomm20_celldiff_r2.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_TOMM20_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/celldiff_r2/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints/epoch=19-step=192800-v1.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_JOINT_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -39,7 +39,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2/checkpoints
 
 # `_`-prefixed top-level keys are stripped by load_composed_config; see
 # er/celldiff_r2/joint_*/train.yml for the full anchor-convention rationale.
@@ -133,7 +133,7 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/celldiff_r2
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=115-step=18328.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=115-step=18328.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=115-step=18328.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=115-step=18328.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=139-step=22120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=139-step=22120.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_pretrained_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_A549_TOMM20_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,7 +42,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained/checkpoints
 
 data:
   init_args:
@@ -52,4 +52,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_A549_TOMM20_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=58-step=18408.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=58-step=18408.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=58-step=18408.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=58-step=18408.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=58-step=18408.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=58-step=18408.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=58-step=18408.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=58-step=18408.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_pretrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_iPSC_TOMM20_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,8 +42,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_TOMM20_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=70-step=34080.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=70-step=34080.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_pretrained_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=70-step=34080.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # ckpt lives under the _ws8500 training-output subdir; config namespace
     # uses fcmae_vscyto3d_pretrained (no _ws8500 suffix) for consistency with
     # iPSC + a549 single-set predict configs.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
 
 data:
   init_args:
@@ -44,8 +44,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_pretrained_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_TOMM20_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_pretrained/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -27,7 +27,7 @@ model:
     # ckpt lives under the _ws8500 training-output subdir; config namespace
     # uses fcmae_vscyto3d_pretrained (no _ws8500 suffix) for consistency with
     # iPSC + a549 single-set predict configs.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=43-step=21120.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints/epoch=70-step=34080.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_JOINT_TOMM20_ws8500
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,7 +57,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -151,4 +151,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_JOINT_TOMM20_ws8500
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_pretrained_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=167-step=26544.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=167-step=26544.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=167-step=26544.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -29,7 +29,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=167-step=26544.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -29,7 +29,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=113-step=18012.ckpt
 
 data:
   init_args:
@@ -46,8 +46,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_scratch_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -22,7 +22,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_A549_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -33,7 +33,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch/checkpoints
 
 data:
   init_args:
@@ -43,4 +43,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_A549_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -30,6 +30,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=21840.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_scratch.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -22,7 +22,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_iPSC_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -33,8 +33,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -30,6 +30,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=33600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=33600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fcmae_vscyto3d_scratch_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=33600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fcmae_vscyto3d_scratch_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_TOMM20_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fcmae_vscyto3d_scratch/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=63-step=30720.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints/epoch=69-step=33600.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_JOINT_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -139,4 +139,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_JOINT_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=170-step=87210.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=170-step=87210.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=170-step=87210.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=170-step=87210.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=126990.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fnet3d_paper_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/train.yml
@@ -20,7 +20,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_A549_TOMM20_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -31,7 +31,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper/checkpoints
 
 data:
   init_args:
@@ -41,7 +41,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_A549_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/tomm20/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~75 GB for TOMM20_all alone (single-set); 512G gives

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/a549_mantis/train.yml
@@ -28,6 +28,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper/checkpoints/epoch=215-step=187056.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fnet3d_paper.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/train.yml
@@ -20,7 +20,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_iPSC_TOMM20_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -31,8 +31,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/tomm20/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet3d_paper

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/ipsc_confocal/train.yml
@@ -28,6 +28,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=139-step=192640.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=139-step=192640.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_fnet3d_paper_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -22,7 +22,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=139-step=192640.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=139-step=192640.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints/epoch=132-step=183008.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_fnet3d_paper_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_TOMM20_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/fnet3d_paper/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_JOINT_TOMM20_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -115,7 +115,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_JOINT_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet3d_paper
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_denv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_denv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=44072.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__denv/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_A549TR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_mock.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_mock
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=44072.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__mock/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_zikv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_zikv
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__a549_mantis__pix2pix3d_unetvit__a549_mantis_tomm20_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=44072.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_A549TR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# pix2pix3d_unetvit predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/pix2pix3d_unetvit_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: pix2pix3d_unetvit
+  experiment_id: mito__a549_mantis__pix2pix3d_unetvit__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=44072.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/ipsc/prediction.zarr
+
+launcher:
+  job_name: pix2pix3d_unetvit_PRED_TOMM20_A549TR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_A549_TOMM20_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,7 +40,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit/checkpoints
 
 data:
   init_args:
@@ -50,7 +50,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_A549_TOMM20_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_pix2pix3d_unetvit__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_TOMM20
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=136192.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=136192.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/tomm20_pix2pix3d_unetvit__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=136192.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit/checkpoints/epoch=27-step=136192.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/tomm20_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_TOMM20_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/pix2pix3d_unetvit/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -41,7 +41,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_JOINT_TOMM20_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -52,7 +52,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). `_`-prefixed top-level keys are stripped by load_composed_config
@@ -150,7 +150,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_TOMM20_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -49,6 +49,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_denv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_denv
+  model_name: unetvit3d
+  experiment_id: mito__a549_mantis__unetvit3d__a549_mantis_tomm20_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d/checkpoints/epoch=16-step=53550.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__denv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_A549TR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_mock.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_mock
+  model_name: unetvit3d
+  experiment_id: mito__a549_mantis__unetvit3d__a549_mantis_tomm20_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d/checkpoints/epoch=16-step=53550.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__mock/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_zikv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: a549_mantis_tomm20_zikv
+  model_name: unetvit3d
+  experiment_id: mito__a549_mantis__unetvit3d__a549_mantis_tomm20_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d/checkpoints/epoch=16-step=53550.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_A549TR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: a549_mantis
+  predict_set: ipsc_confocal
+  model_name: unetvit3d
+  experiment_id: mito__a549_mantis__unetvit3d__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d/checkpoints/epoch=16-step=53550.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/ipsc/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_A549TR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/a549__deconv/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_A549_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,7 +30,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d/checkpoints
 
 data:
   init_args:
@@ -40,4 +40,4 @@ data:
 
 launcher:
   job_name: UNetViT3D_A549_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/tomm20/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/unetvit3d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_unetvit3d__tomm20_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_TOMM20_ON_A549_tomm20_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_unetvit3d__tomm20_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_TOMM20_ON_A549_tomm20_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/tomm20_unetvit3d__tomm20_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_TOMM20_ON_A549_tomm20_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/tomm20_unetvit3d.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_TOMM20
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_iPSC_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,8 +30,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d/checkpoints
 
 launcher:
   job_name: UNetViT3D_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/tomm20/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/unetvit3d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_denv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_denv
+  model_name: unetvit3d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_tomm20_denv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d/checkpoints/epoch=19-step=189200.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__denv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_JOINTTR_DENV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_mock.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_mock
+  model_name: unetvit3d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_tomm20_mock
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d/checkpoints/epoch=19-step=189200.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__mock/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_JOINTTR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_tomm20_zikv.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: a549_mantis_tomm20_zikv
+  model_name: unetvit3d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__unetvit3d__a549_mantis_tomm20_zikv
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d/checkpoints/epoch=19-step=189200.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__zikv/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_JOINTTR_ZIKV
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -1,0 +1,43 @@
+# unetvit3d predict: mito (TOMM20) trained on joint_ipsc_confocal_a549_mantis. Gap-fill predict leaf (2026-07-14).
+base:
+  - ../../../_internal/shared/model/predict_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/model_overlays/unetvit3d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  trained_on: joint_ipsc_confocal_a549_mantis
+  predict_set: ipsc_confocal
+  model_name: unetvit3d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__unetvit3d__ipsc_confocal
+
+model:
+  init_args:
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d/checkpoints/epoch=19-step=189200.ckpt
+
+data:
+  init_args:
+    # override target-inherited normalizations: predict only reads source
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    # clear target-inherited RandWeightedCropd; predict has no CPU augs
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/ipsc/prediction.zarr
+
+launcher:
+  job_name: UNetViT3D_PRED_TOMM20_JOINTTR_IPSC
+  run_root: /hpc/projects/virtual_staining/training/dynacell/mito/unetvit3d/joint__legacy_deconvgt/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -29,7 +29,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_JOINT_TOMM20
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -40,7 +40,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -134,7 +134,7 @@ data:
 
 launcher:
   job_name: UNetViT3D_JOINT_TOMM20
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/tomm20/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/unetvit3d
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -37,6 +37,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_NUCL_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_denv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_NUCL_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_mock.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_NUCL_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__a549_mantis_zikv.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_celldiff_r2_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_A549_PRED_NUCL_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints/epoch=19-step=86400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/a549_mantis/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_A549_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,7 +29,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2/checkpoints
 
 data:
   init_args:
@@ -39,4 +39,4 @@ data:
 
 launcher:
   job_name: CELLDiff_A549_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_iterative_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_iterative_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_celldiff_r2_iterative_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__denoise.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: denoise
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_celldiff_r2_denoise.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_denoise/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_DN
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_denoise/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_celldiff_r2_iterative.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_ITER
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_iterative/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__iterative.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_celldiff_r2_sliding_window.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_sliding_window/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_PRED_NUCL_SW
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2_sliding_window/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/predict__ipsc_confocal__sliding_window.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints/epoch=19-step=128000.ckpt
     predict_method: sliding_window
     predict_overlap: [0, 0, 0]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_iPSC_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -29,8 +29,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2/checkpoints
 
 launcher:
   job_name: CELLDiff_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/celldiff_r2

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_celldiff_r2_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_NUCL_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative # denoise, generate, sliding_window, or iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_celldiff_r2_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_NUCL_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_celldiff_r2_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_NUCL_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/epoch=19-step=214400.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints/last.ckpt
     predict_method: iterative
     predict_overlap: [4, 256, 256]
 
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/nucl_celldiff_r2.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: CELLDiff_JOINT_PRED_NUCL_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/celldiff_r2/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/celldiff/joint_ipsc_confocal_a549_mantis/train.yml
@@ -33,7 +33,7 @@ trainer:
   logger:
     init_args:
       name: CELLDiff_JOINT_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -43,7 +43,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: -1
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -133,7 +133,7 @@ data:
 
 launcher:
   job_name: CELLDiff_JOINT_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/celldiff_r2
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/celldiff_r2
   # Joint preloads two stores (iPSC + A549 pool) into /dev/shm; the default
   # 256G cap is too tight (256G iPSC mem + ~50G A549 + worker peak OOMs).
   # 512G is the smallest tier that fits joint preload + worker overhead.

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=134-step=29295.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_pretrained_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -57,6 +57,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/a549_mantis/train.yml
@@ -49,7 +49,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_A549_Nucleus
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -60,8 +60,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_A549_Nucleus
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_pretrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_iPSC_Nucleus
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,8 +57,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_Nucleus
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -28,7 +28,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
 
 data:
   init_args:
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_pretrained_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained/checkpoints/epoch=62-step=33390.ckpt
 
 data:
   init_args:
@@ -40,8 +40,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_pretrained_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_PRED_NUCL_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_pretrained/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -54,6 +54,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -46,7 +46,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Pretrained_JOINT_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -57,7 +57,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -152,4 +152,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Pretrained_JOINT_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_pretrained
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=110-step=24087.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_scratch_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -49,6 +49,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/a549_mantis/train.yml
@@ -41,7 +41,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_A549_Nucleus
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -52,8 +52,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_A549_Nucleus
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=80-step=25272.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -52,8 +52,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=80-step=25272.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -52,8 +52,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=80-step=25272.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -35,7 +35,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -52,8 +52,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -28,7 +28,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -45,8 +45,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_scratch.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/predict__ipsc_confocal.yml
@@ -28,7 +28,7 @@ model:
     # unless explicitly ablating against the scratch baseline.
     # Hardlink alias at run_root; underlying epoch=80-step=25272.ckpt also
     # preserved in checkpoints_frozen_ep80_<ts>/.
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/best_ep80_val0.39342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=80-step=25272.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -46,6 +46,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/ipsc_confocal/train.yml
@@ -38,7 +38,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_iPSC_Nucleus
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -49,8 +49,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch/checkpoints
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_Nucleus
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fcmae_vscyto3d_scratch_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -21,7 +21,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch/checkpoints/epoch=92-step=49290.ckpt
 
 data:
   init_args:
@@ -38,8 +38,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fcmae_vscyto3d_scratch_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_PRED_NUCL_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto3d_scratch/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FCMAE_VSCyto3D_Scratch_JOINT_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 5
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -139,4 +139,4 @@ data:
 
 launcher:
   job_name: FCMAE_VSCyto3D_Scratch_JOINT_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fcmae_vscyto3d_scratch
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto3d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto3d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 5
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_denv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_a549trained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_A549TR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_a549trained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_A549TR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__a549_mantis_zikv.yml
@@ -25,7 +25,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_a549trained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_A549TR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/predict__ipsc_confocal.yml
@@ -19,7 +19,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper/checkpoints/epoch=293-step=199920.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fnet3d_paper_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_A549TR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/train.yml
@@ -61,6 +61,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/a549_mantis/train.yml
@@ -53,7 +53,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_A549_NUCL_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -64,11 +64,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_A549_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549_mantis/nucl/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~75 GB for H2B_all alone (single-set) or ~185 GB for

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
 
 data:
   init_args:
@@ -41,8 +41,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/predict__ipsc_confocal.yml
@@ -18,7 +18,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper/checkpoints/epoch=226-step=196582.ckpt
 
 data:
   init_args:
@@ -35,8 +35,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fnet3d_paper.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/train.yml
@@ -58,6 +58,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/ipsc_confocal/train.yml
@@ -50,7 +50,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_iPSC_NUCL_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -61,11 +61,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper/checkpoints
 
 launcher:
   job_name: FNet3DPaper_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucl/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet3d_paper
   # cell.zarr-backed preload pushes MaxVMSize past the shared 256G cap
   # (observed 264G on the first launch; worker OOM-killed in validation).
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_jointtrained_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_JOINTTR_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_jointtrained_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_JOINTTR_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -26,7 +26,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_fnet3d_paper_jointtrained_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_JOINTTR_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -20,7 +20,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper/checkpoints/epoch=126-step=196342.ckpt
 
 data:
   init_args:
@@ -37,8 +37,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_fnet3d_paper_jointtrained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: FNet3DPaper_PRED_NUCL_JOINTTR_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fnet3d_paper/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -34,7 +34,7 @@ trainer:
   logger:
     init_args:
       name: FNet3D_JOINT_NUCL_paper
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -45,7 +45,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper/checkpoints
 
 _hcs_init_args: &hcs_init_args
   source_channel: Phase3D
@@ -118,7 +118,7 @@ data:
 
 launcher:
   job_name: FNet3DPaper_JOINT_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint_ipsc_confocal_a549_mantis/nucl/fnet3d_paper
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet3d_paper
   # 512G to match the shared headroom convention across the fnet3d
   # leaves on a549/joint workloads. mmap_preload after the BasicIndexer
   # fix peaks at ~185 GB for joint cell.zarr + H2B_all; 512G gives

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet3d_paper/joint_ipsc_confocal_a549_mantis/train.yml
@@ -42,6 +42,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=86400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=86400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=86400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit_a549trained__h2b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_h2b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/predict__ipsc_confocal.yml
@@ -20,7 +20,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501550, best at epoch 39, validate_ema=1.51563). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=86400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=86400.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_pix2pix3d_unetvit_a549trained.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_A549TR_PRED_NUCL_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/a549/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_A549_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,7 +42,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit/checkpoints
 
 data:
   init_args:
@@ -52,7 +52,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_A549_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/a549_mantis/train_4gpu_modernized.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501549, converged early at epoch 15). predict_step uses generator_ema
     # (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501549, converged early at epoch 15). predict_step uses generator_ema
     # (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501549, converged early at epoch 15). predict_step uses generator_ema
     # (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucl_pix2pix3d_unetvit__h2b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_NUCL_ON_A549_h2b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/predict__ipsc_confocal.yml
@@ -20,7 +20,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33501549, converged early at epoch 15). predict_step uses generator_ema
     # (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=15-step=51200.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit/checkpoints/epoch=15-step=51200.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucl_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_PRED_NUCL
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
@@ -31,7 +31,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_iPSC_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -42,11 +42,11 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit/checkpoints
 
 launcher:
   job_name: pix2pix3d_unetvit_iPSC_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/ipsc_confocal/train_4gpu_modernized.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_denv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__denv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_denv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__mock/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_mock
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_zikv.yml
@@ -24,7 +24,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:
@@ -43,8 +43,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions/nucl_pix2pix3d_unetvit__h2b_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__zikv/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_A549_h2b_zikv
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__ipsc_confocal.yml
@@ -20,7 +20,7 @@ model:
     # Best loss/validate_ema checkpoint, modernized Run-D 40ep run (job
     # 33502019, best at epoch 39, validate_ema=1.00041). predict_step uses
     # generator_ema (use_ema_at_predict=True default).
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints/epoch=39-step=214400.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit/checkpoints/epoch=39-step=214400.ckpt
 
 data:
   init_args:
@@ -39,8 +39,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions/nucl_pix2pix3d_unetvit.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/ipsc/prediction.zarr
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_PRED_NUCL_ON_IPSC
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/joint_predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/pix2pix3d_unetvit/joint/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train.yml
@@ -39,6 +39,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -43,7 +43,7 @@ trainer:
   logger:
     init_args:
       name: pix2pix3d_unetvit_JOINT_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -54,7 +54,7 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit/checkpoints
 
 # Child HCSDataModule init_args shared across both datasets (only data_path
 # differs). `_`-prefixed top-level keys are stripped by load_composed_config
@@ -152,7 +152,7 @@ data:
 
 launcher:
   job_name: pix2pix3d_unetvit_JOINT_NUCL_4gpu_modernized_lambdaL1_10_lecam_40ep
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/joint_ipsc_confocal_a549_mantis/nucl/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/pix2pix3d_unetvit
   # pix2pix3d GAN (UNetViT3D G + multiscale-patch D, large 3D crops) OOMs on
   # 80 GB h100; needs h200 (141 GB). Narrow the hardware_4gpu h100|h200 default.
   sbatch:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/train_4gpu_modernized.yml
@@ -51,6 +51,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate_ema
+        filename: "epoch={epoch}-step={step}-loss={loss/validate_ema:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/a549_mantis/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucleus_unetvit3d_denv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__denv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_NUCLEUS_ON_A549_DENV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__denv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_denv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucleus_unetvit3d_mock.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__mock/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_NUCLEUS_ON_A549_MOCK
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_mock.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__a549_mantis_zikv.yml
@@ -23,7 +23,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -42,8 +42,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/a549/predictions/nucleus_unetvit3d_zikv.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__zikv/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_NUCLEUS_ON_A549_ZIKV
-  run_root: /hpc/projects/virtual_staining/training/dynacell/a549/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/a549__zikv

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/epoch=19-step=128000.ckpt
 
 data:
   init_args:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/predict__ipsc_confocal.yml
@@ -17,7 +17,7 @@ benchmark:
 
 model:
   init_args:
-    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d/checkpoints/last.ckpt
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints/last.ckpt
 
 data:
   init_args:
@@ -36,8 +36,8 @@ trainer:
   callbacks:
     - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
       init_args:
-        output_store: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions/nucleus_unetvit3d.zarr
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/ipsc/prediction.zarr
 
 launcher:
   job_name: UNetViT3D_PRED_NUCLEUS
-  run_root: /hpc/projects/virtual_staining/training/dynacell/ipsc/predictions
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/unetvit3d/ipsc/ipsc

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/train.yml
@@ -27,6 +27,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/ipsc_confocal/train.yml
@@ -19,7 +19,7 @@ trainer:
   logger:
     init_args:
       name: UNetViT3D_iPSC_NUCL
-      save_dir: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d
   callbacks:
     - class_path: lightning.pytorch.callbacks.LearningRateMonitor
       init_args:
@@ -30,8 +30,8 @@ trainer:
         every_n_epochs: 1
         save_top_k: 4
         save_last: true
-        dirpath: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d/checkpoints
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d/checkpoints
 
 launcher:
   job_name: UNetViT3D_NUCL
-  run_root: /hpc/projects/comp.micro/virtual_staining/models/cell_diff_vs_viscy/ipsc/nucl/unetvit3d
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/unetvit3d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/unetvit3d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -41,6 +41,8 @@ trainer:
     - class_path: lightning.pytorch.callbacks.ModelCheckpoint
       init_args:
         monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
         every_n_epochs: 1
         save_top_k: 4
         save_last: true

--- a/applications/dynacell/tests/test_bake_best_ckpt.py
+++ b/applications/dynacell/tests/test_bake_best_ckpt.py
@@ -1,0 +1,93 @@
+"""Tests for the best-checkpoint baking codemod (bake_best_ckpt)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import bake_best_ckpt as bb
+
+from dynacell.evaluation import paths
+
+MODELS = str(paths.MODELS_ROOT)
+
+
+def _fixed(path):
+    """A resolver stub that ignores the dir and returns a fixed Path (or None)."""
+    return lambda _d: path
+
+
+def _boom(_d):
+    raise AssertionError("resolver must not run for preserved values")
+
+
+def test_ckpt_dir_for_standard_and_alias():
+    assert bb._ckpt_dir_for(f"{MODELS}/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=1.ckpt") == Path(
+        f"{MODELS}/a549/mito/fnet3d_paper/checkpoints"
+    )
+    # bare best-epoch alias at the model run-dir root -> the alias's own dir
+    assert bb._ckpt_dir_for(f"{MODELS}/ipsc/er/fcmae_vscyto3d_pretrained/best_ep123_val0.40979.ckpt") == Path(
+        f"{MODELS}/ipsc/er/fcmae_vscyto3d_pretrained"
+    )
+
+
+def test_rebake_stale_filename():
+    """A dangling baked epoch is rewritten to the resolver's best (the retrained case)."""
+    old = f"{MODELS}/a549/mito/fnet3d_paper/checkpoints/epoch=248-step=999.ckpt"
+    new = f"{MODELS}/a549/mito/fnet3d_paper/checkpoints/epoch=170-step=1.ckpt"
+    text = f"predict:\n  model:\n    init_args:\n      ckpt_path: {old}\n"
+    new_text, changes = bb.bake_leaf(text, _fixed(Path(new)))
+    assert f"ckpt_path: {new}\n" in new_text
+    assert changes == [(old, new, "rebaked")]
+
+
+def test_already_best_is_noop():
+    val = f"{MODELS}/a549/er/fnet3d_paper/checkpoints/epoch=350-step=1.ckpt"
+    text = f"model:\n  init_args:\n    ckpt_path: {val}\n"
+    new_text, changes = bb.bake_leaf(text, _fixed(Path(val)))
+    assert new_text == text
+    assert changes == [(val, val, "already_best")]
+
+
+def test_replace_me_and_external_preserved():
+    published = "/hpc/projects/comp.micro/virtual_staining/datasets/public/VS_models/VSCyto3D/epoch=83.ckpt"
+    for val, cat in (("REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH", "replace_me"), (published, "external")):
+        text = f"model:\n  init_args:\n    ckpt_path: {val}\n"
+        new_text, changes = bb.bake_leaf(text, _boom)
+        assert new_text == text
+        assert changes == [(val, val, cat)]
+
+
+def test_canonical_ckpt_dir_for_leaf():
+    rel = Path("er/pix2pix3d_unetvit/joint_ipsc_confocal_a549_mantis/predict__a549_mantis_mock.yml")
+    assert bb.canonical_ckpt_dir_for_leaf(rel) == Path(f"{MODELS}/joint/er/pix2pix3d_unetvit/checkpoints")
+    # organelle/train alias also resolves (sec61b -> er, a549_mantis -> a549)
+    rel2 = Path("mito/fnet3d_paper/a549_mantis/predict__a549_mantis_mock.yml")
+    assert bb.canonical_ckpt_dir_for_leaf(rel2) == Path(f"{MODELS}/a549/mito/fnet3d_paper/checkpoints")
+    # a train term that does not normalize -> None (no grammar fallback)
+    assert bb.canonical_ckpt_dir_for_leaf(Path("er/x/_no_train_randinit/predict__a549_mantis_mock.yml")) is None
+
+
+def test_repoint_when_baked_dir_stale():
+    """A baked dir the resolver can't resolve falls back to the canonical dir (path miss)."""
+    stale = f"{MODELS}/joint_ipsc_confocal_a549_mantis/sec61b/pix2pix3d_unetvit/checkpoints/last.ckpt"
+    canonical = Path(f"{MODELS}/joint/er/pix2pix3d_unetvit/checkpoints")
+    best = canonical / "epoch=26-step=118422.ckpt"
+
+    def resolver(d):
+        return best if d == canonical else None
+
+    text = f"model:\n  init_args:\n    ckpt_path: {stale}\n"
+    new_text, changes = bb.bake_leaf(text, resolver, canonical)
+    assert f"ckpt_path: {best}\n" in new_text
+    assert changes == [(stale, str(best), "repointed")]
+
+
+def test_kept_current_vs_unresolvable(tmp_path, monkeypatch):
+    """resolver -> None: a curated alias that exists is kept; a missing file is flagged."""
+    monkeypatch.setattr(bb, "_MODELS_ROOT_PREFIX", str(tmp_path) + "/")
+    existing = tmp_path / "m" / "best_ep1_val0.1.ckpt"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("c")
+    assert bb.resolve_leaf_ckpt(str(existing), _fixed(None)) == (None, "kept_current")
+    missing = str(tmp_path / "m" / "gone.ckpt")
+    assert bb.resolve_leaf_ckpt(missing, _fixed(None)) == (None, "unresolvable")

--- a/applications/dynacell/tests/test_migration_tools.py
+++ b/applications/dynacell/tests/test_migration_tools.py
@@ -233,14 +233,15 @@ def test_apply_idempotent_and_rollback(tmp_path, monkeypatch):
     assert bmm.main(["--out", str(manifest), "--full-hardlink-check"]) == 0
 
     moves = rm.load_moves(manifest)
-    pending, already, errors = rm.preflight(moves)
+    pending, merges, already, errors = rm.preflight(moves)
     assert errors == []
     assert already == []
+    assert merges == []  # fixture evals map to fresh leaves -> plain renames
     assert len(pending) == len(moves)
 
     # Apply for real.
     journal = tmp_path / "manifest.journal.csv"
-    applied = rm.apply_moves(pending, journal, dry_run=False)
+    applied = rm.apply_moves(pending, merges, journal, dry_run=False)
     assert applied == len(pending)
     # Every winner src is gone; every dest exists.
     for m in pending:
@@ -252,9 +253,10 @@ def test_apply_idempotent_and_rollback(tmp_path, monkeypatch):
     assert (er_dest / "checkpoints" / "last.ckpt").is_file()
 
     # Idempotent re-run: everything is already-applied, nothing pending.
-    pending2, already2, errors2 = rm.preflight(rm.load_moves(manifest))
+    pending2, merges2, already2, errors2 = rm.preflight(rm.load_moves(manifest))
     assert errors2 == []
     assert pending2 == []
+    assert merges2 == []
     assert len(already2) == len(moves)
 
     # Rollback reverses every applied row.
@@ -272,7 +274,48 @@ def test_preflight_blocks_preexisting_dest(tmp_path, monkeypatch):
     manifest = tmp_path / "manifest.csv"
     assert bmm.main(["--out", str(manifest), "--full-hardlink-check"]) == 0
     moves = rm.load_moves(manifest)
-    # Pre-create one dest so BOTH src and dest exist -> unexpected, must error.
-    moves[0].dest.mkdir(parents=True, exist_ok=True)
-    _, _, errors = rm.preflight(moves)
+    # Pre-create one checkpoint dest so BOTH src and dest exist -> unexpected, must
+    # error (the merge path is eval-only; checkpoints/predictions never merge).
+    ckpt_move = next(m for m in moves if m.kind == "checkpoint")
+    ckpt_move.dest.mkdir(parents=True, exist_ok=True)
+    _, _, _, errors = rm.preflight(moves)
     assert any("DEST ALREADY EXISTS" in e for e in errors)
+
+
+def test_eval_merges_into_shared_prediction_leaf(tmp_path):
+    """An eval whose canonical dest leaf already holds prediction.zarr is merged,
+    not whole-dir renamed onto it; rollback restores the eval without touching
+    prediction.zarr."""
+    leaf = tmp_path / "data" / "er" / "celldiff_r2" / "a549__deconv" / "a549__denv"
+    # The prediction move ran first: the leaf exists and holds prediction.zarr.
+    _make_zarr(leaf / "prediction.zarr")
+    # Legacy eval src with typical outputs (no prediction.zarr, no instance_ap).
+    src = (
+        tmp_path / "data" / "a549" / "evaluations_a549trained_with_embeddings" / "eval_celldiff_r2_a549trained_er_denv"
+    )
+    _write(src / "pixel_metrics.csv", "p")
+    _write(src / "feature_metrics.csv", "f")
+    _write(src / "embeddings" / "gt_cp.npz", "e")
+    _make_zarr(src / "segmentation_results.zarr")
+
+    move = rm.Move("eval", src, leaf, "eval->leaf")
+    pending, merges, already, errors = rm.preflight([move])
+    assert errors == []
+    assert pending == []
+    assert merges == [move]
+
+    journal = tmp_path / "journal.csv"
+    assert rm.apply_moves(pending, merges, journal, dry_run=False) == 1
+    # Merge result: prediction.zarr survives + every eval child landed alongside it.
+    assert (leaf / "prediction.zarr" / "zarr.json").is_file()
+    assert (leaf / "pixel_metrics.csv").is_file()
+    assert (leaf / "embeddings" / "gt_cp.npz").is_file()
+    assert (leaf / "segmentation_results.zarr" / "zarr.json").is_file()
+    assert not src.exists()  # emptied src dir removed
+
+    # Rollback: eval children return to src; prediction.zarr stays in the leaf.
+    rm.rollback(journal, dry_run=False)
+    assert (src / "pixel_metrics.csv").is_file()
+    assert (src / "embeddings" / "gt_cp.npz").is_file()
+    assert not (leaf / "pixel_metrics.csv").exists()
+    assert (leaf / "prediction.zarr" / "zarr.json").is_file()

--- a/applications/dynacell/tests/test_migration_tools.py
+++ b/applications/dynacell/tests/test_migration_tools.py
@@ -120,6 +120,47 @@ def test_checkpoints_dedup_and_noise_skip(tmp_path):
     assert any("_smoke" in s.src for s in skips)
 
 
+def test_checkpoint_curation_prunes_experiments(tmp_path):
+    """iPSC graveyard: noise/pre-D pix2pix/celldiff-R1 skipped; distinct-run collisions
+    resolved by config reference (paper's final recipe wins)."""
+    models_root = tmp_path / "models" / "dynacell"
+    cd = models_root.parent / "cell_diff_vs_viscy"
+
+    def mk(root, org, run):
+        d = root / "ipsc" / org / run / "checkpoints"
+        d.mkdir(parents=True)
+        (d / "last.ckpt").write_text(run)  # distinct content -> non-hardlinked
+        return d.parent
+
+    # sec61b (er): a config-referenced final fcmae + an unreferenced bare variant + noise + R1 celldiff.
+    mk(models_root, "sec61b", "fcmae_vscyto3d_pretrained_ws8500")  # paper final (referenced)
+    mk(models_root, "sec61b", "fcmae_vscyto3d_pretrained")  # bare, superseded (unreferenced)
+    mk(models_root, "sec61b", "fcmae_vscyto3d_pretrained_H100_sanity")  # noise
+    mk(cd, "sec61b", "celldiff")  # pre-R2, dropped
+    mk(cd, "sec61b", "celldiff_r2")  # paper final
+    mk(cd, "sec61b", "pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep")  # Run D (kept)
+    mk(cd, "sec61b", "pix2pix3d_unetvit_modernized_lambdaL1_1")  # pre-D (dropped)
+
+    referenced = {str(models_root / "ipsc" / "sec61b" / "fcmae_vscyto3d_pretrained_ws8500")}
+    rows, gaps = bmm.collect_checkpoints(models_root, full_hardlink_check=True, referenced_dirs=referenced)
+    assert gaps == []
+    moved = {r.src for r in rows if r.status == "move"}
+    skipped = {r.src: r.reason for r in rows if r.status == "skip"}
+
+    # Config-referenced final fcmae wins its dest; bare variant skipped as unreferenced.
+    assert str(models_root / "ipsc" / "sec61b" / "fcmae_vscyto3d_pretrained_ws8500") in moved
+    assert "unreferenced" in skipped[str(models_root / "ipsc" / "sec61b" / "fcmae_vscyto3d_pretrained")]
+    # celldiff_r2 kept, pre-R2 celldiff dropped; Run D kept, pre-D pruned.
+    assert str(cd / "ipsc" / "sec61b" / "celldiff_r2") in moved
+    assert "superseded" in skipped[str(cd / "ipsc" / "sec61b" / "celldiff")]
+    assert str(cd / "ipsc" / "sec61b" / "pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep") in moved
+    assert "pre-D" in skipped[str(cd / "ipsc" / "sec61b" / "pix2pix3d_unetvit_modernized_lambdaL1_1")]
+    assert "noise" in skipped[str(models_root / "ipsc" / "sec61b" / "fcmae_vscyto3d_pretrained_H100_sanity")]
+    # Every canonical dest is unique (no collision survived).
+    dests = [r.dest for r in rows if r.status == "move"]
+    assert len(dests) == len(set(dests))
+
+
 def test_predictions_dedup_and_ablation_skip(tmp_path):
     _, data_root = _fixture(tmp_path)
     rows, skips, gaps = bmm.collect_predictions(data_root, full_hardlink_check=True)

--- a/applications/dynacell/tests/test_migration_tools.py
+++ b/applications/dynacell/tests/test_migration_tools.py
@@ -1,0 +1,237 @@
+"""Integration tests for the Phase-7 migration manifest builder + apply tool.
+
+Builds a self-contained fixture tree mirroring the on-disk source layout (both
+checkpoint roots, prediction dual-homes, the eval families) and exercises the real
+collectors + the ``run_migration`` apply / idempotent-resume / rollback cycle.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from pathlib import Path
+
+import build_migration_manifest as bmm
+import run_migration as rm
+
+
+def _write(path: Path, text: str = "x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def _make_ckpt_run(models_root: Path, root_name: str, term: str, org: str, run: str, payload: str = "ck") -> Path:
+    """Create ``<root>/<term>/<org>/<run>/{checkpoints/last.ckpt,resolved,wandb}``."""
+    run_dir = (
+        models_root.parent / root_name / term / org / run if root_name != "dynacell" else models_root / term / org / run
+    )
+    _write(run_dir / "checkpoints" / "last.ckpt", payload)
+    _write(run_dir / "checkpoints" / "epoch=9.ckpt", payload)
+    (run_dir / "resolved").mkdir(parents=True, exist_ok=True)
+    _write(run_dir / "resolved" / "fit.yml", "cfg")
+    (run_dir / "wandb").mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def _make_zarr(store: Path, meta: str = "meta") -> Path:
+    store.mkdir(parents=True, exist_ok=True)
+    _write(store / "zarr.json", meta)
+    _write(store / "0" / "0", "chunk")
+    return store
+
+
+def _hardlink_tree(src: Path, dst: Path) -> None:
+    """Recreate ``src`` at ``dst`` with every file hardlinked (``cp -al``)."""
+    for f in src.rglob("*"):
+        if f.is_file():
+            rel = f.relative_to(src)
+            (dst / rel).parent.mkdir(parents=True, exist_ok=True)
+            os.link(f, dst / rel)
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (models_root, data_root) populated with a representative slice."""
+    models_root = tmp_path / "models" / "dynacell"
+    data_root = tmp_path / "data" / "dynacell"
+    models_root.mkdir(parents=True)
+    data_root.mkdir(parents=True)
+
+    # --- checkpoints ---
+    # ER (sec61b) a549: single dynacell-root run, run-dir name carries a recipe suffix.
+    _make_ckpt_run(models_root, "dynacell", "a549_mantis", "sec61b", "fcmae_vscyto3d_pretrained_ws8500")
+    # Membrane joint: hardlink-duplicated across BOTH roots -> one canonical dest (dedup).
+    # The whole run dir (checkpoints/ + resolved/ ...) is hardlinked, mirroring cp -al.
+    a = _make_ckpt_run(models_root, "dynacell", "joint_ipsc_confocal_a549_mantis", "memb", "pix2pix3d_unetvit")
+    b_run = "pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep"
+    b = models_root.parent / "cell_diff_vs_viscy" / "joint_ipsc_confocal_a549_mantis" / "memb" / b_run
+    _hardlink_tree(a, b)
+    # A smoke run must be skipped (would collide with the real pix2pix run).
+    _make_ckpt_run(models_root, "cell_diff_vs_viscy", "joint_ipsc_confocal_a549_mantis", "nucl", b_run + "_smoke")
+
+    # --- predictions ---
+    # Joint membrane prediction dual-homed (hardlinked) in predictions/ + joint_predictions/.
+    p_name = "memb_fnet3d_paper_jointtrained_mock.zarr"
+    p1 = _make_zarr(data_root / "a549" / "predictions" / p_name)
+    _hardlink_tree(p1, data_root / "a549" / "joint_predictions" / p_name)
+    # A plain single-home a549-trained nucleus prediction.
+    _make_zarr(data_root / "a549" / "predictions" / "nucl_fnet3d_paper_a549trained_mock.zarr")
+    # An ablation prediction -> skipped (own track).
+    _make_zarr(data_root / "a549" / "predictions" / "nucl_vscyto3d_randinit_mock.zarr")
+
+    # --- evals ---
+    # Triad (default track), iPSC-trained on iPSC.
+    (data_root / "ipsc" / "evaluations_with_embeddings" / "eval_vscyto3d_nucleus").mkdir(parents=True)
+    # instance_ap subtrack, a549.
+    (data_root / "a549" / "evaluations_instance_ap" / "eval_vscyto3d_nucleus_mock").mkdir(parents=True)
+    # Own-track ablation eval (default-excluded).
+    (data_root / "a549" / "evaluations_randinit" / "eval_vscyto3d_randinit_nucleus_mock").mkdir(parents=True)
+    # Stale pre-2D parent -> normalize_legacy None -> skip.
+    (data_root / "a549" / "evaluations" / "eval_vscyto3d_nucleus_mock").mkdir(parents=True)
+    return models_root, data_root
+
+
+# ---------------------------------------------------------------------------
+# builder
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoints_dedup_and_noise_skip(tmp_path):
+    models_root, _ = _fixture(tmp_path)
+    rows, gaps = bmm.collect_checkpoints(models_root, full_hardlink_check=True)
+    assert gaps == []
+    moves = {Path(r.src): Path(r.dest) for r in rows if r.status == "move"}
+    dedup = [r for r in rows if r.status == "dedup_legacy"]
+    skips = [r for r in rows if r.status == "skip"]
+
+    # Recipe-suffixed run canonicalizes to the bare model code key.
+    er = models_root / "a549_mantis" / "sec61b" / "fcmae_vscyto3d_pretrained_ws8500"
+    assert moves[er] == models_root / "a549" / "er" / "fcmae_vscyto3d_pretrained"
+
+    # Hardlinked cross-root dup: dynacell-root copy wins the move; cell_diff is dedup_legacy.
+    win = models_root / "joint_ipsc_confocal_a549_mantis" / "memb" / "pix2pix3d_unetvit"
+    dest = models_root / "joint" / "membrane" / "pix2pix3d_unetvit"
+    assert moves[win] == dest
+    assert len(dedup) == 1
+    assert dedup[0].dest == str(dest)
+    assert "cell_diff_vs_viscy" in dedup[0].src
+
+    # Smoke run skipped.
+    assert any("_smoke" in s.src for s in skips)
+
+
+def test_predictions_dedup_and_ablation_skip(tmp_path):
+    _, data_root = _fixture(tmp_path)
+    rows, skips, gaps = bmm.collect_predictions(data_root, full_hardlink_check=True)
+    assert gaps == []
+    moves = {Path(r.src): Path(r.dest) for r in rows if r.status == "move"}
+    dedup = [r for r in rows if r.status == "dedup_legacy"]
+
+    dest = data_root / "membrane" / "fnet3d_paper" / "joint" / "a549__mock" / "prediction.zarr"
+    # Dual-home dedups to one move; winner is lexicographically first (joint_predictions).
+    assert dest in moves.values()
+    assert len(dedup) == 1
+    assert "joint_predictions" in [r.src for r in rows if r.status == "move" and r.dest == str(dest)][0]
+
+    # Plain single-home prediction present.
+    plain = data_root / "a549" / "predictions" / "nucl_fnet3d_paper_a549trained_mock.zarr"
+    assert moves[plain] == data_root / "nucleus" / "fnet3d_paper" / "a549" / "a549__mock" / "prediction.zarr"
+
+    # Ablation prediction skipped, not a gap.
+    assert any("randinit" in s for s in skips)
+
+
+def test_evals_scope_default_excludes_own_track(tmp_path):
+    _, data_root = _fixture(tmp_path)
+    rows, skips, gaps = bmm.collect_evals(data_root, include_own_track=False)
+    assert gaps == []
+    dests = {r.dest for r in rows if r.status == "move"}
+
+    # Triad default-track leaf.
+    assert str(data_root / "nucleus" / "fcmae_vscyto3d_pretrained" / "ipsc" / "ipsc") in dests
+    # instance_ap subtrack leaf.
+    assert str(data_root / "nucleus" / "fcmae_vscyto3d_pretrained" / "ipsc" / "a549__mock" / "instance_ap") in dests
+    # Own-track ablation + stale pre-2D are skipped (not moved).
+    assert not any("randinit" in r.dest for r in rows if r.status == "move")
+    assert any("own-track" in s for s in skips)
+    assert any("normalize->None" in s for s in skips)
+
+
+def test_evals_scope_include_own_track(tmp_path):
+    _, data_root = _fixture(tmp_path)
+    rows, _, gaps = bmm.collect_evals(data_root, include_own_track=True)
+    assert gaps == []
+    assert any(r.status == "move" and "fcmae_vscyto3d_pretrained_randinit" in r.dest for r in rows)
+
+
+def test_builder_main_writes_manifest(tmp_path, monkeypatch):
+    models_root, data_root = _fixture(tmp_path)
+    monkeypatch.setattr(bmm, "MODELS_ROOT", models_root)
+    monkeypatch.setattr(bmm, "DATA_ROOT", data_root)
+    out = tmp_path / "manifest.csv"
+    rc = bmm.main(["--out", str(out), "--full-hardlink-check"])
+    assert rc == 0
+    assert out.exists()
+    with out.open(newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert {r["status"] for r in rows} <= {"move", "dedup_legacy", "skip"}
+    assert any(r["kind"] == "checkpoint" and r["status"] == "move" for r in rows)
+    assert (tmp_path / "manifest.report.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# apply tool
+# ---------------------------------------------------------------------------
+
+
+def test_apply_idempotent_and_rollback(tmp_path, monkeypatch):
+    models_root, data_root = _fixture(tmp_path)
+    monkeypatch.setattr(bmm, "MODELS_ROOT", models_root)
+    monkeypatch.setattr(bmm, "DATA_ROOT", data_root)
+    manifest = tmp_path / "manifest.csv"
+    assert bmm.main(["--out", str(manifest), "--full-hardlink-check"]) == 0
+
+    moves = rm.load_moves(manifest)
+    pending, already, errors = rm.preflight(moves)
+    assert errors == []
+    assert already == []
+    assert len(pending) == len(moves)
+
+    # Apply for real.
+    journal = tmp_path / "manifest.journal.csv"
+    applied = rm.apply_moves(pending, journal, dry_run=False)
+    assert applied == len(pending)
+    # Every winner src is gone; every dest exists.
+    for m in pending:
+        assert not m.src.exists()
+        assert m.dest.exists()
+    # A moved checkpoint carried its siblings (resolved/) along.
+    er_dest = models_root / "a549" / "er" / "fcmae_vscyto3d_pretrained"
+    assert (er_dest / "resolved" / "fit.yml").is_file()
+    assert (er_dest / "checkpoints" / "last.ckpt").is_file()
+
+    # Idempotent re-run: everything is already-applied, nothing pending.
+    pending2, already2, errors2 = rm.preflight(rm.load_moves(manifest))
+    assert errors2 == []
+    assert pending2 == []
+    assert len(already2) == len(moves)
+
+    # Rollback reverses every applied row.
+    reversed_n = rm.rollback(journal, dry_run=False)
+    assert reversed_n == applied
+    for m in pending:
+        assert m.src.exists()
+        assert not m.dest.exists()
+
+
+def test_preflight_blocks_preexisting_dest(tmp_path, monkeypatch):
+    models_root, data_root = _fixture(tmp_path)
+    monkeypatch.setattr(bmm, "MODELS_ROOT", models_root)
+    monkeypatch.setattr(bmm, "DATA_ROOT", data_root)
+    manifest = tmp_path / "manifest.csv"
+    assert bmm.main(["--out", str(manifest), "--full-hardlink-check"]) == 0
+    moves = rm.load_moves(manifest)
+    # Pre-create one dest so BOTH src and dest exist -> unexpected, must error.
+    moves[0].dest.mkdir(parents=True, exist_ok=True)
+    _, _, errors = rm.preflight(moves)
+    assert any("DEST ALREADY EXISTS" in e for e in errors)

--- a/applications/dynacell/tests/test_restandardize_config_paths.py
+++ b/applications/dynacell/tests/test_restandardize_config_paths.py
@@ -133,3 +133,23 @@ def test_build_ckpt_map_on_fixture(tmp_path):
     dest = f"{models_root}/joint/membrane/pix2pix3d_unetvit"
     assert cmap[str(a)] == dest
     assert cmap[str(b)] == dest  # dedup_legacy sibling maps to the same dest
+
+
+def test_load_ckpt_map_from_manifest(tmp_path):
+    """After migration the live tree is gone; the frozen manifest supplies the map.
+
+    Only checkpoint move/dedup_legacy rows contribute; predictions/evals/skips do not.
+    """
+    old_dedup = f"{CELLDIFF}/joint_ipsc_confocal_a549_mantis/memb/pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep"
+    new_dedup = f"{MODELS}/joint/membrane/pix2pix3d_unetvit"
+    manifest = tmp_path / "manifest.csv"
+    manifest.write_text(
+        "kind,status,src,dest,reason\n"
+        f"checkpoint,move,{_OLD_CKPT_DIR},{_NEW_CKPT_DIR},raw a549 home\n"
+        f"checkpoint,dedup_legacy,{old_dedup},{new_dedup},cross-root dup\n"
+        f"checkpoint,skip,{MODELS}/ipsc/nucl/celldiff/checkpoints,,superseded R1\n"
+        "prediction,move,/data/a/x.zarr,/data/b/prediction.zarr,pred\n"
+        "eval,move,/data/a/eval_x,/data/b/leaf,eval\n"
+    )
+    cmap = rc.load_ckpt_map_from_manifest(manifest)
+    assert cmap == {_OLD_CKPT_DIR: _NEW_CKPT_DIR, old_dedup: new_dedup}

--- a/applications/dynacell/tests/test_restandardize_config_paths.py
+++ b/applications/dynacell/tests/test_restandardize_config_paths.py
@@ -116,8 +116,15 @@ def test_build_ckpt_map_on_fixture(tmp_path):
         (d / "last.ckpt").write_text("c")
         return d.parent
 
+    # Both names are canonical pix2pix keeps (clean + Run D), so they hardlink-dedup
+    # rather than being pruned as pre-D experiments.
     a = mk("dynacell", "joint_ipsc_confocal_a549_mantis", "memb", "pix2pix3d_unetvit")
-    b = mk("cell_diff_vs_viscy", "joint_ipsc_confocal_a549_mantis", "memb", "pix2pix3d_unetvit_x")
+    b = mk(
+        "cell_diff_vs_viscy",
+        "joint_ipsc_confocal_a549_mantis",
+        "memb",
+        "pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep",
+    )
     # hardlink b's ckpt to a's so the two dedup to one dest
     os.remove(b / "checkpoints" / "last.ckpt")
     os.link(a / "checkpoints" / "last.ckpt", b / "checkpoints" / "last.ckpt")

--- a/applications/dynacell/tests/test_restandardize_config_paths.py
+++ b/applications/dynacell/tests/test_restandardize_config_paths.py
@@ -1,0 +1,128 @@
+"""Tests for the predict/train config-leaf path codemod (restandardize_config_paths)."""
+
+from __future__ import annotations
+
+import os
+
+import restandardize_config_paths as rc
+
+from dynacell.evaluation import paths
+
+MODELS = str(paths.MODELS_ROOT)
+CELLDIFF = str(paths.MODELS_ROOT.parent / "cell_diff_vs_viscy")
+DATA = str(paths.DATA_ROOT)
+
+# A migrated a549 ER checkpoint (recipe-suffixed run dir) -> canonical raw a549 home.
+_OLD_CKPT_DIR = f"{MODELS}/a549_mantis/sec61b/fcmae_vscyto3d_pretrained_ws8500"
+_NEW_CKPT_DIR = f"{MODELS}/a549/er/fcmae_vscyto3d_pretrained"
+_CKPT_MAP = {_OLD_CKPT_DIR: _NEW_CKPT_DIR}
+
+
+def test_rewrite_predict_leaf_deconv_ck_vs_pred_split():
+    """ER/mito A549 predict: ckpt -> raw a549 home, prediction -> a549__deconv home."""
+    text = (
+        "predict:\n"
+        "  model:\n"
+        "    init_args:\n"
+        f"      ckpt_path: {_OLD_CKPT_DIR}/checkpoints/epoch=132-step=22876.ckpt\n"
+        "  trainer:\n"
+        "    callbacks:\n"
+        "      - init_args:\n"
+        f"          output_store: {DATA}/a549/predictions/sec61b_fcmae_vscyto3d_pretrained_a549trained_mock.zarr\n"
+        "  launcher:\n"
+        f"    run_root: {DATA}/a549/predictions\n"
+    )
+    new_text, changes = rc.rewrite_leaf(text, _CKPT_MAP)
+    assert f"ckpt_path: {_NEW_CKPT_DIR}/checkpoints/epoch=132-step=22876.ckpt" in new_text
+    assert f"output_store: {DATA}/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock/prediction.zarr" in new_text
+    # predict run_root -> canonical prediction leaf dir (output_store parent)
+    assert f"run_root: {DATA}/er/fcmae_vscyto3d_pretrained/a549__deconv/a549__mock" in new_text
+    assert len(changes) == 3
+
+
+def test_rewrite_train_leaf_fields():
+    """Train: save_dir/dirpath/run_root -> canonical model dir; init ckpt + data_path preserved."""
+    text = (
+        "model:\n"
+        "  init_args:\n"
+        "    ckpt_path: /hpc/projects/virtual_staining/models/mehta-lab/VSCyto3D/fcmae.ckpt\n"
+        "data:\n"
+        "  init_args:\n"
+        f"    data_path: {DATA}/a549/mantis_v1/train/SEC61B_all.zarr\n"
+        "trainer:\n"
+        "  logger:\n"
+        "    init_args:\n"
+        f"      save_dir: {_OLD_CKPT_DIR}\n"
+        "  callbacks:\n"
+        "    - init_args:\n"
+        f"        dirpath: {_OLD_CKPT_DIR}/checkpoints\n"
+        "launcher:\n"
+        f"  run_root: {_OLD_CKPT_DIR}\n"
+    )
+    new_text, changes = rc.rewrite_leaf(text, _CKPT_MAP)
+    assert f"save_dir: {_NEW_CKPT_DIR}\n" in new_text
+    assert f"dirpath: {_NEW_CKPT_DIR}/checkpoints\n" in new_text
+    assert f"run_root: {_NEW_CKPT_DIR}\n" in new_text
+    # Preserved: pretrained init + training-input data_path.
+    assert "ckpt_path: /hpc/projects/virtual_staining/models/mehta-lab/VSCyto3D/fcmae.ckpt" in new_text
+    assert f"data_path: {DATA}/a549/mantis_v1/train/SEC61B_all.zarr" in new_text
+    assert len(changes) == 3
+
+
+def test_preserve_unmigrated_and_external_ckpt():
+    """ckpt_path not in the map (iPSC-trained / published baseline / REPLACE_ME) -> untouched."""
+    ipsc = f"{MODELS}/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt"
+    published = "/hpc/projects/comp.micro/virtual_staining/datasets/public/VS_models/VSCyto3D/epoch=83.ckpt"
+    for val in (ipsc, published, "REPLACE_ME_WITH_PRODUCTION_CHECKPOINT_PATH"):
+        text = f"model:\n  init_args:\n    ckpt_path: {val}\n"
+        new_text, changes = rc.rewrite_leaf(text, _CKPT_MAP)
+        assert changes == []
+        assert new_text == text
+
+
+def test_prediction_skip_left_untouched():
+    """An ablation output_store (normalize_legacy -> None) is preserved, not blanked."""
+    val = f"{DATA}/a549/predictions/nucl_vscyto3d_randinit_mock.zarr"
+    text = f"trainer:\n  callbacks:\n    - init_args:\n        output_store: {val}\n"
+    new_text, changes = rc.rewrite_leaf(text, _CKPT_MAP)
+    assert changes == []
+    assert new_text == text
+
+
+def test_cross_root_celldiff_joint():
+    """celldiff_r2 joint ER: cross-root ckpt -> dynacell/joint/er; prediction -> joint__legacy_deconvgt."""
+    old_ckpt = f"{CELLDIFF}/joint_ipsc_confocal_a549_mantis/sec61b/celldiff_r2"
+    ckpt_map = {old_ckpt: f"{MODELS}/joint/er/celldiff_r2"}
+    text = (
+        "model:\n  init_args:\n"
+        f"    ckpt_path: {old_ckpt}/checkpoints/last.ckpt\n"
+        "trainer:\n  callbacks:\n    - init_args:\n"
+        f"        output_store: {DATA}/a549/joint_predictions/sec61b_celldiff_r2_denv.zarr\n"
+    )
+    new_text, _ = rc.rewrite_leaf(text, ckpt_map)
+    assert f"ckpt_path: {MODELS}/joint/er/celldiff_r2/checkpoints/last.ckpt" in new_text
+    assert f"output_store: {DATA}/er/celldiff_r2/joint__legacy_deconvgt/a549__denv/prediction.zarr" in new_text
+
+
+def test_build_ckpt_map_on_fixture(tmp_path):
+    """build_ckpt_map returns old-dir -> dest for both move winner and dedup_legacy siblings."""
+    models_root = tmp_path / "models" / "dynacell"
+    (models_root).mkdir(parents=True)
+
+    def mk(root_name, term, org, run):
+        base = models_root if root_name == "dynacell" else models_root.parent / root_name
+        d = base / term / org / run / "checkpoints"
+        d.mkdir(parents=True)
+        (d / "last.ckpt").write_text("c")
+        return d.parent
+
+    a = mk("dynacell", "joint_ipsc_confocal_a549_mantis", "memb", "pix2pix3d_unetvit")
+    b = mk("cell_diff_vs_viscy", "joint_ipsc_confocal_a549_mantis", "memb", "pix2pix3d_unetvit_x")
+    # hardlink b's ckpt to a's so the two dedup to one dest
+    os.remove(b / "checkpoints" / "last.ckpt")
+    os.link(a / "checkpoints" / "last.ckpt", b / "checkpoints" / "last.ckpt")
+
+    cmap = rc.build_ckpt_map(models_root)
+    dest = f"{models_root}/joint/membrane/pix2pix3d_unetvit"
+    assert cmap[str(a)] == dest
+    assert cmap[str(b)] == dest  # dedup_legacy sibling maps to the same dest

--- a/applications/dynacell/tests/test_restandardize_config_paths.py
+++ b/applications/dynacell/tests/test_restandardize_config_paths.py
@@ -69,6 +69,23 @@ def test_rewrite_train_leaf_fields():
     assert len(changes) == 3
 
 
+def test_rewrite_ckpt_run_root_alias_no_checkpoints_subdir():
+    """A best-epoch alias directly at the run-dir root (no ``checkpoints/`` subdir) is
+    repointed to the canonical model dir + alias filename, not silently preserved.
+
+    Regression: several legacy iPSC runs store the best ckpt as a bare alias at the run
+    root; ``value.find('/checkpoints')`` returns -1, and the old code let ``model_dir``
+    swallow the filename so the map lookup missed and the migrated-away path survived.
+    """
+    old_dir = f"{MODELS}/ipsc/sec61b/fcmae_vscyto3d_pretrained_ws8500"
+    new_dir = f"{MODELS}/ipsc/er/fcmae_vscyto3d_pretrained"
+    ckpt_map = {old_dir: new_dir}
+    text = f"model:\n  init_args:\n    ckpt_path: {old_dir}/best_ep123_val0.40979.ckpt\n"
+    new_text, changes = rc.rewrite_leaf(text, ckpt_map)
+    assert f"ckpt_path: {new_dir}/best_ep123_val0.40979.ckpt" in new_text
+    assert len(changes) == 1
+
+
 def test_preserve_unmigrated_and_external_ckpt():
     """ckpt_path not in the map (iPSC-trained / published baseline / REPLACE_ME) -> untouched."""
     ipsc = f"{MODELS}/ipsc/nucl/fcmae_vscyto3d_pretrained/checkpoints/epoch=89-step=28080.ckpt"

--- a/applications/dynacell/tests/test_submit_benchmark_job.py
+++ b/applications/dynacell/tests/test_submit_benchmark_job.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import os
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -206,6 +207,29 @@ def test_resolve_best_ckpt_rebases_moved_dir(tmp_path):
         tmp_path / "last.ckpt",
     )
     assert sbj._resolve_best_ckpt(tmp_path) == best
+
+
+def test_resolve_best_ckpt_prefers_newest_last_v(tmp_path):
+    """A resumed run leaves last.ckpt + last-vN.ckpt; the newest (by mtime) is
+    authoritative. Keying on last.ckpt alone mis-resolves to the first segment's best
+    (the messy legacy iPSC dirs: last.ckpt is epoch 1, last-v5.ckpt is epoch 183)."""
+    torch = pytest.importorskip("torch")
+    stale_best = tmp_path / "epoch=1-step=10.ckpt"
+    stale_best.write_bytes(b"x")
+    true_best = tmp_path / "epoch=183-step=1830.ckpt"
+    true_best.write_bytes(b"x")
+    torch.save(
+        {"callbacks": {"ModelCheckpoint{'monitor': 'loss/validate'}": {"best_model_path": str(stale_best)}}},
+        tmp_path / "last.ckpt",
+    )
+    torch.save(
+        {"callbacks": {"ModelCheckpoint{'monitor': 'loss/validate'}": {"best_model_path": str(true_best)}}},
+        tmp_path / "last-v5.ckpt",
+    )
+    # make last.ckpt older so last-v5.ckpt is the newest by mtime
+    older = (tmp_path / "last-v5.ckpt").stat().st_mtime - 100
+    os.utime(tmp_path / "last.ckpt", (older, older))
+    assert sbj.resolve_best_ckpt(tmp_path) == true_best
 
 
 def test_rendered_sbatch_has_preflight_srun_absolute_path(rendered_celldiff_sbatch):

--- a/applications/dynacell/tools/bake_best_ckpt.py
+++ b/applications/dynacell/tools/bake_best_ckpt.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+"""Codemod: bake each predict leaf's best-by-monitor checkpoint into ``ckpt_path``.
+
+After the canonical-path migration + ``restandardize_config_paths`` codemod, predict
+leaves point at a checkpoint DIRECTORY that is canonical but may carry a stale FILENAME
+(the path codemod preserves the tail): the retrained ER/mito A549/joint leaves still
+name a pre-flip ``epoch=NNN`` file that no longer exists. This pass rewrites
+``model.init_args.ckpt_path`` in every predict leaf to the actual best checkpoint
+resolved from disk, so the final evals run straight from the leaf with no ``--ckpt
+best`` override.
+
+Resolution per leaf (only for a ``ckpt_path`` value under ``MODELS_ROOT``):
+
+- normal trained dir (has ``last*.ckpt``): best = newest ``last*.ckpt``'s
+  ``best_model_path`` (rebased onto the dir), else the highest ``epoch=*.ckpt``.
+  Uses ``submit_benchmark_job.resolve_best_ckpt`` — the same resolver ``--ckpt best``
+  uses at submit time — so a baked leaf and ``--ckpt best`` agree by construction.
+- pure-alias dir (a curated ``best_ep*.ckpt`` with no ``last*.ckpt`` / ``epoch=*.ckpt``
+  to scan, as several legacy iPSC runs store it): the current value IS the curated
+  best — kept, not clobbered.
+- unresolvable / external / published baseline / ``REPLACE_ME`` placeholder: preserved
+  and reported (never trained -> no best to list).
+
+Only ``predict__*.yml`` leaves are touched; a train leaf's ``ckpt_path`` is an init /
+resume source, not a prediction target. Dry-run by default (prints a per-leaf report);
+``--apply`` writes in place. Leaves are git-tracked, so ``--apply`` is reversible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from submit_benchmark_job import resolve_best_ckpt
+
+from dynacell.evaluation import paths
+
+CONFIG_ROOT_REL = "applications/dynacell/configs/benchmarks/virtual_staining"
+
+_MODELS_ROOT_PREFIX = str(paths.MODELS_ROOT) + "/"
+_CKPT_LINE = re.compile(r"^(?P<indent>\s*)ckpt_path:\s*(?P<val>\S+)\s*$")
+_REPLACE_ME = "REPLACE_ME"
+
+Resolver = Callable[[Path], "Path | None"]
+
+
+def _ckpt_dir_for(value: str) -> Path:
+    """Return the directory ``resolve_best_ckpt`` scans for a ``ckpt_path`` value.
+
+    ``<model_dir>/checkpoints/<file>`` -> ``<model_dir>/checkpoints``; a bare alias at
+    ``<model_dir>/<file>`` -> ``<model_dir>`` (the alias's own dir).
+    """
+    idx = value.find("/checkpoints")
+    if idx != -1:
+        return Path(value[: idx + len("/checkpoints")])
+    return Path(value).parent
+
+
+def canonical_ckpt_dir_for_leaf(rel: Path) -> Path | None:
+    """Grammar-derived canonical checkpoint dir from a leaf's config-tree position.
+
+    ``<organelle>/<model>/<train_term>/predict__<test>.yml`` ->
+    ``MODELS_ROOT/<train_set>/<organelle>/<model>/checkpoints``. Used only as a fallback
+    when a leaf's baked ``ckpt_path`` directory is stale/empty (a path-codemod miss).
+    Returns None when the organelle/train_term don't normalize to a canonical tuple
+    (e.g. the ``_no_train_*`` ablation trees). ``REPLACE_ME`` / external leaves are
+    short-circuited before this fallback is consulted, so a dir computed for them is
+    never used.
+    """
+    parts = rel.parts
+    if len(parts) < 4:
+        return None
+    organelle_tok, model, train_tok = parts[0], parts[1], parts[2]
+    try:
+        return paths.checkpoint_dir(paths._norm_organelle(organelle_tok), model, paths._norm_train_set(train_tok))
+    except ValueError:
+        return None
+
+
+def resolve_leaf_ckpt(value: str, resolver: Resolver, canonical_dir: Path | None = None) -> tuple[str | None, str]:
+    """Return (new_ckpt_path_or_None, category) for one ``ckpt_path`` value.
+
+    ``new`` is None when the value is preserved. ``category`` is one of: ``rebaked``,
+    ``repointed`` (baked dir stale -> resolved from the grammar-canonical dir),
+    ``already_best``, ``kept_current``, ``unresolvable``, ``external``, ``replace_me``.
+    """
+    if value.startswith(_REPLACE_ME):
+        return None, "replace_me"
+    if not value.startswith(_MODELS_ROOT_PREFIX):
+        return None, "external"
+    current_dir = _ckpt_dir_for(value)
+    best = resolver(current_dir)
+    if best is None and canonical_dir is not None and canonical_dir != current_dir:
+        # baked dir is stale/empty (a path-codemod miss); resolve from the canonical home
+        best = resolver(canonical_dir)
+        if best is not None:
+            return str(best), "repointed"
+    if best is None:
+        # No last*.ckpt / epoch=*.ckpt to scan. Keep a curated alias that exists;
+        # otherwise the value is genuinely unresolvable (report, do not blank).
+        return None, "kept_current" if Path(value).is_file() else "unresolvable"
+    new = str(best)
+    if new == value:
+        return None, "already_best"
+    return new, "rebaked"
+
+
+def bake_leaf(
+    text: str, resolver: Resolver, canonical_dir: Path | None = None
+) -> tuple[str, list[tuple[str, str, str]]]:
+    """Return (new_text, changes) for one predict leaf. changes: (old, new, category)."""
+    out: list[str] = []
+    changes: list[tuple[str, str, str]] = []
+    for line in text.splitlines(keepends=True):
+        m = _CKPT_LINE.match(line)
+        if not m:
+            out.append(line)
+            continue
+        val = m.group("val")
+        new, category = resolve_leaf_ckpt(val, resolver, canonical_dir)
+        if new is not None:
+            nl = "\n" if line.endswith("\n") else ""
+            out.append(f"{m.group('indent')}ckpt_path: {new}{nl}")
+            changes.append((val, new, category))
+        else:
+            out.append(line)
+            changes.append((val, val, category))
+    return "".join(out), changes
+
+
+def iter_predict_leaves(config_root: Path) -> list[Path]:
+    """Every hand-authored predict leaf under the organelle config tree."""
+    return sorted(config_root.rglob("predict__*.yml"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: dry-run (report) or --apply the best-ckpt baking over predict leaves."""
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--config-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[3] / CONFIG_ROOT_REL,
+        help="root of the benchmark config tree (default: repo config root)",
+    )
+    ap.add_argument("--apply", action="store_true", help="write changes in place (default: dry-run report)")
+    args = ap.parse_args(argv)
+
+    # Many leaves (per-condition, per-test) share one checkpoint dir; memoize so each
+    # dir's last*.ckpt is torch.load-ed once, not once per leaf.
+    resolver = functools.lru_cache(maxsize=None)(resolve_best_ckpt)
+
+    tally: dict[str, int] = {}
+    n_files_changed = 0
+    for leaf in iter_predict_leaves(args.config_root):
+        rel = leaf.relative_to(args.config_root)
+        text = leaf.read_text()
+        new_text, changes = bake_leaf(text, resolver, canonical_ckpt_dir_for_leaf(rel))
+        for old, new, category in changes:
+            tally[category] = tally.get(category, 0) + 1
+            if category in ("rebaked", "repointed"):
+                print(f"{category.upper():11s} {rel}\n    {old}\n -> {new}")
+            elif category in ("unresolvable", "replace_me"):
+                print(f"{category.upper():11s} {rel}\n    {old}")
+        if new_text != text:
+            n_files_changed += 1
+            if args.apply:
+                leaf.write_text(new_text)
+
+    print(f"\n{'applied' if args.apply else 'would change'}: {n_files_changed} predict leaf file(s)")
+    print("categories: " + ", ".join(f"{k}={v}" for k, v in sorted(tally.items())))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/build_migration_manifest.py
+++ b/applications/dynacell/tools/build_migration_manifest.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python
+"""Build the Phase-7 canonical-path migration manifest (READ-ONLY, no ``mv``).
+
+Enumerates the on-disk dynacell campaign artifacts and computes their canonical
+destinations with :mod:`dynacell.evaluation.paths` — the single source of truth.
+The tool deliberately carries **no independent skip policy**: whatever
+:func:`paths.normalize_legacy` / :func:`paths.checkpoint_dir` map is migrated;
+whatever they refuse (``None`` / ``ValueError``) is reported as a skip or a gap.
+The only tool-side exception is a noise-run filter for checkpoint run dirs
+(``*_smoke`` / ``*_debug`` / ``*_sanity``), which would otherwise canonicalize
+onto — and collide with — their real sibling run.
+
+Three artifact families:
+
+1. **checkpoints** — ``<root>/<term>/<org>/<run_dir>/`` model dirs (both the
+   ``dynacell`` and ``cell_diff_vs_viscy`` roots) whose ``run_dir`` carries a
+   ``checkpoints/`` subdir. The WHOLE ``run_dir`` moves (carrying ``resolved/`` +
+   ``wandb/`` + ``checkpoints/preflip_deconv/`` …) to ``checkpoint_dir(...).parent``,
+   renaming the run-dir leaf to its canonical model code key.
+2. **predictions** — ``<domain>/{predictions,joint_predictions[_v2]}/*.zarr``.
+   Legacy dual-home writes the same joint zarr into both ``predictions/`` and
+   ``joint_predictions/`` (``cp -al`` hardlinks); both normalize to one canonical
+   ``prediction.zarr``. The colliding group is deduped to a single ``move`` winner
+   (verified hardlink-identical) plus ``dedup_legacy`` rows left in place.
+3. **evals** — every ``<domain>/evaluations*|joint_evaluations/<leaf>`` dir.
+
+Output: a CSV manifest (``--out``) consumed by ``run_migration.py`` and a
+human-readable ``.report.txt`` beside it. Columns::
+
+    kind, status, src, dest, reason
+
+``status`` ∈ ``move`` | ``dedup_legacy`` | ``skip``. The apply tool consumes only
+``move`` rows. Exits non-zero when any artifact is UNMAPPED (a real hole in
+``normalize_legacy``) or a canonical dest collides (two distinct sources) —
+never guesses, never silently drops.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import defaultdict
+from dataclasses import astuple, dataclass
+from pathlib import Path
+
+from dynacell.evaluation import paths
+
+MODELS_ROOT: Path = paths.MODELS_ROOT
+DATA_ROOT: Path = paths.DATA_ROOT
+# Checkpoints live under two source roots; the canonical tree consolidates both
+# under the models root (dynacell), so cell_diff_vs_viscy entries are cross-root
+# moves (still a same-filesystem rename — both under models/). The sibling root is
+# derived from ``models_root`` inside collect_checkpoints so a test can point it
+# at a fixture.
+# Campaign train terms (the raw on-disk source dir names). iPSC-trained-only
+# checkpoints (their own top-level term) are out of this campaign's scope.
+MODELS_TERMS: tuple[str, ...] = ("a549_mantis", "joint_ipsc_confocal_a549_mantis")
+PRED_SUBDIRS: tuple[str, ...] = ("predictions", "joint_predictions", "joint_predictions_v2")
+# Run-dir markers that identify smoke/debug runs (excluded — they canonicalize
+# onto their real sibling's dest and would collide).
+NOISE_RUN_MARKERS: tuple[str, ...] = ("smoke", "debug", "sanity")
+
+# Non-artifact eval leaf names / suffixes to skip (not eval outputs).
+_EVAL_SKIP_EXACT: frozenset[str] = frozenset({"slurm"})
+_EVAL_SKIP_SUFFIX: tuple[str, ...] = ("_CPU", "_local_gpu")
+
+# Eval parents whose leaves are in the coherent canonical scope: the focus-2D
+# ``*_with_embeddings`` triad (default track) + the instance-AP subtrack. Other
+# normalize_legacy-mapped parents (ablation ``evaluations_{randinit,cytoland,
+# infectionft}`` and the FT ``*_cytolandft*`` / ``*_infectionft_dynacellft*``
+# families) are OWN-TRACK: paths.py maps their eval dirs but SKIPS their prediction
+# zarrs (the ``_cytoland`` / ``_infectionft`` prediction skip), so their configs
+# cannot be fully canonicalized. Excluded by default; ``--include-own-track-evals``
+# folds them anyway.
+_CANONICAL_EVAL_PARENTS: frozenset[str] = frozenset(
+    {
+        "evaluations_with_embeddings",
+        "evaluations_a549trained_with_embeddings",
+        "evaluations_jointtrained_with_embeddings",
+        "evaluations_instance_ap",
+    }
+)
+
+
+CSV_HEADER: tuple[str, ...] = ("kind", "status", "src", "dest", "reason")
+
+
+@dataclass(frozen=True)
+class Row:
+    """One manifest row: an artifact and its resolved migration disposition."""
+
+    kind: str  # checkpoint | prediction | eval
+    status: str  # move | dedup_legacy | skip
+    src: str
+    dest: str  # "" for skip
+    reason: str
+
+
+def _is_noise_run(name: str) -> bool:
+    low = name.lower()
+    return any(m in low for m in NOISE_RUN_MARKERS)
+
+
+def _pred_skip_reason(name: str) -> str | None:
+    """Deliberate normalize_legacy prediction skips (own track / stale), not gaps."""
+    if name in paths._SKIP_ZARR_FILENAMES:
+        return "alias-dup (stale short-name)"
+    if any(tok in name for tok in ("_randinit", "_cytoland", "_infectionft")):
+        return "ablation-track (own eval track)"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hardlink-equivalence check for deduping prediction dual-homes
+# ---------------------------------------------------------------------------
+
+
+def _stat_key(path: Path) -> tuple[int, int]:
+    st = path.stat()
+    return (st.st_dev, st.st_ino)
+
+
+def _group_hardlinked(srcs: list[str], full: bool, sentinel: str) -> tuple[bool, str]:
+    """Return (equivalent, detail) for a group of dirs mapping to one dest.
+
+    Fast mode (default): identical ``sentinel`` inode ``(dev, ino)`` across the
+    group — two stats per member, no tree walk. A shared sentinel inode
+    (``zarr.json`` for predictions, ``checkpoints/last.ckpt`` for model dirs) is a
+    strong ``cp -al`` signature. Full mode (``--full-hardlink-check``): the entire
+    ``(relpath -> (dev, ino))`` map is identical (a true hardlink tree). A group
+    that fails is NOT safe to dedup by selection — surfaced as a collision, never
+    silently dropped.
+    """
+    for s in srcs:
+        if not (Path(s) / sentinel).is_file():
+            return False, f"no {sentinel} in {s}"
+    key0 = _stat_key(Path(srcs[0]) / sentinel)
+    for s in srcs[1:]:
+        if _stat_key(Path(s) / sentinel) != key0:
+            return False, f"{sentinel} inode differs ({s})"
+    if not full:
+        return True, f"{sentinel} inode match (fast)"
+
+    def relino(root_str: str) -> dict[str, tuple[int, int]]:
+        root = Path(root_str)
+        return {str(f.relative_to(root)): _stat_key(f) for f in root.rglob("*") if f.is_file()}
+
+    base = relino(srcs[0])
+    for s in srcs[1:]:
+        if relino(s) != base:
+            return False, f"tree inode mismatch ({s})"
+    return True, f"{len(base)} files fully hardlinked"
+
+
+def _dedup_group(
+    kind: str,
+    dest: str,
+    srcs: list[str],
+    full: bool,
+    sentinel: str,
+    prefer_root: Path | None = None,
+) -> tuple[list[Row], str | None]:
+    """Resolve a group of sources mapping to one canonical dest.
+
+    A single source is a plain ``move``. Multiple sources must be hardlink-identical
+    (a legit ``cp -al`` dual-home) — one becomes the ``move`` winner, the rest
+    ``dedup_legacy`` (left in place). ``prefer_root`` wins the tie (keep the copy
+    already under the canonical root; leave the other tree, e.g. a cross-user root,
+    untouched). Returns (rows, gap): a non-hardlinked group yields a gap, no rows.
+    """
+    if len(srcs) == 1:
+        return [Row(kind, "move", srcs[0], dest, "")], None
+
+    def sort_key(s: str) -> tuple[bool, str]:
+        under_pref = prefer_root is not None and Path(s).is_relative_to(prefer_root)
+        return (not under_pref, s)  # prefer_root first, then lexicographic
+
+    ordered = sorted(srcs, key=sort_key)
+    equivalent, detail = _group_hardlinked(ordered, full=full, sentinel=sentinel)
+    if not equivalent:
+        return [], f"COLLISION (non-hardlinked, unsafe to dedup) {dest}: {detail}; sources={ordered}"
+    winner = ordered[0]
+    rows = [Row(kind, "move", winner, dest, f"dedup winner of {len(ordered)} ({detail})")]
+    rows += [Row(kind, "dedup_legacy", o, dest, f"hardlink dup of {winner}") for o in ordered[1:]]
+    return rows, None
+
+
+# ---------------------------------------------------------------------------
+# Collectors
+# ---------------------------------------------------------------------------
+
+
+def collect_checkpoints(models_root: Path, full_hardlink_check: bool) -> tuple[list[Row], list[str]]:
+    """Whole model-dir moves for every checkpointed run in scope. Returns (rows, gaps).
+
+    A model dir hardlink-duplicated across the two source roots (``cp -al``
+    consolidation) canonicalizes to one dest; the group is deduped to a single
+    ``move`` winner (preferring the copy already under the canonical dynacell root)
+    plus ``dedup_legacy`` rows for the others.
+    """
+    rows: list[Row] = []
+    gaps: list[str] = []
+    dest_to_srcs: dict[str, list[str]] = defaultdict(list)
+    source_roots = (models_root, models_root.parent / "cell_diff_vs_viscy")
+    for src_root in source_roots:
+        for term in MODELS_TERMS:
+            term_dir = src_root / term
+            if not term_dir.is_dir():
+                continue
+            for org_dir in sorted(p for p in term_dir.iterdir() if p.is_dir()):
+                for model_dir in sorted(p for p in org_dir.iterdir() if p.is_dir()):
+                    if not (model_dir / "checkpoints").is_dir():
+                        continue
+                    if _is_noise_run(model_dir.name):
+                        rows.append(Row("checkpoint", "skip", str(model_dir), "", f"noise run dir ({model_dir.name})"))
+                        continue
+                    try:
+                        model = paths.canonical_model_name(model_dir.name)
+                        # Move the whole model dir -> canonical <train_set>/<org>/<model>.
+                        dest = paths.checkpoint_dir(org_dir.name, model, term, models_root=models_root).parent
+                    except ValueError as exc:
+                        gaps.append(f"{model_dir}  -> ERR {exc}")
+                        continue
+                    dest_to_srcs[str(dest)].append(str(model_dir))
+
+    for dest, srcs in sorted(dest_to_srcs.items()):
+        group_rows, gap = _dedup_group(
+            "checkpoint",
+            dest,
+            sorted(srcs),
+            full=full_hardlink_check,
+            sentinel="checkpoints/last.ckpt",
+            prefer_root=models_root,
+        )
+        rows.extend(group_rows)
+        if gap:
+            gaps.append(gap)
+    return rows, gaps
+
+
+def collect_predictions(data_root: Path, full_hardlink_check: bool) -> tuple[list[Row], list[str], list[str]]:
+    """Prediction-zarr moves with hardlinked dual-home dedup. Returns (rows, skips, gaps)."""
+    rows: list[Row] = []
+    skips: list[str] = []
+    gaps: list[str] = []
+    dest_to_srcs: dict[str, list[str]] = defaultdict(list)
+    for domain in ("a549", "ipsc"):
+        for sub in PRED_SUBDIRS:
+            d = data_root / domain / sub
+            if not d.is_dir():
+                continue
+            for z in sorted(d.glob("*.zarr")):
+                key = paths.normalize_legacy(z, data_root=data_root)
+                if key is None:
+                    reason = _pred_skip_reason(z.name)
+                    if reason:
+                        skips.append(f"{z}  [{reason}]")
+                    else:
+                        gaps.append(f"{z}  -> UNMAPPED (normalize_legacy None)")
+                    continue
+                try:
+                    dest = paths.prediction_store(
+                        key.organelle, key.model, key.train_set, key.test_set, key.condition, data_root=data_root
+                    )
+                except ValueError as exc:
+                    gaps.append(f"{z}  -> ERR {exc}")
+                    continue
+                dest_to_srcs[str(dest)].append(str(z))
+
+    for dest, srcs in sorted(dest_to_srcs.items()):
+        group_rows, gap = _dedup_group("prediction", dest, sorted(srcs), full=full_hardlink_check, sentinel="zarr.json")
+        rows.extend(group_rows)
+        if gap:
+            gaps.append(gap)
+    return rows, skips, gaps
+
+
+def collect_evals(data_root: Path, include_own_track: bool) -> tuple[list[Row], list[str], list[str]]:
+    """Eval-dir moves for every normalize_legacy-mapped leaf. Returns (rows, skips, gaps)."""
+    rows: list[Row] = []
+    skips: list[str] = []
+    gaps: list[str] = []
+    for domain in ("a549", "ipsc"):
+        base = data_root / domain
+        if not base.is_dir():
+            continue
+        for evroot in sorted(
+            p
+            for p in base.iterdir()
+            if p.is_dir() and (p.name.startswith("evaluations") or p.name == "joint_evaluations")
+        ):
+            own_track = evroot.name not in _CANONICAL_EVAL_PARENTS
+            for leafdir in sorted(p for p in evroot.iterdir() if p.is_dir()):
+                if leafdir.name in _EVAL_SKIP_EXACT or leafdir.name.endswith(_EVAL_SKIP_SUFFIX):
+                    skips.append(f"{leafdir}  [non-artifact dir]")
+                    continue
+                key = paths.normalize_legacy(leafdir, data_root=data_root)
+                if key is None:
+                    skips.append(f"{leafdir}  [normalize->None (stale pre-2D / dropped deconv-GT / own track)]")
+                    continue
+                if own_track and not include_own_track:
+                    skips.append(f"{leafdir}  [own-track eval ({evroot.name}); predictions not canonicalized]")
+                    continue
+                try:
+                    dest = paths.eval_leaf(
+                        key.organelle,
+                        key.model,
+                        key.train_set,
+                        key.test_set,
+                        key.condition,
+                        component=key.component,
+                        track=key.track,
+                        data_root=data_root,
+                    )
+                except ValueError as exc:
+                    gaps.append(f"{leafdir}  -> ERR {exc}")
+                    continue
+                rows.append(Row("eval", "move", str(leafdir), str(dest), f"track={key.track}"))
+    return rows, skips, gaps
+
+
+# ---------------------------------------------------------------------------
+# Collision guard + report
+# ---------------------------------------------------------------------------
+
+
+def _dest_collisions(rows: list[Row]) -> list[str]:
+    """Return errors for any canonical ``move`` dest reached by >1 distinct source."""
+    by_dest: dict[str, list[str]] = defaultdict(list)
+    for r in rows:
+        if r.status == "move":
+            by_dest[r.dest].append(r.src)
+    errs = []
+    for dest, srcs in sorted(by_dest.items()):
+        if len(srcs) > 1:
+            errs.append(f"DEST COLLISION {dest} <- {srcs}")
+    return errs
+
+
+def _write_manifest(rows: list[Row], out: Path) -> None:
+    with out.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(CSV_HEADER)
+        for r in rows:
+            w.writerow(astuple(r))
+
+
+def _summarize(rows: list[Row], kind: str) -> str:
+    move = sum(1 for r in rows if r.kind == kind and r.status == "move")
+    dedup = sum(1 for r in rows if r.kind == kind and r.status == "dedup_legacy")
+    skip = sum(1 for r in rows if r.kind == kind and r.status == "skip")
+    extra = f", {dedup} dedup_legacy" if dedup else ""
+    extra += f", {skip} skip" if skip else ""
+    return f"{move} move{extra}"
+
+
+def _write_report(
+    report: Path,
+    rows: list[Row],
+    skips: list[str],
+    gaps: list[str],
+    collisions: list[str],
+) -> None:
+    lines: list[str] = []
+    lines.append("Phase-7 canonical-path migration manifest — dry-run report")
+    lines.append("=" * 64)
+    for kind in ("checkpoint", "prediction", "eval"):
+        lines.append(f"{kind:12s}: {_summarize(rows, kind)}")
+    n_move = sum(1 for r in rows if r.status == "move")
+    lines.append(f"{'TOTAL move':12s}: {n_move}")
+    lines.append("")
+    lines.append(f"deliberate skips (not migrated, left in place): {len(skips)}")
+    lines.append(f"GAPS (UNMAPPED — must be 0): {len(gaps)}")
+    lines.append(f"DEST COLLISIONS (must be 0): {len(collisions)}")
+    lines.append("")
+    if gaps:
+        lines.append("---- GAPS ----")
+        lines.extend(f"  {g}" for g in gaps)
+        lines.append("")
+    if collisions:
+        lines.append("---- DEST COLLISIONS ----")
+        lines.extend(f"  {c}" for c in collisions)
+        lines.append("")
+    lines.append("---- checkpoint moves ----")
+    for r in rows:
+        if r.kind == "checkpoint" and r.status == "move":
+            tag = f"  [{r.reason}]" if r.reason else ""
+            lines.append(f"  {r.src}\n    -> {r.dest}{tag}")
+    lines.append("")
+    lines.append("---- deliberate skips ----")
+    lines.extend(f"  {s}" for s in skips)
+    report.write_text("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: enumerate artifacts, write the manifest CSV + report, exit 1 on gaps/collisions."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, required=True, help="manifest CSV output path")
+    ap.add_argument(
+        "--full-hardlink-check",
+        action="store_true",
+        help="verify prediction dedup groups by the full per-file (relpath -> inode) "
+        "tree comparison (slow; walks every zarr). Default: zarr.json inode match only "
+        "(use --full-hardlink-check for the pre-apply run).",
+    )
+    ap.add_argument(
+        "--include-own-track-evals",
+        action="store_true",
+        help="also migrate own-track eval dirs (ablation randinit/cytoland/infectionft + "
+        "FT families) whose prediction zarrs are NOT canonicalized by paths.py. Default: "
+        "migrate only the coherent canonical set (*_with_embeddings triad + instance_ap).",
+    )
+    ap.add_argument(
+        "--allow-gaps",
+        action="store_true",
+        help="write the manifest and exit 0 even if UNMAPPED artifacts / collisions exist "
+        "(for inspection; default is to exit non-zero)",
+    )
+    args = ap.parse_args(argv)
+
+    ck_rows, ck_gaps = collect_checkpoints(MODELS_ROOT, full_hardlink_check=args.full_hardlink_check)
+    pr_rows, pr_skips, pr_gaps = collect_predictions(DATA_ROOT, full_hardlink_check=args.full_hardlink_check)
+    ev_rows, ev_skips, ev_gaps = collect_evals(DATA_ROOT, include_own_track=args.include_own_track_evals)
+
+    rows = ck_rows + pr_rows + ev_rows
+    gaps = ck_gaps + pr_gaps + ev_gaps
+    collisions = _dest_collisions(rows)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    _write_manifest(rows, args.out)
+    report = args.out.with_suffix(".report.txt")
+    _write_report(report, rows, pr_skips + ev_skips, gaps, collisions)
+
+    for kind in ("checkpoint", "prediction", "eval"):
+        print(f"{kind:12s}: {_summarize(rows, kind)}")
+    print(f"{'skip':12s}: {len(pr_skips) + len(ev_skips) + sum(1 for r in rows if r.status == 'skip')}")
+    print(f"{'GAPS':12s}: {len(gaps)}")
+    print(f"{'COLLISIONS':12s}: {len(collisions)}")
+    print(f"manifest -> {args.out}")
+    print(f"report   -> {report}")
+    for g in gaps:
+        print(f"  GAP {g}")
+    for c in collisions:
+        print(f"  {c}")
+
+    if (gaps or collisions) and not args.allow_gaps:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/build_migration_manifest.py
+++ b/applications/dynacell/tools/build_migration_manifest.py
@@ -3,12 +3,15 @@
 
 Enumerates the on-disk dynacell campaign artifacts and computes their canonical
 destinations with :mod:`dynacell.evaluation.paths` — the single source of truth.
-The tool deliberately carries **no independent skip policy**: whatever
-:func:`paths.normalize_legacy` / :func:`paths.checkpoint_dir` map is migrated;
-whatever they refuse (``None`` / ``ValueError``) is reported as a skip or a gap.
-The only tool-side exception is a noise-run filter for checkpoint run dirs
-(``*_smoke`` / ``*_debug`` / ``*_sanity``), which would otherwise canonicalize
-onto — and collide with — their real sibling run.
+For predictions/evals the tool carries **no independent skip policy**: whatever
+:func:`paths.normalize_legacy` maps is migrated; whatever it refuses (``None``) is
+a skip or a gap. For checkpoints (the ``ipsc`` term is an experiment graveyard) it
+applies a "keep only the paper's one final recipe per model" curation: noise /
+perf-probe runs (``*_smoke`` / ``*_debug`` / ``*_sanity`` / ``*tuning*``), pre-D
+pix2pix recipe experiments, and superseded/non-paper run dirs (pre-R2 ``celldiff``,
+legacy ``unext2``) are skipped; when several distinct runs canonicalize to one
+dest the config-referenced run (the paper's actual checkpoint) wins and the rest
+are skipped as unreferenced variants.
 
 Three artifact families:
 
@@ -39,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import re
 import sys
 from collections import defaultdict
 from dataclasses import astuple, dataclass
@@ -48,18 +52,33 @@ from dynacell.evaluation import paths
 
 MODELS_ROOT: Path = paths.MODELS_ROOT
 DATA_ROOT: Path = paths.DATA_ROOT
+# Benchmark config tree (source of the "which checkpoint the paper uses" reference
+# set that resolves distinct-run collisions in the iPSC experiment graveyard).
+CONFIG_ROOT: Path = Path(__file__).resolve().parents[3] / "applications/dynacell/configs/benchmarks/virtual_staining"
 # Checkpoints live under two source roots; the canonical tree consolidates both
 # under the models root (dynacell), so cell_diff_vs_viscy entries are cross-root
 # moves (still a same-filesystem rename — both under models/). The sibling root is
 # derived from ``models_root`` inside collect_checkpoints so a test can point it
 # at a fixture.
-# Campaign train terms (the raw on-disk source dir names). iPSC-trained-only
-# checkpoints (their own top-level term) are out of this campaign's scope.
-MODELS_TERMS: tuple[str, ...] = ("a549_mantis", "joint_ipsc_confocal_a549_mantis")
+# Campaign train terms (the raw on-disk source dir names). ``ipsc`` (the
+# iPSC-trained models) is fully canonicalized alongside a549/joint; its dir is an
+# experiment graveyard, so the curation rules below prune the clutter.
+MODELS_TERMS: tuple[str, ...] = ("a549_mantis", "joint_ipsc_confocal_a549_mantis", "ipsc")
 PRED_SUBDIRS: tuple[str, ...] = ("predictions", "joint_predictions", "joint_predictions_v2")
-# Run-dir markers that identify smoke/debug runs (excluded — they canonicalize
-# onto their real sibling's dest and would collide).
-NOISE_RUN_MARKERS: tuple[str, ...] = ("smoke", "debug", "sanity")
+# Run-dir markers that identify smoke/debug/perf-probe runs (excluded — they
+# canonicalize onto their real sibling's dest and would collide).
+NOISE_RUN_MARKERS: tuple[str, ...] = ("smoke", "debug", "sanity", "tuning")
+
+# pix2pix3d_unetvit recipe sweep: only Run D (LeCam + lambdaL1=10, 40ep) and the
+# consolidated clean name are canonical; the pre-D experiment recipes are pruned
+# (the whole sweep canonicalizes to `pix2pix3d_unetvit`, so keeping them all would
+# collide). See project_pix2pix3d_sec61b_recipe_sweep.
+_PIX2PIX_KEEP: frozenset[str] = frozenset({"pix2pix3d_unetvit", "pix2pix3d_unetvit_modernized_lambdaL1_10_lecam_40ep"})
+# Superseded / non-paper run-dir names dropped outright: ``celldiff`` is pre-R2
+# (the paper CELL-Diff is celldiff_r2); ``unext2`` is the ambiguous legacy
+# paper-key dir (the code model is fcmae_vscyto3d_scratch). "Keep only the paper's
+# one final recipe per model."
+_SUPERSEDED_RUN_NAMES: frozenset[str] = frozenset({"celldiff", "unext2"})
 
 # Non-artifact eval leaf names / suffixes to skip (not eval outputs).
 _EVAL_SKIP_EXACT: frozenset[str] = frozenset({"slurm"})
@@ -191,13 +210,50 @@ def _dedup_group(
 # ---------------------------------------------------------------------------
 
 
-def collect_checkpoints(models_root: Path, full_hardlink_check: bool) -> tuple[list[Row], list[str]]:
+def _checkpoint_skip_reason(model_dir_name: str, model: str | None) -> str | None:
+    """Curation skip for a checkpoint run dir (non-paper experiment clutter), else None."""
+    if _is_noise_run(model_dir_name):
+        return f"noise/perf-probe run ({model_dir_name})"
+    if model_dir_name in _SUPERSEDED_RUN_NAMES:
+        return f"superseded/non-paper run dir ({model_dir_name})"
+    if model == "pix2pix3d_unetvit" and model_dir_name not in _PIX2PIX_KEEP:
+        return f"pre-D pix2pix recipe experiment ({model_dir_name})"
+    return None
+
+
+def _referenced_model_dirs(config_root: Path) -> set[str]:
+    """Model dirs referenced by any config path value (ckpt_path/run_root/dirpath/save_dir).
+
+    A value under the two model roots identifies the paper's actual checkpoint for a
+    leaf; stripping any ``/checkpoints`` tail yields the run dir. Used to pick the
+    paper's final run when several distinct runs canonicalize to one dest.
+    """
+    roots = (str(MODELS_ROOT) + "/", str(MODELS_ROOT.parent / "cell_diff_vs_viscy") + "/")
+    refs: set[str] = set()
+    for leaf in config_root.rglob("*.y*ml"):
+        for match in re.finditer(r"/hpc/projects/\S+", leaf.read_text()):
+            val = match.group(0)
+            if val.startswith(roots):
+                refs.add(val.split("/checkpoints")[0])
+    return refs
+
+
+def collect_checkpoints(
+    models_root: Path,
+    full_hardlink_check: bool,
+    referenced_dirs: set[str] | None = None,
+) -> tuple[list[Row], list[str]]:
     """Whole model-dir moves for every checkpointed run in scope. Returns (rows, gaps).
 
-    A model dir hardlink-duplicated across the two source roots (``cp -al``
-    consolidation) canonicalizes to one dest; the group is deduped to a single
-    ``move`` winner (preferring the copy already under the canonical dynacell root)
-    plus ``dedup_legacy`` rows for the others.
+    Curation (the ``ipsc`` term is an experiment graveyard): noise/perf-probe runs,
+    pre-D pix2pix recipes, and ambiguous legacy paper-key dirs are skipped.
+
+    Collision resolution when >1 run canonicalizes to one dest:
+    - hardlink-identical (``cp -al`` cross-root consolidation) -> dedup to one
+      ``move`` winner (dynacell-root preferred) + ``dedup_legacy`` siblings;
+    - otherwise (distinct runs) resolve by config reference: the single
+      config-referenced run wins (``move``), the rest are skipped as unreferenced
+      experimental variants; zero referenced -> skip all; >1 referenced -> gap.
     """
     rows: list[Row] = []
     gaps: list[str] = []
@@ -212,30 +268,49 @@ def collect_checkpoints(models_root: Path, full_hardlink_check: bool) -> tuple[l
                 for model_dir in sorted(p for p in org_dir.iterdir() if p.is_dir()):
                     if not (model_dir / "checkpoints").is_dir():
                         continue
-                    if _is_noise_run(model_dir.name):
-                        rows.append(Row("checkpoint", "skip", str(model_dir), "", f"noise run dir ({model_dir.name})"))
-                        continue
                     try:
-                        model = paths.canonical_model_name(model_dir.name)
-                        # Move the whole model dir -> canonical <train_set>/<org>/<model>.
-                        dest = paths.checkpoint_dir(org_dir.name, model, term, models_root=models_root).parent
-                    except ValueError as exc:
-                        gaps.append(f"{model_dir}  -> ERR {exc}")
+                        model: str | None = paths.canonical_model_name(model_dir.name)
+                    except ValueError:
+                        model = None
+                    reason = _checkpoint_skip_reason(model_dir.name, model)
+                    if reason is not None:
+                        rows.append(Row("checkpoint", "skip", str(model_dir), "", reason))
                         continue
+                    if model is None:
+                        gaps.append(f"{model_dir}  -> ERR cannot canonicalize run-dir name")
+                        continue
+                    # Move the whole model dir -> canonical <train_set>/<org>/<model>.
+                    dest = paths.checkpoint_dir(org_dir.name, model, term, models_root=models_root).parent
                     dest_to_srcs[str(dest)].append(str(model_dir))
 
     for dest, srcs in sorted(dest_to_srcs.items()):
-        group_rows, gap = _dedup_group(
-            "checkpoint",
-            dest,
-            sorted(srcs),
-            full=full_hardlink_check,
-            sentinel="checkpoints/last.ckpt",
-            prefer_root=models_root,
-        )
-        rows.extend(group_rows)
-        if gap:
-            gaps.append(gap)
+        srcs = sorted(srcs)
+        if len(srcs) == 1:
+            rows.append(Row("checkpoint", "move", srcs[0], dest, ""))
+            continue
+        equivalent, _ = _group_hardlinked(srcs, full=full_hardlink_check, sentinel="checkpoints/last.ckpt")
+        if equivalent:
+            group_rows, gap = _dedup_group(
+                "checkpoint",
+                dest,
+                srcs,
+                full=full_hardlink_check,
+                sentinel="checkpoints/last.ckpt",
+                prefer_root=models_root,
+            )
+            rows.extend(group_rows)
+            if gap:
+                gaps.append(gap)
+            continue
+        # Distinct (non-hardlinked) runs -> resolve by config reference.
+        ref = [s for s in srcs if referenced_dirs and s in referenced_dirs]
+        if len(ref) == 1:
+            rows.append(Row("checkpoint", "move", ref[0], dest, "config-referenced winner"))
+            rows += [Row("checkpoint", "skip", o, "", f"unreferenced variant of {dest}") for o in srcs if o != ref[0]]
+        elif len(ref) == 0:
+            rows += [Row("checkpoint", "skip", s, "", f"unreferenced (superseded) run for {dest}") for s in srcs]
+        else:
+            gaps.append(f"COLLISION (>1 config-referenced distinct runs) {dest}: {ref}")
     return rows, gaps
 
 
@@ -419,7 +494,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    ck_rows, ck_gaps = collect_checkpoints(MODELS_ROOT, full_hardlink_check=args.full_hardlink_check)
+    referenced = _referenced_model_dirs(CONFIG_ROOT)
+    ck_rows, ck_gaps = collect_checkpoints(
+        MODELS_ROOT, full_hardlink_check=args.full_hardlink_check, referenced_dirs=referenced
+    )
     pr_rows, pr_skips, pr_gaps = collect_predictions(DATA_ROOT, full_hardlink_check=args.full_hardlink_check)
     ev_rows, ev_skips, ev_gaps = collect_evals(DATA_ROOT, include_own_track=args.include_own_track_evals)
 

--- a/applications/dynacell/tools/restandardize_config_paths.py
+++ b/applications/dynacell/tools/restandardize_config_paths.py
@@ -41,6 +41,7 @@ leaves are git-tracked, so ``--apply`` is fully reversible via git.
 from __future__ import annotations
 
 import argparse
+import csv
 import difflib
 import re
 import sys
@@ -78,6 +79,10 @@ def build_ckpt_map(models_root: Path) -> dict[str, str]:
 
     Includes both the dedup ``move`` winner and its ``dedup_legacy`` siblings, so a
     config pointing at EITHER cross-root copy resolves to the same canonical dest.
+
+    Re-enumerates the LIVE models tree — valid only BEFORE ``run_migration`` has
+    relocated the checkpoints (else the legacy dirs are gone and the map is empty).
+    After migrating, pass the frozen manifest to ``load_ckpt_map_from_manifest``.
     """
     rows, gaps = collect_checkpoints(
         models_root, full_hardlink_check=False, referenced_dirs=_referenced_model_dirs(CONFIG_ROOT)
@@ -85,6 +90,24 @@ def build_ckpt_map(models_root: Path) -> dict[str, str]:
     if gaps:
         raise RuntimeError("checkpoint enumeration has gaps; refusing to codemod:\n" + "\n".join(gaps))
     return {r.src: r.dest for r in rows if r.status in ("move", "dedup_legacy")}
+
+
+def load_ckpt_map_from_manifest(manifest: Path) -> dict[str, str]:
+    """Return {old model-dir -> canonical dest} from a frozen manifest CSV.
+
+    The codemod runs AFTER ``run_migration`` relocates the checkpoints, so the live
+    models tree can no longer be re-enumerated for the legacy dirs. The manifest is
+    the frozen record of what moved (checkpoint ``move`` + ``dedup_legacy`` rows) —
+    the same {src -> dest} pairs ``build_ckpt_map`` would have produced pre-migration.
+    """
+    out: dict[str, str] = {}
+    with manifest.open(newline="") as fh:
+        for row in csv.DictReader(fh):
+            if row["kind"] == "checkpoint" and row["status"] in ("move", "dedup_legacy"):
+                out[row["src"]] = row["dest"]
+    if not out:
+        raise RuntimeError(f"no checkpoint move rows in manifest {manifest}; refusing to codemod")
+    return out
 
 
 def _rewrite_ckpt_value(value: str, ckpt_map: dict[str, str]) -> str | None:
@@ -169,10 +192,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument("--apply", action="store_true", help="write changes in place (default: dry-run diff)")
     ap.add_argument("--models-root", type=Path, default=MODELS_ROOT, help="checkpoint models root (for the ckpt map)")
+    ap.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="frozen manifest CSV; build the ckpt map from it instead of re-scanning the "
+        "(already-migrated) models tree. Required when run AFTER run_migration --apply.",
+    )
     ap.add_argument("--show-diff", action="store_true", help="print a unified diff per changed file")
     args = ap.parse_args(argv)
 
-    ckpt_map = build_ckpt_map(args.models_root)
+    ckpt_map = load_ckpt_map_from_manifest(args.manifest) if args.manifest else build_ckpt_map(args.models_root)
     leaves = iter_leaves(args.config_root)
     n_changed = 0
     n_field_changes = 0

--- a/applications/dynacell/tools/restandardize_config_paths.py
+++ b/applications/dynacell/tools/restandardize_config_paths.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""Codemod: rewrite dynacell predict/train config-leaf paths to the canonical grammar.
+
+Part of the Phase-7 canonicalization. After the artifact migration
+(``run_migration.py``) relocates checkpoints + predictions onto the
+``dynacell.evaluation.paths`` grammar, the config leaves that drive re-training /
+re-prediction must point at the new locations, or Phase-9 re-predict reads stale
+checkpoints and writes to legacy prediction dirs.
+
+Scope (this tool): the hand-authored ``train.yml`` and ``predict__*.yml`` leaves
+under ``applications/dynacell/configs/benchmarks/virtual_staining/<organelle>/
+<model>/<train_term>/``. Generated eval leaves (grouped / instance_ap) are handled
+by fixing their GENERATORS + regeneration, not here.
+
+Rewrite rules (per the verified field inventory) — a value is rewritten IFF it
+resolves to a MIGRATED artifact; everything else is preserved:
+
+- **checkpoint paths** (value under ``models/dynacell/`` or ``models/cell_diff_vs_viscy/``):
+  ``model.init_args.ckpt_path`` (predict: the trained ckpt to LOAD), ``launcher.run_root``
+  / ``ModelCheckpoint.dirpath`` / ``logger.save_dir`` (train: the model OUTPUT dir).
+  Rewritten via the SAME old-model-dir -> canonical-dest map the manifest builder
+  computes (``collect_checkpoints``), preserving any ``/checkpoints/<file>`` tail.
+  This correctly sends ER/mito A549 ckpts to the raw ``a549`` home (not the
+  ``a549__deconv`` prediction home). A checkpoint NOT in the map (iPSC-trained,
+  external init, published baseline, ``REPLACE_ME`` placeholder) is left untouched.
+- **prediction output** (``HCSPredictionWriter.output_store``, a data-tree ``.zarr``):
+  ``normalize_legacy(old) -> prediction_store(...)`` — byte-identical to the
+  manifest's prediction dest.
+- **predict ``launcher.run_root``** (a data-tree ``predictions/`` dir): set to the
+  canonical prediction leaf dir (``output_store``'s parent), co-locating logs with
+  the prediction.
+
+PRESERVED (never rewritten): training-input ``data*.data_path``, eval GT
+``nuclei_gt_path``, ``scratch_dir``, and any checkpoint value outside the two
+migrated model roots.
+
+Dry-run by default (prints a unified diff); ``--apply`` writes in place. Config
+leaves are git-tracked, so ``--apply`` is fully reversible via git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+from build_migration_manifest import DATA_ROOT, MODELS_ROOT, collect_checkpoints
+
+from dynacell.evaluation import paths
+
+CONFIG_ROOT_REL = "applications/dynacell/configs/benchmarks/virtual_staining"
+
+# Value roots.
+_MODELS_MIGRATED_ROOTS = (
+    str(MODELS_ROOT) + "/",  # .../models/dynacell/
+    str(MODELS_ROOT.parent / "cell_diff_vs_viscy") + "/",
+)
+
+# A ``key: /hpc/projects/...`` line (captures indent, key, value; tolerates inline
+# trailing whitespace). Values are unquoted in these leaves.
+_KV = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][A-Za-z0-9_]*):\s*(?P<val>/hpc/projects/\S+)\s*$")
+
+# Keys that may carry a rewritable path (others with /hpc values are inputs we preserve).
+_CKPT_OR_DIR_KEYS = frozenset({"ckpt_path", "run_root", "dirpath", "save_dir"})
+_PRED_OUT_KEY = "output_store"
+
+
+def build_ckpt_map(models_root: Path) -> dict[str, str]:
+    """Return {old model-dir -> canonical dest} for every migrated checkpoint run.
+
+    Includes both the dedup ``move`` winner and its ``dedup_legacy`` siblings, so a
+    config pointing at EITHER cross-root copy resolves to the same canonical dest.
+    """
+    rows, gaps = collect_checkpoints(models_root, full_hardlink_check=False)
+    if gaps:
+        raise RuntimeError("checkpoint enumeration has gaps; refusing to codemod:\n" + "\n".join(gaps))
+    return {r.src: r.dest for r in rows if r.status in ("move", "dedup_legacy")}
+
+
+def _rewrite_ckpt_value(value: str, ckpt_map: dict[str, str]) -> str | None:
+    """Rewrite a checkpoint-tree value via the map, preserving a ``/checkpoints`` tail.
+
+    Returns the canonical value, or None if the value is not a migrated checkpoint
+    (outside the two model roots, or a model dir absent from the map) -> preserve.
+    """
+    if not value.startswith(_MODELS_MIGRATED_ROOTS):
+        return None
+    idx = value.find("/checkpoints")
+    model_dir = value[:idx] if idx != -1 else value
+    tail = value[idx:] if idx != -1 else ""
+    dest = ckpt_map.get(model_dir)
+    if dest is None:
+        return None
+    return dest + tail
+
+
+def _rewrite_prediction_value(value: str) -> str | None:
+    """Rewrite a data-tree prediction ``.zarr`` value via normalize_legacy. None -> preserve."""
+    if not value.endswith(".zarr"):
+        return None
+    key = paths.normalize_legacy(value)
+    if key is None:
+        return None
+    return str(paths.prediction_store(key.organelle, key.model, key.train_set, key.test_set, key.condition))
+
+
+def rewrite_leaf(text: str, ckpt_map: dict[str, str]) -> tuple[str, list[str]]:
+    """Return (new_text, changes) for one predict/train leaf. changes is human-readable."""
+    lines = text.splitlines(keepends=True)
+    changes: list[str] = []
+
+    # Pass 1: canonical prediction output (drives predict run_root).
+    canonical_pred: str | None = None
+    for line in lines:
+        m = _KV.match(line)
+        if m and m.group("key") == _PRED_OUT_KEY:
+            canonical_pred = _rewrite_prediction_value(m.group("val"))
+            break
+
+    out: list[str] = []
+    for line in lines:
+        m = _KV.match(line)
+        if not m:
+            out.append(line)
+            continue
+        key, val, indent = m.group("key"), m.group("val"), m.group("indent")
+        new_val: str | None = None
+        if key == _PRED_OUT_KEY:
+            new_val = _rewrite_prediction_value(val)
+        elif key == "run_root" and val.startswith(str(DATA_ROOT) + "/"):
+            # predict working dir -> canonical prediction leaf dir (output_store parent)
+            new_val = str(Path(canonical_pred).parent) if canonical_pred else None
+        elif key in _CKPT_OR_DIR_KEYS:
+            new_val = _rewrite_ckpt_value(val, ckpt_map)
+        if new_val is not None and new_val != val:
+            out.append(f"{indent}{key}: {new_val}\n" if line.endswith("\n") else f"{indent}{key}: {new_val}")
+            changes.append(f"{key}: {val}\n         -> {new_val}")
+        else:
+            out.append(line)
+    return "".join(out), changes
+
+
+def iter_leaves(config_root: Path) -> list[Path]:
+    """Every hand-authored predict/train leaf under the organelle config tree."""
+    leaves = sorted(config_root.rglob("predict__*.yml"))
+    leaves += sorted(config_root.rglob("train.yml"))
+    leaves += sorted(config_root.rglob("train_*.yml"))  # train_4gpu / train_smoke variants
+    return leaves
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: dry-run (diff) or --apply the predict/train leaf path codemod."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--config-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[3] / CONFIG_ROOT_REL,
+        help="root of the benchmark config tree (default: repo config root)",
+    )
+    ap.add_argument("--apply", action="store_true", help="write changes in place (default: dry-run diff)")
+    ap.add_argument("--models-root", type=Path, default=MODELS_ROOT, help="checkpoint models root (for the ckpt map)")
+    ap.add_argument("--show-diff", action="store_true", help="print a unified diff per changed file")
+    args = ap.parse_args(argv)
+
+    ckpt_map = build_ckpt_map(args.models_root)
+    leaves = iter_leaves(args.config_root)
+    n_changed = 0
+    n_field_changes = 0
+    for leaf in leaves:
+        text = leaf.read_text()
+        new_text, changes = rewrite_leaf(text, ckpt_map)
+        if not changes:
+            continue
+        n_changed += 1
+        n_field_changes += len(changes)
+        rel = leaf.relative_to(args.config_root)
+        print(f"{'APPLY' if args.apply else 'DRY'} {rel}  ({len(changes)} field(s))")
+        if args.show_diff:
+            diff = difflib.unified_diff(
+                text.splitlines(), new_text.splitlines(), fromfile=str(rel), tofile=str(rel), lineterm=""
+            )
+            print("\n".join(diff))
+        else:
+            for c in changes:
+                print(f"    {c}")
+        if args.apply:
+            leaf.write_text(new_text)
+
+    print(f"\n{'applied' if args.apply else 'would change'}: {n_changed} leaf file(s), {n_field_changes} field(s)")
+    print(f"checkpoint map: {len(ckpt_map)} old-dir -> canonical-dest entries")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/restandardize_config_paths.py
+++ b/applications/dynacell/tools/restandardize_config_paths.py
@@ -111,16 +111,33 @@ def load_ckpt_map_from_manifest(manifest: Path) -> dict[str, str]:
 
 
 def _rewrite_ckpt_value(value: str, ckpt_map: dict[str, str]) -> str | None:
-    """Rewrite a checkpoint-tree value via the map, preserving a ``/checkpoints`` tail.
+    """Rewrite a checkpoint-tree value via the map, preserving any file/subdir tail.
+
+    Handles every on-disk shape a checkpoint-tree value takes in these leaves:
+
+    - a bare model dir (``save_dir`` / train ``run_root``) — an exact map key;
+    - ``<model_dir>/checkpoints`` or ``<model_dir>/checkpoints/<file>`` (``dirpath`` /
+      ``ckpt_path``), split on ``/checkpoints``;
+    - a bare best-epoch hardlink alias at ``<model_dir>/<file>`` with no ``checkpoints/``
+      subdir (several legacy iPSC runs store the best ckpt this way), or a sibling subdir
+      like ``<model_dir>/smoke`` — split on the final path separator.
+
+    Without the last branch ``find`` returned ``-1``, ``model_dir`` swallowed the whole
+    value, the map lookup missed, and the stale (migrated-away) path was silently kept.
 
     Returns the canonical value, or None if the value is not a migrated checkpoint
     (outside the two model roots, or a model dir absent from the map) -> preserve.
     """
     if not value.startswith(_MODELS_MIGRATED_ROOTS):
         return None
+    if value in ckpt_map:  # bare model dir (save_dir / train run_root), no tail
+        return ckpt_map[value]
     idx = value.find("/checkpoints")
-    model_dir = value[:idx] if idx != -1 else value
-    tail = value[idx:] if idx != -1 else ""
+    if idx != -1:
+        model_dir, tail = value[:idx], value[idx:]
+    else:
+        parent, _, filename = value.rpartition("/")
+        model_dir, tail = parent, "/" + filename
     dest = ckpt_map.get(model_dir)
     if dest is None:
         return None

--- a/applications/dynacell/tools/restandardize_config_paths.py
+++ b/applications/dynacell/tools/restandardize_config_paths.py
@@ -46,7 +46,13 @@ import re
 import sys
 from pathlib import Path
 
-from build_migration_manifest import DATA_ROOT, MODELS_ROOT, collect_checkpoints
+from build_migration_manifest import (
+    CONFIG_ROOT,
+    DATA_ROOT,
+    MODELS_ROOT,
+    _referenced_model_dirs,
+    collect_checkpoints,
+)
 
 from dynacell.evaluation import paths
 
@@ -73,7 +79,9 @@ def build_ckpt_map(models_root: Path) -> dict[str, str]:
     Includes both the dedup ``move`` winner and its ``dedup_legacy`` siblings, so a
     config pointing at EITHER cross-root copy resolves to the same canonical dest.
     """
-    rows, gaps = collect_checkpoints(models_root, full_hardlink_check=False)
+    rows, gaps = collect_checkpoints(
+        models_root, full_hardlink_check=False, referenced_dirs=_referenced_model_dirs(CONFIG_ROOT)
+    )
     if gaps:
         raise RuntimeError("checkpoint enumeration has gaps; refusing to codemod:\n" + "\n".join(gaps))
     return {r.src: r.dest for r in rows if r.status in ("move", "dedup_legacy")}

--- a/applications/dynacell/tools/run_migration.py
+++ b/applications/dynacell/tools/run_migration.py
@@ -74,13 +74,18 @@ def _existing_ancestor(path: Path) -> Path:
     return p
 
 
-def preflight(moves: list[Move]) -> tuple[list[Move], list[Move], list[str]]:
+def preflight(moves: list[Move]) -> tuple[list[Move], list[Move], list[Move], list[str]]:
     """Classify moves and collect blocking errors.
 
-    Returns (pending, already_applied, errors). ``pending`` are src-present /
-    dest-absent renames to run; ``already_applied`` are idempotent no-ops.
+    Returns (pending, merges, already_applied, errors). ``pending`` are
+    src-present / dest-absent renames to run; ``merges`` are eval leaves whose
+    canonical dest dir already exists (the prediction move creates the shared
+    leaf and drops ``prediction.zarr`` into it first) — the eval's children are
+    merged into that leaf rather than whole-dir renamed onto it; ``already`` are
+    idempotent no-ops.
     """
     pending: list[Move] = []
+    merges: list[Move] = []
     already: list[Move] = []
     errors: list[str] = []
 
@@ -115,10 +120,22 @@ def preflight(moves: list[Move]) -> tuple[list[Move], list[Move], list[str]]:
         elif not src_exists and dest_exists:
             already.append(m)
         elif src_exists and dest_exists:
-            errors.append(f"DEST ALREADY EXISTS (unexpected) src={m.src} dest={m.dest}")
+            # Canonical eval leaf == the prediction leaf: prediction.zarr is
+            # already inside the dest dir. A whole-dir rename would collide, so
+            # merge the eval's children into the leaf iff none of them clash.
+            if m.kind == "eval" and m.src.is_dir() and m.dest.is_dir():
+                clashes = sorted(c.name for c in m.src.iterdir() if (m.dest / c.name).exists())
+                if clashes:
+                    errors.append(f"MERGE CLASH {m.dest} already has {clashes} (src {m.src})")
+                elif m.src.stat().st_dev != m.dest.stat().st_dev:
+                    errors.append(f"CROSS-DEVICE (merge unsafe) src={m.src} dest={m.dest}")
+                else:
+                    merges.append(m)
+            else:
+                errors.append(f"DEST ALREADY EXISTS (unexpected) src={m.src} dest={m.dest}")
         else:  # neither exists
             errors.append(f"SRC MISSING and DEST ABSENT (lost?) src={m.src} dest={m.dest}")
-    return pending, already, errors
+    return pending, merges, already, errors
 
 
 def _append_journal(journal: Path, kind: str, src: Path, dest: Path, result: str, detail: str) -> None:
@@ -130,8 +147,8 @@ def _append_journal(journal: Path, kind: str, src: Path, dest: Path, result: str
         w.writerow((_now(), kind, str(src), str(dest), result, detail))
 
 
-def apply_moves(pending: list[Move], journal: Path, dry_run: bool) -> int:
-    """Execute (or preview) the pending renames. Returns count applied."""
+def apply_moves(pending: list[Move], merges: list[Move], journal: Path, dry_run: bool) -> int:
+    """Execute (or preview) the pending renames and eval-leaf merges. Returns count applied."""
     applied = 0
     for m in pending:
         if dry_run:
@@ -148,6 +165,30 @@ def apply_moves(pending: list[Move], journal: Path, dry_run: bool) -> int:
         _append_journal(journal, m.kind, m.src, m.dest, "applied", m.reason)
         applied += 1
         print(f"  moved {m.kind}: {m.src.name} -> {m.dest}")
+
+    # Eval-leaf merges: rename each child of the eval src into the shared
+    # (prediction-occupied) dest leaf. Journal one row PER CHILD so --rollback
+    # reverses exactly, never touching prediction.zarr (which the eval never owns).
+    for m in merges:
+        children = sorted(m.src.iterdir())
+        if dry_run:
+            print(f"  [dry-run] MERGE {m.kind}: {m.src} ({len(children)} entries)\n            -> {m.dest}/")
+            continue
+        m.dest.mkdir(parents=True, exist_ok=True)
+        for child in children:
+            target = m.dest / child.name
+            if target.exists():
+                _append_journal(journal, m.kind, child, target, "error", "merge target exists")
+                raise FileExistsError(f"merge target exists: {target}")
+            try:
+                child.rename(target)
+            except OSError as exc:
+                _append_journal(journal, m.kind, child, target, "error", f"{type(exc).__name__}: {exc}")
+                raise
+            _append_journal(journal, m.kind, child, target, "applied", f"merge {m.reason}")
+        m.src.rmdir()  # src is now empty; fails loudly if not
+        applied += 1
+        print(f"  merged {m.kind}: {m.src.name} ({len(children)} entries) -> {m.dest}/")
     return applied
 
 
@@ -198,10 +239,11 @@ def main(argv: list[str] | None = None) -> int:
     moves = load_moves(args.manifest)
     if args.kind:
         moves = [m for m in moves if m.kind == args.kind]
-    pending, already, errors = preflight(moves)
+    pending, merges, already, errors = preflight(moves)
 
     print(
-        f"manifest moves: {len(moves)}  (pending {len(pending)}, already-applied {len(already)}, errors {len(errors)})"
+        f"manifest moves: {len(moves)}  (pending {len(pending)}, merges {len(merges)}, "
+        f"already-applied {len(already)}, errors {len(errors)})"
     )
     for e in errors:
         print(f"  ERROR {e}")
@@ -211,12 +253,16 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.limit is not None:
         pending = pending[: args.limit]
-        print(f"--limit {args.limit}: applying first {len(pending)} move(s)")
+        merges = merges[: max(0, args.limit - len(pending))]
+        print(f"--limit {args.limit}: applying first {len(pending)} rename(s) + {len(merges)} merge(s)")
 
-    print(f"{'DRY-RUN (no changes)' if dry_run else 'APPLYING'} — {len(pending)} rename(s):")
-    applied = apply_moves(pending, journal, dry_run)
+    print(f"{'DRY-RUN (no changes)' if dry_run else 'APPLYING'} — {len(pending)} rename(s), {len(merges)} merge(s):")
+    applied = apply_moves(pending, merges, journal, dry_run)
     if dry_run:
-        print(f"[dry-run] would move {len(pending)}; {len(already)} already applied. journal -> {journal}")
+        print(
+            f"[dry-run] would move {len(pending)} + merge {len(merges)}; "
+            f"{len(already)} already applied. journal -> {journal}"
+        )
     else:
         print(f"applied {applied}; {len(already)} already applied. journal -> {journal}")
     return 0

--- a/applications/dynacell/tools/run_migration.py
+++ b/applications/dynacell/tools/run_migration.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+"""Apply (or dry-run / roll back) the Phase-7 canonical-path migration.
+
+Consumes the CSV manifest from ``build_migration_manifest.py`` and executes the
+``move`` rows as whole-directory renames (``Path.rename``) so every sibling of a
+moved dir travels with it (``checkpoints/`` + ``resolved/`` + ``wandb/`` for a
+model dir; the whole ``prediction.zarr`` / eval-leaf tree otherwise).
+
+Safety model
+------------
+* **Dry-run by default.** ``--apply`` is required to touch disk.
+* **Journaled.** Every executed rename is appended to a journal CSV
+  (``<manifest>.journal.csv`` by default) as ``ts,kind,src,dest,result,detail``.
+  ``--rollback`` replays the journal in reverse (dest -> src).
+* **Idempotent.** A row whose ``src`` is already gone and whose ``dest`` already
+  exists is treated as previously-applied and skipped, so a re-run after an
+  interruption resumes cleanly.
+* **Pre-flight, always (even dry-run):** every ``move`` src exists; no ``dest``
+  pre-exists (except the idempotent already-applied case); src and dest are on the
+  same filesystem (rename is not cross-device); src/dest namespaces are disjoint
+  (no dest nested under any src or vice-versa). Any violation aborts before a
+  single rename — never a partial, un-journaled mutation.
+
+``dedup_legacy`` rows are never moved (they are hardlinked duplicates of a ``move``
+winner, left in place as legacy). ``skip`` rows are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime
+import errno
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+JOURNAL_HEADER: tuple[str, ...] = ("ts", "kind", "src", "dest", "result", "detail")
+
+
+@dataclass(frozen=True)
+class Move:
+    """One planned rename: whole-dir ``src`` -> canonical ``dest``."""
+
+    kind: str
+    src: Path
+    dest: Path
+    reason: str
+
+
+def _now() -> str:
+    return datetime.datetime.now().isoformat(timespec="seconds")
+
+
+def load_moves(manifest: Path) -> list[Move]:
+    """Read the ``move`` rows from the manifest CSV (skips dedup_legacy / skip)."""
+    moves: list[Move] = []
+    with manifest.open(newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            if row["status"] != "move":
+                continue
+            moves.append(Move(row["kind"], Path(row["src"]), Path(row["dest"]), row["reason"]))
+    return moves
+
+
+def _existing_ancestor(path: Path) -> Path:
+    """Return the nearest existing ancestor of ``path`` (for a same-device check)."""
+    p = path
+    while not p.exists():
+        if p.parent == p:
+            return p
+        p = p.parent
+    return p
+
+
+def preflight(moves: list[Move]) -> tuple[list[Move], list[Move], list[str]]:
+    """Classify moves and collect blocking errors.
+
+    Returns (pending, already_applied, errors). ``pending`` are src-present /
+    dest-absent renames to run; ``already_applied`` are idempotent no-ops.
+    """
+    pending: list[Move] = []
+    already: list[Move] = []
+    errors: list[str] = []
+
+    srcs = {m.src for m in moves}
+    dests = {m.dest for m in moves}
+
+    # Namespace disjointness: no dest may be nested under any src (or vice-versa),
+    # else moving the outer dir first would drag/lose the inner one.
+    for d in dests:
+        for s in srcs:
+            if d == s or s in d.parents or d in s.parents:
+                errors.append(f"NESTED src/dest: src={s} <-> dest={d}")
+
+    seen_dest: dict[Path, Path] = {}
+    for m in moves:
+        if m.dest in seen_dest and seen_dest[m.dest] != m.src:
+            errors.append(f"DEST COLLISION {m.dest} <- {seen_dest[m.dest]} and {m.src}")
+        seen_dest[m.dest] = m.src
+
+        src_exists = m.src.exists()
+        dest_exists = m.dest.exists()
+        if src_exists and not dest_exists:
+            # Same-filesystem (rename is not cross-device)?
+            src_dev = m.src.stat().st_dev
+            dest_dev = _existing_ancestor(m.dest).stat().st_dev
+            if src_dev != dest_dev:
+                errors.append(
+                    f"CROSS-DEVICE (rename unsafe) src={m.src} (dev {src_dev}) dest={m.dest} (dev {dest_dev})"
+                )
+            else:
+                pending.append(m)
+        elif not src_exists and dest_exists:
+            already.append(m)
+        elif src_exists and dest_exists:
+            errors.append(f"DEST ALREADY EXISTS (unexpected) src={m.src} dest={m.dest}")
+        else:  # neither exists
+            errors.append(f"SRC MISSING and DEST ABSENT (lost?) src={m.src} dest={m.dest}")
+    return pending, already, errors
+
+
+def _append_journal(journal: Path, kind: str, src: Path, dest: Path, result: str, detail: str) -> None:
+    new = not journal.exists()
+    with journal.open("a", newline="") as fh:
+        w = csv.writer(fh)
+        if new:
+            w.writerow(JOURNAL_HEADER)
+        w.writerow((_now(), kind, str(src), str(dest), result, detail))
+
+
+def apply_moves(pending: list[Move], journal: Path, dry_run: bool) -> int:
+    """Execute (or preview) the pending renames. Returns count applied."""
+    applied = 0
+    for m in pending:
+        if dry_run:
+            print(f"  [dry-run] {m.kind}: {m.src}\n            -> {m.dest}")
+            continue
+        m.dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            m.src.rename(m.dest)
+        except OSError as exc:
+            _append_journal(journal, m.kind, m.src, m.dest, "error", f"{type(exc).__name__}: {exc}")
+            if exc.errno == errno.EXDEV:
+                raise RuntimeError(f"cross-device rename despite pre-flight; src={m.src} dest={m.dest}") from exc
+            raise
+        _append_journal(journal, m.kind, m.src, m.dest, "applied", m.reason)
+        applied += 1
+        print(f"  moved {m.kind}: {m.src.name} -> {m.dest}")
+    return applied
+
+
+def rollback(journal: Path, dry_run: bool) -> int:
+    """Reverse applied journal rows (dest -> src), newest first."""
+    if not journal.exists():
+        raise FileNotFoundError(f"no journal at {journal}")
+    with journal.open(newline="") as fh:
+        applied_rows = [r for r in csv.DictReader(fh) if r["result"] == "applied"]
+    reversed_count = 0
+    for r in reversed(applied_rows):
+        src, dest = Path(r["src"]), Path(r["dest"])
+        if not dest.exists():
+            print(f"  [skip] dest gone (already reversed?): {dest}")
+            continue
+        if src.exists():
+            raise RuntimeError(f"cannot reverse: src already exists {src}")
+        if dry_run:
+            print(f"  [dry-run] reverse {r['kind']}: {dest}\n            -> {src}")
+            continue
+        src.parent.mkdir(parents=True, exist_ok=True)
+        dest.rename(src)
+        _append_journal(journal, r["kind"], dest, src, "reversed", "rollback")
+        reversed_count += 1
+        print(f"  reversed {r['kind']}: {dest.name} -> {src}")
+    return reversed_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: dry-run / apply / rollback the manifest's ``move`` rows."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", type=Path, required=True, help="manifest CSV from build_migration_manifest.py")
+    ap.add_argument("--journal", type=Path, default=None, help="journal CSV (default: <manifest>.journal.csv)")
+    ap.add_argument("--apply", action="store_true", help="execute renames (default: dry-run preview)")
+    ap.add_argument("--rollback", action="store_true", help="reverse applied journal rows (dest -> src)")
+    ap.add_argument("--kind", choices=("checkpoint", "prediction", "eval"), help="restrict to one artifact family")
+    ap.add_argument("--limit", type=int, default=None, help="apply at most N moves (canary)")
+    args = ap.parse_args(argv)
+
+    journal = args.journal or args.manifest.with_suffix(".journal.csv")
+    dry_run = not args.apply
+
+    if args.rollback:
+        n = rollback(journal, dry_run)
+        print(f"{'[dry-run] would reverse' if dry_run else 'reversed'} {n} move(s); journal {journal}")
+        return 0
+
+    moves = load_moves(args.manifest)
+    if args.kind:
+        moves = [m for m in moves if m.kind == args.kind]
+    pending, already, errors = preflight(moves)
+
+    print(
+        f"manifest moves: {len(moves)}  (pending {len(pending)}, already-applied {len(already)}, errors {len(errors)})"
+    )
+    for e in errors:
+        print(f"  ERROR {e}")
+    if errors:
+        print("ABORT: pre-flight errors — no renames performed.")
+        return 1
+
+    if args.limit is not None:
+        pending = pending[: args.limit]
+        print(f"--limit {args.limit}: applying first {len(pending)} move(s)")
+
+    print(f"{'DRY-RUN (no changes)' if dry_run else 'APPLYING'} — {len(pending)} rename(s):")
+    applied = apply_moves(pending, journal, dry_run)
+    if dry_run:
+        print(f"[dry-run] would move {len(pending)}; {len(already)} already applied. journal -> {journal}")
+    else:
+        print(f"applied {applied}; {len(already)} already applied. journal -> {journal}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/submit_benchmark_job.py
+++ b/applications/dynacell/tools/submit_benchmark_job.py
@@ -224,33 +224,32 @@ def _render_env_block(env: dict | None) -> str:
     return "\n".join(lines)
 
 
-def _resolve_best_ckpt(ckpt_dir: Path) -> Path:
-    """Resolve the best-by-monitor checkpoint in ``ckpt_dir``.
+def resolve_best_ckpt(ckpt_dir: Path) -> Path | None:
+    """Best-by-monitor checkpoint in ``ckpt_dir``, or None if none is resolvable.
 
-    Reads ``best_model_path`` from the ``ModelCheckpoint`` callback state saved
-    inside ``last.ckpt`` (the training recipe uses ``monitor: loss/validate``,
-    ``save_top_k: 5`` with the default ``epoch=N-step=M`` filename, so the loss
-    is not in the filename and the checkpoint state is the authoritative source).
-    Falls back to the highest-epoch ``epoch=*.ckpt`` when the state is missing or
-    points at a pruned file.
+    Reads ``best_model_path`` from the ``ModelCheckpoint`` callback state in the most
+    recently modified ``last*.ckpt``. A resumed run leaves ``last.ckpt`` alongside
+    ``last-vN.ckpt``; the newest is the authoritative training state — keying on
+    ``last.ckpt`` alone mis-resolves a resumed run to its FIRST segment's best (e.g.
+    the messy legacy iPSC dirs, where ``last.ckpt`` is epoch 1 but ``last-v5.ckpt`` is
+    epoch 183). The training recipe uses ``monitor: loss/validate``, ``save_top_k: 5``
+    with the default ``epoch=N-step=M`` filename, so the loss is not in the filename and
+    the checkpoint state is the authoritative source.
+
+    ``best_model_path`` is an ABSOLUTE path into the directory where training ran, so
+    after a dir move/rename (e.g. the canonical-path migration) it is stale; the best
+    file travels with the dir, so its basename under ``ckpt_dir`` is authoritative —
+    prefer that, then the literal stored path, then the highest-epoch ``epoch=*.ckpt``.
     """
-    last = ckpt_dir / "last.ckpt"
-    if last.is_file():
-        import torch  # lazy: only imported for --ckpt best resolution
+    lasts = sorted(ckpt_dir.glob("last*.ckpt"), key=lambda p: p.stat().st_mtime)
+    if lasts:
+        import torch  # lazy: only imported for best-ckpt resolution
 
-        state = torch.load(last, map_location="cpu", weights_only=False)
+        state = torch.load(lasts[-1], map_location="cpu", weights_only=False)
         for key, val in state.get("callbacks", {}).items():
             if "ModelCheckpoint" in str(key) and isinstance(val, dict):
                 best = val.get("best_model_path")
                 if best:
-                    # ``best_model_path`` is stored as an ABSOLUTE path into the
-                    # directory where training ran. After a checkpoint dir is
-                    # moved or renamed (e.g. the canonical-path migration) that
-                    # path is stale, and without re-basing this would silently
-                    # fall through to the highest-epoch (more overfit) ckpt. The
-                    # best ckpt file travels with the dir, so its basename under
-                    # ``ckpt_dir`` is authoritative; prefer that, then the literal
-                    # stored path, then the highest-epoch fallback below.
                     rebased = ckpt_dir / Path(best).name
                     if rebased.is_file():
                         return rebased
@@ -263,11 +262,17 @@ def _resolve_best_ckpt(ckpt_dir: Path) -> Path:
         m = re.match(r"epoch=(\d+)", p.name)
         if m is not None:
             epoch_ckpts.append((int(m.group(1)), p))
-    if epoch_ckpts:
-        return max(epoch_ckpts, key=lambda t: t[0])[1]
-    raise SystemExit(
-        f"--ckpt best: no resolvable checkpoint in {ckpt_dir} (no last.ckpt best_model_path, no epoch=*.ckpt)"
-    )
+    return max(epoch_ckpts, key=lambda t: t[0])[1] if epoch_ckpts else None
+
+
+def _resolve_best_ckpt(ckpt_dir: Path) -> Path:
+    """Best-by-monitor checkpoint in ``ckpt_dir``; raise if none is resolvable."""
+    best = resolve_best_ckpt(ckpt_dir)
+    if best is None:
+        raise SystemExit(
+            f"--ckpt best: no resolvable checkpoint in {ckpt_dir} (no last*.ckpt best_model_path, no epoch=*.ckpt)"
+        )
+    return best
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:


### PR DESCRIPTION
Relocates the dynacell benchmark artifacts (trained checkpoints, prediction zarrs, eval outputs) onto the `dynacell.evaluation.paths` grammar and repoints the config leaves to match — the barrier before the A549 raw-flip re-predict / re-eval.

**Stacked on #479** (`dynacell-paths-module`), which provides `paths.py`. Review/merge #479 first.

> **Status: the storage migration has already been applied** (with data-owner + author sign-off): 663 moves (67 checkpoints / 269 predictions / 327 eval leaves), journaled and reversible. This PR is the tooling plus the git-tracked config codemod output that matches the on-disk result; nothing here re-runs a migration on merge.

### Canonical grammar (relative)
- checkpoint: `<train_set>/<organelle>/<model>/checkpoints`
- prediction: `<organelle>/<model>/<train_set>/<test>[__<cond>]/prediction.zarr`
- eval: `<organelle>/<model>/<train_set>/<test>[__<cond>]/[<component>/][instance_ap/]`

Prediction and eval share one leaf dir (metrics + `embeddings/` + `instance_ap/` alongside `prediction.zarr`). Checkpoints consolidate the former two-model-root split into a single root.

### What's here
- **`build_migration_manifest.py`** — enumerates checkpoints/predictions/evals, computes legacy→canonical moves, dedups hardlinked dual-homes, curates the iPSC experiment set to the paper's final recipes, writes a CSV manifest + report. Exits non-zero on gaps/collisions.
- **`run_migration.py`** — journaled apply (`--apply`), dry-run default, idempotent resume, `--rollback`, pre-flight aborts (nested/cross-device/pre-existing dest) before any mutation.
- **`restandardize_config_paths.py`** — predict/train leaf codemod; rewrite-iff-migrated, so configs and the on-disk migration agree by construction.
- **Applied config codemod** — 318 leaves / 930 fields repointed (228 `ckpt_path`, 252 `output_store`, 318 `run_root`, 66 `dirpath`, 66 `save_dir`); ER/mito A549 checkpoints → raw `a549` train_set, their legacy-deconv predictions → `a549__deconv`; training inputs / external-init / `REPLACE_ME` preserved.
- **Checkpoint filenames now embed val loss** — restored `epoch={epoch}-step={step}-loss={<monitor>:.3f}` + `auto_insert_metric_name: false` on 79 training leaves (68 `loss/validate`, 11 `loss/validate_ema`; no-monitor celldiff/smoke skipped), so `--ckpt best` targets are identifiable from the filename.

### Two bugs found + fixed during the apply
- **Eval-into-shared-prediction-leaf merge** (`c553063e`): the prediction move creates the shared leaf and drops `prediction.zarr` in first, so the eval whole-dir rename hit `FileExistsError` (dry-run never created the dir, so it was invisible; pre-flight only checked dest-under-src). Now the eval's children are merged into the leaf, journaled per-child so `--rollback` is exact and never touches `prediction.zarr`.
- **Codemod map from the frozen manifest** (`552b9963`): `build_ckpt_map` re-scanned the live models tree, but post-migration the legacy dirs are gone → empty map → silent no-op rewrites. Added `load_ckpt_map_from_manifest(--manifest)`.

### Tests
`test_migration_tools.py` (9, incl. merge + rollback) and `test_restandardize_config_paths.py` (8, incl. deconv split, cross-root, manifest map) pass. The filename template's `/`-containing metric parses cleanly through the fit CLI.

### Deferred (not in this PR)
Eval-leaf codemod (`io.pred_path` / `save_dir`) + the grouped/instance_ap generator-walker fix + retiring the zero-importer `save_paths.py` shim — coupled to the post-migration on-disk layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
