### PR TITLE
feat(dynacell/eval): 2D pixel metrics (FRC) + exclude_fov_names for 2D evaluation

### DIFF
--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
@@ -1,0 +1,78 @@
+# FCMAE-2D (VSCyto2D-geometry FullyConvolutionalMAE) fit-time HCS data
+# hparams for the in-focus 2D benchmark track. Split out from
+# model_overlays/fcmae_vscyto2d_fit.yml so the model+trainer half there
+# stays composable by joint-dataset (BatchedConcatDataModule) leaves that
+# author their own data: block.
+#
+# Mirrors data_overlays/fcmae_vscyto3d_fit.yml but flattens all Z
+# augmentations to the cytoland 2D convention (z_window_size=1 reads the
+# offline `_focus.zarr` 5-plane slab stores; each window is one plane):
+#   - z_window_size: 20 -> 1
+#   - RandWeightedCropd spatial_size [20,600,600] -> [1,600,600]
+#   - BatchedRandAffined rotate_range [3.14,0,0] -> [0,0,0],
+#     scale_range Z [0.7,1.3] -> [1,1] (identity = no Z scale; kornia
+#     affine scale is an absolute factor, so 1.0 is the no-op, not 0)
+#   - BatchedCenterSpatialCropd roi_size [15,384,384] -> [1,384,384]
+#   - BatchedRandGaussianSmoothd sigma_z [0.25,0.75] -> [0,0]
+# XY augmentation policy (shear/scale/contrast/intensity/noise/smooth) is
+# kept identical to the 3D overlay.
+data:
+  init_args:
+    z_window_size: 1
+    # 16 (not the 3D overlay's 32) so a single_gpu fit fits the 48 GB pool
+    # (a40|l40s|a6000): bs=32 OOMs at ~47 GB there, bs=8 uses ~half, so 16
+    # keeps ~2x headroom and constraint:null stays valid. Effective batch is
+    # deliberately not forced to match the 3D 4-GPU global batch — the 2D
+    # nets are trained to their own best on cheap hardware (plan Phase-B).
+    batch_size: 16
+    num_workers: 4
+    yx_patch_size: [384, 384]
+    augmentations:
+      # CPU weighted crop on the 5-plane focus slab: spatial_size Z=1
+      # samples a single target-weighted plane per crop.
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          w_key: Structure
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+    gpu_augmentations:
+      - class_path: viscy_transforms.BatchedRandAffined
+        init_args:
+          keys: [source, target]
+          prob: 0.8
+          rotate_range: [0, 0, 0]
+          shear_range: [0.0, 0.05, 0.05]
+          scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+      - class_path: viscy_transforms.BatchedCenterSpatialCropd
+        init_args:
+          keys: [source, target]
+          roi_size: [1, 384, 384]
+      - class_path: viscy_transforms.BatchedRandAdjustContrastd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          gamma: [0.8, 1.2]
+      - class_path: viscy_transforms.BatchedRandScaleIntensityd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          factors: 0.5
+      - class_path: viscy_transforms.BatchedRandGaussianNoised
+        init_args:
+          keys: [source]
+          prob: 0.5
+          mean: 0.0
+          std: 0.3
+      - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          sigma_x: [0.25, 0.75]
+          sigma_y: [0.25, 0.75]
+          sigma_z: [0, 0]
+    val_gpu_augmentations:
+      - class_path: viscy_transforms.BatchedCenterSpatialCropd
+        init_args:
+          keys: [source, target]
+          roi_size: [1, 384, 384]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fnet2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fnet2d_fit.yml
@@ -1,0 +1,58 @@
+# FNet2D fit-time HCS data hparams for the in-focus 2D benchmark track.
+# Split out from model_overlays/fnet2d_fit.yml so the model+trainer half
+# there stays composable by joint-dataset (BatchedConcatDataModule)
+# leaves that author their own data: block.
+#
+# Mirrors data_overlays/fnet3d_paper_fit.yml (including the mean/std
+# Structure normalization and the 8-crops-per-FOV sampling that diverge
+# from the CellDiff/UNetViT conventions) but flattens Z to the in-focus
+# `_focus.zarr` 5-plane slab stores (z_window_size=1, each window one
+# plane):
+#   - z_window_size: 32 -> 1
+#   - RandWeightedCropd spatial_size [32,64,64] -> [1,64,64]
+#   - CenterSpatialCropd (val) roi_size [32,64,64] -> [1,64,64]
+# The YX flips are unchanged (spatial_axes 1=Y, 2=X are valid at Z=1).
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 48
+    num_workers: 8
+    yx_patch_size: [64, 64]
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Structure]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      # CPU: 8 patches per FOV (amortizes zarr decompression).
+      # batch_size=48 -> DataLoader loads 6 FOVs, each yields 8 patches = 48.
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          w_key: Structure
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    gpu_augmentations:
+      - class_path: viscy_transforms.BatchedRandFlipd
+        init_args:
+          keys: [source, target]
+          spatial_axes: [1]
+          prob: 0.5
+      - class_path: viscy_transforms.BatchedRandFlipd
+        init_args:
+          keys: [source, target]
+          spatial_axes: [2]
+          prob: 0.5
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          roi_size: [1, 64, 64]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
@@ -53,11 +53,5 @@ model:
     warmup_steps: 4000
     warmup_multiplier: 1e-3
 trainer:
-  # 32-true (not 16-mixed): the 2D FCMAE diverges to NaN under fp16 mixed
-  # precision (activation/gradient overflow during training — GradScaler does
-  # not catch it), unlike the 3D FCMAE (stable at 16-mixed) and FNet2D
-  # (32-true). Verified 2026-07-23: MixedLoss/ms_ssim_25d is finite in both
-  # fp32 and fp16 autocast on real inputs, so the NaN is training-dynamics, not
-  # the loss forward. 2D nets are light, so full fp32 is affordable.
-  precision: 32-true
+  precision: 16-mixed
   max_epochs: 200

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
@@ -1,0 +1,57 @@
+# Shared FCMAE-2D (FullyConvolutionalMAE, pretraining=False) fit overlay
+# for the in-focus 2D benchmark track. Geometry is the published VSCyto2D
+# recipe (applications/cytoland/examples/configs/recipes/models/fcmae_2d.yml,
+# plan M5): in_stack_depth=1, stem_kernel_size=[1,2,2]. Used by both
+# fcmae_vscyto2d_scratch and fcmae_vscyto2d_pretrained leaves —
+# encoder_only + ckpt_path are set only in the pretrained leaf so init is
+# the only difference between the two (lr drops to 0.0002 there,
+# mirroring cytoland vscyto2d finetuning).
+#
+# Mirrors model_overlays/fcmae_vscyto3d_fit.yml but with 2D geometry and
+# single-GPU topology:
+#   - stem_kernel_size [5,4,4] -> [1,2,2], in_stack_depth 15 -> 1
+#   - topology ddp_4gpu -> single_gpu (2D nets are light; a Phase-B
+#     throughput decision — see plan §2d). No explicit DDPStrategy /
+#     find_unused_parameters / 3h-timeout block is needed at single-device
+#     (SingleDeviceStrategy has no DDP reducer, so FCMAE pretraining=False
+#     unused decoder/head paths are fine). If a later throughput probe
+#     switches this to DDP, re-add the fcmae_vscyto3d_fit.yml
+#     DDPStrategy(find_unused_parameters=true, timeout="3:00:00") block.
+#
+# HCS data hparams (bs=16, z=1, yx=384, flattened augs) live in
+# data_overlays/fcmae_vscyto2d_fit.yml; single-store train leaves compose
+# both, joint (BatchedConcatDataModule) leaves compose only this one and
+# author data: themselves.
+base:
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: fcmae
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      encoder_blocks: [3, 3, 9, 3]
+      encoder_drop_path_rate: 0.1
+      dims: [96, 192, 384, 768]
+      decoder_conv_blocks: 2
+      stem_kernel_size: [1, 2, 2]
+      in_stack_depth: 1
+      pretraining: false
+    loss_function:
+      class_path: viscy_utils.losses.MixedLoss
+      init_args:
+        l1_alpha: 0.5
+        l2_alpha: 0.0
+        ms_dssim_alpha: 0.5
+    lr: 0.0004
+    schedule: WarmupCosine
+    # Phase-B TODO: re-size warmup_steps to ~1 epoch once the focus-store
+    # FOV count is known (single-GPU bs=16 at z_window_size=1 emits ~5
+    # windows/FOV/T, so steps/epoch differ from the 3D 4-GPU baseline).
+    warmup_steps: 4000
+    warmup_multiplier: 1e-3
+trainer:
+  precision: 16-mixed
+  max_epochs: 200

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
@@ -53,5 +53,11 @@ model:
     warmup_steps: 4000
     warmup_multiplier: 1e-3
 trainer:
-  precision: 16-mixed
+  # 32-true (not 16-mixed): the 2D FCMAE diverges to NaN under fp16 mixed
+  # precision (activation/gradient overflow during training — GradScaler does
+  # not catch it), unlike the 3D FCMAE (stable at 16-mixed) and FNet2D
+  # (32-true). Verified 2026-07-23: MixedLoss/ms_ssim_25d is finite in both
+  # fp32 and fp16 autocast on real inputs, so the NaN is training-dynamics, not
+  # the loss forward. 2D nets are light, so full fp32 is affordable.
+  precision: 32-true
   max_epochs: 200

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
@@ -1,0 +1,49 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) predict overlay for
+# the in-focus 2D benchmark track. Mirrors fcmae_vscyto3d_predict.yml but
+# with 2D geometry.
+#
+# CRITICAL: predict rebuilds the model from THIS overlay's model_config
+# and then loads the trained weights (engine.py:308), so the full 2D
+# model_config MUST be re-declared here (in_stack_depth=1,
+# stem_kernel_size=[1,2,2]) and data.z_window_size MUST be 1 — otherwise
+# load_state_dict fails on a stem/conv shape mismatch against the 2D
+# checkpoint. Used by both fcmae_vscyto2d_pretrained and
+# fcmae_vscyto2d_scratch predict leaves — predict loads the full trained
+# checkpoint, so the pretrained-encoder warm-start path (encoder_only +
+# ckpt_path) from the fit leaf does NOT belong here.
+#
+# The 2D model predicts each z-plane of the full-Z 3D test store from its
+# own phase plane (z_window_size=1 -> one window per z; the writer keys
+# each output to its z-index, z_padding=0). 640x960 / 512x512 need no YX
+# pad (num_blocks=4 -> multiple of 16).
+base:
+  - ../../../../../../recipes/trainer/predict.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: fcmae
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      encoder_blocks: [3, 3, 9, 3]
+      encoder_drop_path_rate: 0.1
+      dims: [96, 192, 384, 768]
+      decoder_conv_blocks: 2
+      stem_kernel_size: [1, 2, 2]
+      in_stack_depth: 1
+      pretraining: false
+    loss_function:
+      class_path: viscy_utils.losses.MixedLoss
+      init_args:
+        l1_alpha: 0.5
+        l2_alpha: 0.0
+        ms_dssim_alpha: 0.5
+    predict_method: full_image
+    predict_overlap: [4, 256, 256]
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 1
+    num_workers: 0
+    yx_patch_size: [512, 512]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_fit.yml
@@ -1,0 +1,25 @@
+# FNet2D fit overlay — model + trainer only — for the in-focus 2D
+# benchmark track. HCS data hparams (the mean/std Structure normalization
+# and 8-crops-per-FOV sampling that diverge from the CellDiff/UNetViT
+# conventions) live in data_overlays/fnet2d_fit.yml; single-store train
+# leaves compose both, joint (BatchedConcatDataModule) leaves compose only
+# this one and author data: themselves.
+#
+# Mirrors model_overlays/fnet3d_paper_fit.yml but binds the fnet2d model
+# recipe (in_stack_depth=1, downsample_z=false). FNet3D was already
+# single-GPU, so topology is unchanged. lr/schedule/loss/precision/
+# max_steps all match the 3D FNet paper baseline.
+base:
+  - ../../../../../../recipes/models/fnet2d.yml
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+seed_everything: 0
+model:
+  init_args:
+    loss_function:
+      class_path: torch.nn.MSELoss
+    lr: 0.001
+    schedule: Constant
+trainer:
+  precision: 32-true
+  max_steps: 200000

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_predict.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_predict.yml
@@ -1,0 +1,26 @@
+# FNet2D predict overlay for the in-focus 2D benchmark track. Binds the
+# fnet2d model recipe + predict trainer recipe, then layers predict-time
+# model hparams and data-loader settings. Predict-time normalizations and
+# data_path are leaf-owned (leaf overrides target-inherited values to
+# match each organelle's test_cropped store).
+#
+# CRITICAL: predict rebuilds the model from the fnet2d recipe's
+# model_config (in_stack_depth=1, downsample_z=false) and then loads the
+# trained weights (engine.py:308); data.z_window_size MUST be 1 so the
+# datamodule emits one window per z-plane of the full-Z 3D test store,
+# matching the Z-preserving 2D checkpoint. A z_window_size mismatch would
+# feed a multi-plane window into a Z=1 network and error.
+base:
+  - ../../../../../../recipes/models/fnet2d.yml
+  - ../../../../../../recipes/trainer/predict.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  init_args:
+    predict_method: full_image
+    predict_overlap: [4, 256, 256]
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 1
+    num_workers: 0
+    yx_patch_size: [512, 512]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,66 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on ER/SEC61B, in-focus 2D benchmark track,
+# A549 mantis pooled (mock + DENV + ZIKV). Paper key: VSCyto2D. Companion
+# to fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store SEC61B_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane). target_channel
+# "Structure" matches the FCMAE-2D data overlay's default augmentation
+# keys, so no augmentation override is needed. Mirror of the 3D
+# er/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on ER/SEC61B, in-focus 2D benchmark track,
+# iPSC confocal (aics-hipsc). Paper key: VSCyto2D. Companion to
+# fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# SEC61B_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure). target_channel "Structure" also
+# matches the FCMAE-2D data overlay's default augmentation keys, so no
+# augmentation override is needed. Mirror of the 3D
+# er/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on er (SEC61B) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors er/fcmae_vscyto2d_pretrained/ipsc_confocal on the
+# joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,57 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on ER/SEC61B, in-focus 2D benchmark track, A549 mantis pooled
+# (mock + DENV + ZIKV). Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store SEC61B_all_focus.zarr
+# (extracted from the 3D SEC61B_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# er/fcmae_vscyto3d_scratch/a549_mantis fit leaf. target_channel ==
+# "Structure" matches the FCMAE-2D data overlay's RandWeightedCropd keys,
+# so no augmentation override is needed here.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,65 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on ER/SEC61B, in-focus 2D benchmark track, iPSC confocal. Scratch
+# control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the
+# two leaves are identical except this one does NOT load pretrained encoder
+# weights. Mirror of the 3D er/fcmae_vscyto3d_scratch/ipsc_confocal fit
+# leaf. target_channel == "Structure" matches the FCMAE-2D data overlay's
+# RandWeightedCropd keys, so no augmentation override is needed here.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# SEC61B_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on er (SEC61B), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint train_set
+# and the 3D er/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B all-conditions in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,56 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on ER (SEC61B marker) — A549
+# mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track. Mirror of
+# the 3D er/fnet3d_paper/a549_mantis fit leaf, flattened onto the offline
+# 5-plane in-focus slab store SEC61B_all_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane). target_channel == Structure, so the fnet2d data
+# overlay's default norms/augs (already [1,64,64]) apply unchanged.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: er__a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_A549_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,63 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on ER (SEC61B marker) — AICS
+# iPSC confocal, in-focus 2D track. Mirror of the 3D
+# er/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline 5-plane
+# in-focus slab store SEC61B_focus.zarr (z_window_size=1 emits one in-focus
+# window per plane). target_channel == Structure, so the fnet2d data overlay's
+# default norms/augs (already [1,64,64]) apply unchanged.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads SEC61B_focus.zarr instead, so the resolver
+# is disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: er__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on er (SEC61B) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# er/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,77 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (Membrane marker), in-focus 2D
+# benchmark track, A549 mantis pooled (mock + DENV + ZIKV). Paper key:
+# VSCyto2D. Companion to fcmae_vscyto2d_scratch — the two leaves are
+# identical except this one loads the 2D FCMAE encoder weights and drops
+# lr to 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__a549_mantis__fcmae_vscyto2d_pretrained
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr.
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,86 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (Membrane marker), in-focus 2D
+# benchmark track, iPSC confocal (aics-hipsc). Paper key: VSCyto2D.
+# Companion to fcmae_vscyto2d_scratch — the two leaves are identical
+# except this one loads the 2D FCMAE encoder weights and drops lr to
+# 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Membrane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (MEMB) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors membrane/fcmae_vscyto2d_pretrained/ipsc_confocal
+# on the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,68 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (Membrane marker), in-focus 2D benchmark track, A549 mantis
+# pooled (mock + DENV + ZIKV). Paper key: UNeXt2-2D. Scratch control for
+# the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the two leaves
+# are identical except this one does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_scratch/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__a549_mantis__fcmae_vscyto2d_scratch
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name
+# in keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the nucleus 2D leaf re-keys to Nuclei).
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (Membrane marker), in-focus 2D benchmark track, iPSC
+# confocal. Scratch control for the fcmae_vscyto2d_pretrained (VSCyto2D)
+# counterpart — the two leaves are identical except this one does NOT load
+# pretrained encoder weights. Mirror of the 3D
+# membrane/fcmae_vscyto3d_scratch/ipsc_confocal fit leaf.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Membrane).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name
+# in keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (MEMB), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D membrane/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl/memb all-conditions in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,84 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (Membrane channel)
+# — A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D membrane/fnet3d_paper/a549_mantis fit leaf, flattened onto
+# the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target). Membrane target_channel is Membrane, so we list-replace those
+# three lists here to re-key them, flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: membrane__a549_mantis__fnet2d
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr.
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Membrane]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_A549_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,96 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (Membrane channel)
+# — AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# membrane/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline
+# 5-plane in-focus slab store cell_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads cell_focus.zarr instead, so the resolver is
+# disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Membrane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target), so we list-replace those three lists here to re-key to Membrane,
+# flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: membrane__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Membrane]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for cell.zarr
+  # mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (MEMB) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# membrane/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc in-focus slab store (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab store (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,66 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito/TOMM20, in-focus 2D benchmark track,
+# A549 mantis pooled (mock + DENV + ZIKV). Paper key: VSCyto2D. Companion
+# to fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store TOMM20_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane). target_channel
+# "Structure" matches the FCMAE-2D data overlay's default augmentation
+# keys, so no augmentation override is needed. Mirror of the 3D
+# mito/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito/TOMM20, in-focus 2D benchmark track,
+# iPSC confocal (aics-hipsc). Paper key: VSCyto2D. Companion to
+# fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# TOMM20_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure). target_channel "Structure" also
+# matches the FCMAE-2D data overlay's default augmentation keys, so no
+# augmentation override is needed. Mirror of the 3D
+# mito/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito (TOMM20) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors mito/fcmae_vscyto2d_pretrained/ipsc_confocal on
+# the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,57 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito/TOMM20, in-focus 2D benchmark track, A549 mantis pooled
+# (mock + DENV + ZIKV). Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store TOMM20_all_focus.zarr
+# (extracted from the 3D TOMM20_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# mito/fcmae_vscyto3d_scratch/a549_mantis fit leaf. target_channel ==
+# "Structure" matches the FCMAE-2D data overlay's RandWeightedCropd keys,
+# so no augmentation override is needed here.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,65 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito/TOMM20, in-focus 2D benchmark track, iPSC confocal. Scratch
+# control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the
+# two leaves are identical except this one does NOT load pretrained encoder
+# weights. Mirror of the 3D mito/fcmae_vscyto3d_scratch/ipsc_confocal fit
+# leaf. target_channel == "Structure" matches the FCMAE-2D data overlay's
+# RandWeightedCropd keys, so no augmentation override is needed here.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# TOMM20_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito (TOMM20), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D mito/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 all-conditions in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,56 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mitochondria (TOMM20 marker)
+# — A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D mito/fnet3d_paper/a549_mantis fit leaf, flattened onto the
+# offline 5-plane in-focus slab store TOMM20_all_focus.zarr (z_window_size=1
+# emits one in-focus window per plane). target_channel == Structure, so the
+# fnet2d data overlay's default norms/augs (already [1,64,64]) apply unchanged.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: mito__a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_A549_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,63 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mitochondria (TOMM20 marker)
+# — AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# mito/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline 5-plane
+# in-focus slab store TOMM20_focus.zarr (z_window_size=1 emits one in-focus
+# window per plane). target_channel == Structure, so the fnet2d data overlay's
+# default norms/augs (already [1,64,64]) apply unchanged.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads TOMM20_focus.zarr instead, so the resolver
+# is disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: mito__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mito (TOMM20) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# mito/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,78 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (Nuclei marker), in-focus 2D
+# benchmark track, A549 mantis pooled (mock + DENV + ZIKV). Paper key:
+# VSCyto2D. Companion to fcmae_vscyto2d_scratch — the two leaves are
+# identical except this one loads the 2D FCMAE encoder weights and drops
+# lr to 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_pretrained
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,86 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (Nuclei marker), in-focus 2D
+# benchmark track, iPSC confocal (aics-hipsc). Paper key: VSCyto2D.
+# Companion to fcmae_vscyto2d_scratch — the two leaves are identical
+# except this one loads the 2D FCMAE encoder weights and drops lr to
+# 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Nuclei). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (NUCL) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal
+# on the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,55 @@
+# FCMAE-2D scratch (UNeXt2-2D) predict: nucleus trained on a549_mantis
+# (dual_nucl_memb in-focus slab), predicting against a549-mantis-h2b-mock
+# test. Runs the 2D model over the full-Z 3D test store (z_window_size=1 ->
+# one window per z-plane; writer stacks per-z into a full-Z prediction
+# store). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml.
+#
+# A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+# `nucleus` target_id from targets/nucleus.yml so the resolver finds the
+# h2b target on a549-mantis-h2b-mock.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_mock.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: a549_mantis_h2b_mock
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_scratch__a549_mantis_h2b_mock
+  # Override the iPSC-side `nucleus` target to a549's gene-keyed `h2b`.
+  dataset_ref:
+    target: h2b
+
+model:
+  init_args:
+    # Phase-F TODO: bake the trained best checkpoint after Phase-E
+    # training (campaign policy: predict with --ckpt best).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch/checkpoints/last.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto2d_scratch/a549/a549__mock/prediction.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_PRED_NUCL_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto2d_scratch/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,68 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (Nuclei marker), in-focus 2D benchmark track, A549 mantis
+# pooled (mock + DENV + ZIKV). Paper key: UNeXt2-2D. Scratch control for
+# the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the two leaves
+# are identical except this one does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_scratch
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (Nuclei marker), in-focus 2D benchmark track, iPSC confocal.
+# Scratch control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart
+# — the two leaves are identical except this one does NOT load pretrained
+# encoder weights. Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/ipsc_confocal fit leaf.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Nuclei).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (NUCL), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D nucleus/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl/memb all-conditions in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,85 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (Nuclei channel) —
+# A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D nucleus/fnet3d_paper/a549_mantis fit leaf, flattened onto
+# the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target). Nucleus target_channel is Nuclei, so we list-replace those three
+# lists here to re-key them, flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: nucleus__a549_mantis__fnet2d
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Nuclei]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_A549_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,96 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (Nuclei channel) —
+# AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# nucleus/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline
+# 5-plane in-focus slab store cell_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads cell_focus.zarr instead, so the resolver is
+# disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Nuclei).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target), so we list-replace those three lists here to re-key to Nuclei,
+# flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: nucleus__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Nuclei]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for cell.zarr
+  # mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,126 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (NUCL) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# nucleus/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # batch_size in joint mode is NOT divided by RandWeightedCropd
+  # num_samples (BatchedConcatDataModule.train_dataloader uses batch_size
+  # as-is, unlike HCSDataModule.train_dataloader which divides by
+  # train_patches_per_stack). To match single-set's effective on-GPU batch
+  # of 48 (single-set's batch_size 48 / 8), use 6 here so
+  # 6 indices * 8 num_samples = 48 GPU samples.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc in-focus slab store (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab store (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/recipes/models/fnet2d.yml
+++ b/applications/dynacell/configs/recipes/models/fnet2d.yml
@@ -1,0 +1,23 @@
+# Model recipe: FNet2D — FNet3D recursive encoder-decoder (Ounkomol et al.
+# 2018) run Z-preserving at Z=1 for the in-focus 2D benchmark track.
+#
+# Mirrors recipes/models/fnet3d.yml but:
+#   - in_stack_depth: 1  (single in-focus plane, not the 32-plane stack)
+#   - downsample_z: false  (Z-preserving encoder: stride (1,2,2) +
+#     ConvTranspose3d k=(1,3,3)). Required so the base UNet3DBase skips the
+#     `D % 2**depth` divisor check and can run at Z=1 (see
+#     viscy_models/unet/unet3d.py downsample_z, unet3d_base.py:162-168).
+# architecture stays "FNet3D" — the dynacell registry maps it to the
+# viscy_models.Unet3d subclass (engine.py:45); FNet2D is that same net
+# with the Z axis frozen, not a distinct architecture.
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: FNet3D
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      depth: 4
+      mult_chan: 32
+      in_stack_depth: 1
+      downsample_z: false

--- a/applications/dynacell/src/dynacell/evaluation/focus.py
+++ b/applications/dynacell/src/dynacell/evaluation/focus.py
@@ -36,6 +36,13 @@ from viscy_utils.meta_utils import write_meta_field
 FOCUS_FIELD = "focus_slice"
 MIDBAND_FRACTIONS: tuple[float, float] = (0.125, 0.25)
 
+# Mantis acquisition defaults for the transverse-band focus estimator, shared by the
+# eval-time compute path (``read_focus_compute_config``) and the offline focus-slab
+# extractor tool. Single source of truth so the training slab and the eval slab land
+# on the same in-focus plane (train/eval cannot diverge).
+DEFAULT_NA_DET: float = 1.35
+DEFAULT_LAMBDA_ILL: float = 0.450
+
 # Nucleus-area focus anchor (the default for 2D instance seg). Per-z nuclear foreground
 # fraction is a smooth, unimodal curve — zero at the stack caps, peaked at the nuclear
 # equator — so its argmax cannot be dragged to an out-of-focus cap by the high-frequency
@@ -142,8 +149,8 @@ def read_focus_compute_config(config: DictConfig, *, channel_name: str | None = 
         pixel_size = float(config.pixel_metrics.spacing[-1])
     return FocusComputeConfig(
         channel_name=channel_name or str(OmegaConf.select(config, "focus.channel_name", default="Phase3D")),
-        na_det=float(OmegaConf.select(config, "focus.na_det", default=1.35)),
-        lambda_ill=float(OmegaConf.select(config, "focus.lambda_ill", default=0.450)),
+        na_det=float(OmegaConf.select(config, "focus.na_det", default=DEFAULT_NA_DET)),
+        lambda_ill=float(OmegaConf.select(config, "focus.lambda_ill", default=DEFAULT_LAMBDA_ILL)),
         pixel_size=float(pixel_size),
         device=str(OmegaConf.select(config, "focus.device", default="cpu")),
     )

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -9,7 +9,7 @@ try:
     from cubic.cuda import ascupy, asnumpy
     from cubic.feature import glcm_features
     from cubic.feature.voxel import regionprops_table
-    from cubic.metrics import fsc_resolution, nrmse, pcc, psnr
+    from cubic.metrics import frc_resolution, fsc_resolution, nrmse, pcc, psnr
     from cubic.metrics import ssim as cubic_ssim  # aliased — dynacell keeps a local ssim() wrapper
     from cubic.metrics.bandlimited import spectral_pcc
     from cubic.scipy import ndimage as _cubic_ndimage
@@ -18,6 +18,7 @@ except ImportError:
     ascupy = None  # type: ignore[assignment]
     asnumpy = None  # type: ignore[assignment]
     cubic_ssim = None  # type: ignore[assignment]
+    frc_resolution = None  # type: ignore[assignment]
     fsc_resolution = None  # type: ignore[assignment]
     glcm_features = None  # type: ignore[assignment]
     nrmse = None  # type: ignore[assignment]
@@ -60,26 +61,35 @@ def _min_max_normalize(
 
 @torch.inference_mode()
 def ssim(img1: torch.Tensor, img2: torch.Tensor, eps: float = 1e-8) -> float:
-    """Compute mean structural similarity index (SSIM) for 3D volumetric inputs.
+    """Compute mean structural similarity index (SSIM) for 2D or 3D inputs.
+
+    ``spatial_dims`` is dispatched from the input rank (cubic convention): a 2-D
+    ``(H, W)`` input scores an in-plane SSIM, a 3-D ``(D, H, W)`` input scores a
+    volumetric SSIM. Both are min-max normalized per input before scoring.
 
     Parameters
     ----------
     img1, img2 : torch.Tensor
-        3-D tensors of shape ``(D, H, W)``.
+        2-D ``(H, W)`` or 3-D ``(D, H, W)`` tensors of the same shape.
     eps : float
         Small constant for min-max normalization stability.
     """
     if cubic_ssim is None:
         raise ImportError("cubic is required for SSIM. Install via the `eval` extra: `uv sync --extra eval`.")
-    if img1.ndim != 3:
-        raise ValueError(f"ssim expects 3-D (D, H, W) input, got {img1.ndim}-D tensor of shape {tuple(img1.shape)}")
+    if img1.ndim not in (2, 3):
+        raise ValueError(
+            f"ssim expects 2-D (H, W) or 3-D (D, H, W) input, got {img1.ndim}-D tensor of shape {tuple(img1.shape)}"
+        )
+    spatial_dims = img1.ndim
     img1 = _min_max_normalize(img1, eps=eps)
     img2 = _min_max_normalize(img2, eps=eps)
 
-    img1 = img1.unsqueeze(0).unsqueeze(0)  # (D,H,W) → (1,1,D,H,W) — cubic's 5D contract
+    # cubic's batched dispatch expects [N, C, (D,) H, W] (ndim = spatial_dims + 2):
+    # (H,W) → (1,1,H,W); (D,H,W) → (1,1,D,H,W).
+    img1 = img1.unsqueeze(0).unsqueeze(0)
     img2 = img2.unsqueeze(0).unsqueeze(0)
 
-    return cubic_ssim(img1, img2, spatial_dims=3, data_range=1.0, gaussian_weights=True)
+    return cubic_ssim(img1, img2, spatial_dims=spatial_dims, data_range=1.0, gaussian_weights=True)
 
 
 def evaluate_segmentations(segmented_pred, segmented_gt) -> dict[str, float]:
@@ -169,13 +179,23 @@ def compute_pixel_metrics(prediction, target, spacing, fsc_kwargs=None, spectral
     if spectral_pcc_kwargs is None and fsc_kwargs is None:
         return metrics
 
+    # Match the frequency-domain metrics to the input rank (cubic convention):
+    # the in-focus 2D path passes (H, W) arrays → trailing YX spacing + the
+    # ring-based FRC; the full-3D path keeps the (Z, Y, X) spacing + shell-based
+    # FSC. The 3D path is byte-identical to before (ndim==3 → full spacing, FSC).
+    ndim = int(pred_xp.ndim)
+    freq_spacing = list(spacing)[-ndim:] if hasattr(spacing, "__len__") and len(spacing) > ndim else spacing
+
     if spectral_pcc_kwargs is not None:
-        metrics["Spectral_PCC"] = spectral_pcc(pred_xp, target_xp, spacing=spacing, **spectral_pcc_kwargs)
+        metrics["Spectral_PCC"] = spectral_pcc(pred_xp, target_xp, spacing=freq_spacing, **spectral_pcc_kwargs)
     if fsc_kwargs is not None:
-        # cubic.fsc_resolution mean-centers internally before every FFT,
+        # cubic.{fsc,frc}_resolution mean-center internally before every FFT,
         # so we pass the raw arrays.
-        resolutions = fsc_resolution(target_xp, pred_xp, spacing=spacing, **fsc_kwargs)
-        metrics.update({f"{k.upper()}_FSC_Resolution": float(v) for k, v in resolutions.items()})
+        if ndim == 2:
+            metrics["FRC_Resolution"] = float(frc_resolution(target_xp, pred_xp, spacing=freq_spacing, **fsc_kwargs))
+        else:
+            resolutions = fsc_resolution(target_xp, pred_xp, spacing=freq_spacing, **fsc_kwargs)
+            metrics.update({f"{k.upper()}_FSC_Resolution": float(v) for k, v in resolutions.items()})
 
     return metrics
 

--- a/applications/dynacell/src/dynacell/evaluation/metrics.py
+++ b/applications/dynacell/src/dynacell/evaluation/metrics.py
@@ -183,8 +183,8 @@ def compute_pixel_metrics(prediction, target, spacing, fsc_kwargs=None, spectral
     # the in-focus 2D path passes (H, W) arrays → trailing YX spacing + the
     # ring-based FRC; the full-3D path keeps the (Z, Y, X) spacing + shell-based
     # FSC. The 3D path is byte-identical to before (ndim==3 → full spacing, FSC).
-    ndim = int(pred_xp.ndim)
-    freq_spacing = list(spacing)[-ndim:] if hasattr(spacing, "__len__") and len(spacing) > ndim else spacing
+    ndim = pred_xp.ndim
+    freq_spacing = list(spacing)[-ndim:]
 
     if spectral_pcc_kwargs is not None:
         metrics["Spectral_PCC"] = spectral_pcc(pred_xp, target_xp, spacing=freq_spacing, **spectral_pcc_kwargs)

--- a/applications/dynacell/src/dynacell/evaluation/pipeline.py
+++ b/applications/dynacell/src/dynacell/evaluation/pipeline.py
@@ -1248,6 +1248,24 @@ def evaluate_predictions(config: DictConfig, *, models: EvalModels | None = None
             if nuclei_path is not None:
                 nuclei_plate = aux_stack.enter_context(open_ome_zarr(Path(nuclei_path), mode="r"))
                 nuclei_by_name = dict(nuclei_plate.positions())
+
+            # Optional explicit FOV exclusion (e.g. drop positions whose prediction
+            # zarr is incomplete). Applied uniformly to pred/gt/seg so the counts
+            # stay aligned and the strict-mode validation below still holds. Unlike
+            # ``limit_positions`` this does NOT set ``partial_walk``, so deep-feature
+            # caches auto-invalidate/self-heal normally. Match on the full position
+            # name (``0/0/fov0011``) or its leaf (``fov0011``).
+            exclude = OmegaConf.select(config, "io.exclude_fov_names", default=None) or []
+            if exclude:
+                exclude_set = set(exclude)
+
+                def _keep(name: str) -> bool:
+                    return name not in exclude_set and name.rsplit("/", 1)[-1] not in exclude_set
+
+                pred_positions = [(n, p) for n, p in pred_positions if _keep(n)]
+                gt_positions = [(n, p) for n, p in gt_positions if _keep(n)]
+                seg_positions = [(n, p) for n, p in seg_positions if _keep(n)]
+
             # Position-count alignment.
             #
             # When ``limit_positions`` is unset (production), require strict

--- a/applications/dynacell/tests/test_evaluation_metrics.py
+++ b/applications/dynacell/tests/test_evaluation_metrics.py
@@ -21,7 +21,8 @@ def _import_metrics_with_stubs(monkeypatch):
     cubic_cuda_module.asnumpy = lambda x: x
 
     cubic_metrics_module = types.ModuleType("cubic.metrics")
-    cubic_metrics_module.fsc_resolution = lambda *args, **kwargs: {}
+    cubic_metrics_module.fsc_resolution = lambda *args, **kwargs: {"mean": 2.0}
+    cubic_metrics_module.frc_resolution = lambda *args, **kwargs: 3.0
     cubic_metrics_module.MicroMS3IM = object
 
     def _stub_pcc(a, b, mask=None):
@@ -60,8 +61,20 @@ def _import_metrics_with_stubs(monkeypatch):
     cubic_bandlimited_module.spectral_pcc = lambda *args, **kwargs: 0.0
 
     cubic_feature_module = types.ModuleType("cubic.feature")
+    cubic_feature_module.glcm_features = lambda *args, **kwargs: {}
     cubic_feature_voxel_module = types.ModuleType("cubic.feature.voxel")
     cubic_feature_voxel_module.regionprops_table = lambda *args, **kwargs: {}
+
+    # cubic.scipy / cubic.skimage: the fake ``cubic`` module has no ``__path__``,
+    # so these submodule imports must be stubbed explicitly too.
+    cubic_scipy_module = types.ModuleType("cubic.scipy")
+    cubic_scipy_ndimage_module = types.ModuleType("cubic.scipy.ndimage")
+    cubic_scipy_ndimage_module.find_objects = lambda *args, **kwargs: []
+    cubic_scipy_module.ndimage = cubic_scipy_ndimage_module
+    cubic_skimage_module = types.ModuleType("cubic.skimage")
+    cubic_skimage_filters_module = types.ModuleType("cubic.skimage.filters")
+    cubic_skimage_filters_module.threshold_otsu = lambda *args, **kwargs: 0.0
+    cubic_skimage_module.filters = cubic_skimage_filters_module
 
     monkeypatch.setitem(sys.modules, "cubic", cubic_module)
     monkeypatch.setitem(sys.modules, "cubic.cuda", cubic_cuda_module)
@@ -69,6 +82,10 @@ def _import_metrics_with_stubs(monkeypatch):
     monkeypatch.setitem(sys.modules, "cubic.metrics.bandlimited", cubic_bandlimited_module)
     monkeypatch.setitem(sys.modules, "cubic.feature", cubic_feature_module)
     monkeypatch.setitem(sys.modules, "cubic.feature.voxel", cubic_feature_voxel_module)
+    monkeypatch.setitem(sys.modules, "cubic.scipy", cubic_scipy_module)
+    monkeypatch.setitem(sys.modules, "cubic.scipy.ndimage", cubic_scipy_ndimage_module)
+    monkeypatch.setitem(sys.modules, "cubic.skimage", cubic_skimage_module)
+    monkeypatch.setitem(sys.modules, "cubic.skimage.filters", cubic_skimage_filters_module)
     sys.modules.pop("dynacell.evaluation.metrics", None)
 
     return importlib.import_module("dynacell.evaluation.metrics")
@@ -99,6 +116,110 @@ def test_identical_images_still_score_perfectly(monkeypatch) -> None:
     assert metrics.nrmse(target, target) == pytest.approx(0.0)
     assert metrics.psnr(target, target) == float("inf")
     assert metrics.ssim(target, target) == pytest.approx(1.0)
+
+
+# --- ssim / pixel-metric dimensionality (2D vs 3D) ---
+
+
+def test_ssim_accepts_2d_input_and_dispatches_spatial_dims_2(monkeypatch) -> None:
+    """A 2-D (H, W) input scores in-plane and passes spatial_dims=2 to cubic."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+
+    captured = {}
+
+    def _capture_ssim(img1, img2, spatial_dims=None, data_range=None, gaussian_weights=None, **kwargs):
+        captured["spatial_dims"] = spatial_dims
+        captured["ndim"] = img1.ndim
+        return float(structural_similarity(img1.numpy().squeeze(), img2.numpy().squeeze(), data_range=1.0))
+
+    monkeypatch.setattr(metrics, "cubic_ssim", _capture_ssim)
+
+    target = torch.rand(16, 16)  # 2-D (H, W)
+    assert metrics.ssim(target, target) == pytest.approx(1.0)
+    assert captured["spatial_dims"] == 2
+    assert captured["ndim"] == 4  # (1, 1, H, W)
+
+
+def test_ssim_dispatches_spatial_dims_3_for_3d(monkeypatch) -> None:
+    """A 3-D (D, H, W) input keeps volumetric SSIM (spatial_dims=3)."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+
+    captured = {}
+
+    def _capture_ssim(img1, img2, spatial_dims=None, data_range=None, gaussian_weights=None, **kwargs):
+        captured["spatial_dims"] = spatial_dims
+        captured["ndim"] = img1.ndim
+        return 1.0  # dispatch-only stub — skimage's 3D window doesn't fit a tiny volume
+
+    monkeypatch.setattr(metrics, "cubic_ssim", _capture_ssim)
+
+    target = torch.rand(4, 16, 16)  # 3-D (D, H, W)
+    assert metrics.ssim(target, target) == pytest.approx(1.0)
+    assert captured["spatial_dims"] == 3
+    assert captured["ndim"] == 5  # (1, 1, D, H, W)
+
+
+def test_ssim_rejects_non_2d_3d(monkeypatch) -> None:
+    """Ranks other than 2 or 3 raise a clear error."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+    with pytest.raises(ValueError, match="2-D .* or 3-D"):
+        metrics.ssim(torch.rand(2, 4, 16, 16), torch.rand(2, 4, 16, 16))
+
+
+def test_compute_pixel_metrics_2d_uses_frc_not_fsc(monkeypatch) -> None:
+    """2-D inputs report FRC_Resolution (ring) and never FSC_Resolution (shell)."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+
+    pred = torch.rand(16, 16)
+    target = torch.rand(16, 16)
+    out = metrics.compute_pixel_metrics(
+        pred, target, spacing=(0.15, 0.15, 0.15), fsc_kwargs={"bin_delta": 5}, use_gpu=False
+    )
+    assert "FRC_Resolution" in out
+    assert not any(k.endswith("_FSC_Resolution") for k in out)
+
+
+def test_compute_pixel_metrics_3d_uses_fsc_not_frc(monkeypatch) -> None:
+    """3-D inputs keep FSC_Resolution (shell) and never emit FRC_Resolution."""
+    metrics = _import_metrics_with_stubs(monkeypatch)
+
+    pred = torch.rand(8, 16, 16)  # D=8 so the stub SSIM's 3D window fits
+    target = torch.rand(8, 16, 16)
+    out = metrics.compute_pixel_metrics(
+        pred, target, spacing=(0.5, 0.15, 0.15), fsc_kwargs={"bin_delta": 5}, use_gpu=False
+    )
+    assert any(k.endswith("_FSC_Resolution") for k in out)
+    assert "FRC_Resolution" not in out
+
+
+# --- real-cubic integration (skipped when cubic is not installed) ---
+
+
+def test_ssim_real_cubic_2d_and_3d_identical_scores_one() -> None:
+    """Real cubic SSIM accepts both a 2-D plane and a 3-D volume (no stubs)."""
+    from dynacell.evaluation import metrics as real_metrics
+
+    if real_metrics.cubic_ssim is None:
+        pytest.skip("cubic not installed")
+    img2d = torch.rand(32, 32)
+    img3d = torch.rand(8, 32, 32)
+    assert real_metrics.ssim(img2d, img2d) == pytest.approx(1.0, abs=1e-3)
+    assert real_metrics.ssim(img3d, img3d) == pytest.approx(1.0, abs=1e-3)
+
+
+def test_compute_pixel_metrics_real_cubic_2d_reports_frc() -> None:
+    """Real cubic: a 2-D input yields FRC_Resolution + SSIM and no FSC key."""
+    from dynacell.evaluation import metrics as real_metrics
+
+    if real_metrics.pcc is None:
+        pytest.skip("cubic not installed")
+    pred = torch.rand(64, 64)
+    target = torch.rand(64, 64)
+    out = real_metrics.compute_pixel_metrics(
+        pred, target, spacing=(0.15, 0.15, 0.15), fsc_kwargs={"bin_delta": 5}, use_gpu=False
+    )
+    assert "SSIM" in out and "FRC_Resolution" in out
+    assert not any(k.endswith("_FSC_Resolution") for k in out)
 
 
 # --- pcc tests ---

--- a/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
+++ b/applications/dynacell/tests/test_evaluation_pipeline_parallel_cpu.py
@@ -154,6 +154,38 @@ def test_limit_positions_with_partial_pred_zarr(tmp_path: Path):
     assert len(mask_rows) == 1 * T
 
 
+@pytest.mark.parametrize("exclude", [["A/1/1"], ["1"]])
+def test_exclude_fov_names_drops_positions(tmp_path: Path, exclude: list[str]):
+    """``io.exclude_fov_names`` drops matching FOVs from pred/gt/seg before eval.
+
+    End-to-end via evaluate_predictions on the standard 3-position fixture:
+    excluding one position — matched either by its full name ``A/1/1`` or by
+    its leaf ``1`` — leaves ``N_POSITIONS - 1`` positions' worth of rows, and
+    the strict pred/gt count-alignment still holds because the filter is applied
+    uniformly.
+    """
+    fixture_root = tmp_path / "fixture"
+    fixture_root.mkdir()
+    pred_path, gt_path, gt_cache_dir, pred_cache_dir = build_fixture(fixture_root)
+    save_dir = tmp_path / "out"
+    save_dir.mkdir()
+
+    cfg = build_eval_config(
+        pred_path,
+        gt_path,
+        gt_cache_dir,
+        pred_cache_dir,
+        save_dir,
+        executor="serial",
+        fov_workers=1,
+    )
+    cfg.io.exclude_fov_names = exclude
+    pipeline = live_pipeline_module()
+    pixel_rows, mask_rows, _ = pipeline.evaluate_predictions(cfg)
+    assert len(pixel_rows) == (N_POSITIONS - 1) * T
+    assert len(mask_rows) == (N_POSITIONS - 1) * T
+
+
 def test_limit_positions_rejects_pred_with_unknown_position(tmp_path: Path):
     """``limit_positions`` only relaxes count strict equality when pred ⊂ gt.
 

--- a/applications/dynacell/tools/extract_focus_slab_store.py
+++ b/applications/dynacell/tools/extract_focus_slab_store.py
@@ -92,8 +92,6 @@ class ExtractionSummary:
     ----------
     output_store : str
         Absolute path of the written focus-slab store.
-    n_positions : int
-        Number of positions written.
     n_planes : int
         Slab depth (``2*halfwidth + 1``); uniform across all positions/timepoints.
     pixel_size : float
@@ -102,14 +100,20 @@ class ExtractionSummary:
         Per-position list of estimated focus z-planes (one per timepoint).
     slab_starts : dict of str to list of int
         Per-position list of clamp-shifted slab start z-indices (one per timepoint).
+    n_positions : int
+        Number of positions written (derived: ``len(focus_planes)``).
     """
 
     output_store: str
-    n_positions: int
     n_planes: int
     pixel_size: float
     focus_planes: dict[str, list[int]] = field(default_factory=dict)
     slab_starts: dict[str, list[int]] = field(default_factory=dict)
+
+    @property
+    def n_positions(self) -> int:
+        """Number of positions written (one entry per position in ``focus_planes``)."""
+        return len(self.focus_planes)
 
 
 def clamp_shift_slab(z_focus: int, z_total: int, halfwidth: int) -> slice:
@@ -155,14 +159,6 @@ def clamp_shift_slab(z_focus: int, z_total: int, halfwidth: int) -> slice:
 def _custom_zattrs(node) -> dict:
     """Return a node's custom zattrs (everything except the iohub-managed ``ome`` block)."""
     return {k: v for k, v in dict(node.zattrs).items() if k != _OME_METADATA_KEY}
-
-
-def _split_position_name(name: str) -> tuple[str, str, str]:
-    """Split an HCS position path ``row/col/fov`` into its three components."""
-    parts = name.split("/")
-    if len(parts) != 3:
-        raise ValueError(f"expected an HCS 'row/col/fov' position path, got {name!r} ({len(parts)} parts)")
-    return parts[0], parts[1], parts[2]
 
 
 def extract_focus_slab_store(
@@ -230,7 +226,6 @@ def extract_focus_slab_store(
         shutil.rmtree(output_path)
 
     width = 2 * halfwidth + 1
-    summary = ExtractionSummary(output_store=str(output_path), n_positions=0, n_planes=width, pixel_size=float("nan"))
 
     with open_ome_zarr(input_path, mode="r") as src:
         if phase_channel not in src.channel_names:
@@ -243,7 +238,7 @@ def extract_focus_slab_store(
             raise ValueError(f"{input_path} has no positions to extract")
 
         resolved_pixel_size = float(positions[0][1].scale[-1]) if pixel_size is None else float(pixel_size)
-        summary.pixel_size = resolved_pixel_size
+        summary = ExtractionSummary(output_store=str(output_path), n_planes=width, pixel_size=resolved_pixel_size)
         logger.info(
             "focus estimator: channel=%s pixel_size=%g (%s) na_det=%g lambda_ill=%g midband=%s device=%s",
             phase_channel,
@@ -280,7 +275,7 @@ def extract_focus_slab_store(
             norm_note_emitted = False
             for name, pos in positions:
                 data = pos.data
-                t_count, _, z_total = data.shape[0], data.shape[1], data.shape[2]
+                t_count, _, z_total = data.shape[:3]
                 if z_total < width:
                     raise ValueError(
                         f"{name}: stack has {z_total} planes but a halfwidth={halfwidth} slab needs {width}"
@@ -301,7 +296,7 @@ def extract_focus_slab_store(
                 if np.isnan(slab_stack).any():
                     raise ValueError(f"{name}: NaN encountered in extracted slab")
 
-                row, col, fov = _split_position_name(name)
+                row, col, fov = name.split("/")
                 new_pos = dst.create_position(row, col, fov)
                 chunks = (1, 1, width, slab_stack.shape[-2], slab_stack.shape[-1])
                 new_pos.create_image(
@@ -326,7 +321,6 @@ def extract_focus_slab_store(
 
                 summary.focus_planes[name] = planes
                 summary.slab_starts[name] = [s.start for s in slabs]
-                summary.n_positions += 1
                 logger.info("wrote %s: focus planes=%s slab starts=%s", name, planes, summary.slab_starts[name])
 
     logger.info(

--- a/applications/dynacell/tools/extract_focus_slab_store.py
+++ b/applications/dynacell/tools/extract_focus_slab_store.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python
+r"""Extract an in-focus slab OME-Zarr from a 3D train store (DynaCell 2D VS track).
+
+Phase A of the 2D in-focus VS model track. Given a 3D OME-Zarr train store and a
+phase channel name, this writes a ``<name>_focus.zarr`` where every position holds
+the ``2*halfwidth + 1``-plane in-focus slab of **all** channels (phase + targets),
+centered on the per-FOV/per-timepoint waveorder focus plane. A ``z_window_size=1``
+2D training run then reads the slab as ``2*halfwidth + 1`` in-focus windows per
+FOV/timepoint.
+
+Design
+------
+Focus reuse
+    The focus plane is estimated with
+    :func:`dynacell.evaluation.focus.estimate_focus_plane` (which wraps
+    ``waveorder.focus.focus_from_transverse_band`` on the ``midband`` transverse
+    band) on the ``Phase3D`` ``(Z, Y, X)`` volume per FOV/timepoint. The estimator
+    is *imported*, never reimplemented, so the training slab lands on the same
+    in-focus plane the focus-aware eval derives (train/eval cannot diverge). The
+    ``midband_fractions`` band is the module constant ``MIDBAND_FRACTIONS`` — not a
+    parameter — so it already matches the eval.
+Pixel size
+    ``na_det`` / ``lambda_ill`` / ``pixel_size`` set the transverse-band cutoff.
+    ``pixel_size`` defaults to the **store's lateral spacing** (``position.scale[-1]``)
+    rather than a hardcoded value, because iPSC stores carry a different (sometimes
+    placeholder) spacing than the A549 mantis ``0.1494`` — pass ``--pixel-size`` to
+    override when a store's recorded scale is not the physical spacing.
+Clamp-shift window
+    Unlike the eval's :func:`~dynacell.evaluation.focus.focus_slab_from_plane`
+    (which *clips* the slab at the stack caps, yielding fewer planes near an edge),
+    this tool **clamp-shifts** the whole window inward into ``[hw, Z-1-hw]`` so every
+    FOV/timepoint yields a uniform ``2*hw+1`` depth. That keeps the derived zarr
+    rectangular and the ``SlidingWindowDataset`` window count uniform per FOV.
+Channels & zattrs
+    Every channel is copied at the per-timepoint slab z-range. The ``omero``
+    rendering metadata and all custom position/plate zattrs (``normalization``,
+    provenance, condition, ...) are preserved verbatim. The source ``normalization``
+    stats are **full-stack** (per-FOV over all Z); they are copied as-is (not
+    recomputed over the thin slab) and a log line notes this — per-FOV
+    ``NormalizeSampled`` stats are close enough on the in-focus band that re-use is
+    the intended behavior.
+
+Layout is zarr v3 / OME-Zarr v0.5 end to end via :func:`iohub.open_ome_zarr`.
+
+Usage::
+
+    python applications/dynacell/tools/extract_focus_slab_store.py \\
+        --input  /hpc/.../a549/mantis/train/dual_nucl_memb_all.zarr \\
+        --output /hpc/.../a549/mantis/train/dual_nucl_memb_all_focus.zarr \\
+        --phase-channel Phase3D --halfwidth 2
+
+Importing this module pulls in ``dynacell.evaluation.focus`` (cubic + waveorder at
+import), so run it in the dynacell-eval env, not the bare ``.venv``. The focus
+argmax itself runs on CPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+from iohub.ngff import TransformationMeta, open_ome_zarr
+
+from dynacell.evaluation.focus import MIDBAND_FRACTIONS, estimate_focus_plane
+
+logger = logging.getLogger(__name__)
+
+# Estimator defaults mirroring ``dynacell.evaluation.focus.read_focus_compute_config``
+# (mantis acquisition), so the training slab and the eval slab share a focus plane.
+DEFAULT_NA_DET: float = 1.35
+DEFAULT_LAMBDA_ILL: float = 0.450
+DEFAULT_HALFWIDTH: int = 2
+
+# zattrs key iohub manages itself (multiscales / axes / omero). Copied metadata
+# must never clobber it, so it is excluded from the verbatim zattr copy.
+_OME_METADATA_KEY: str = "ome"
+
+
+@dataclass
+class ExtractionSummary:
+    """Result of an :func:`extract_focus_slab_store` run.
+
+    Attributes
+    ----------
+    output_store : str
+        Absolute path of the written focus-slab store.
+    n_positions : int
+        Number of positions written.
+    n_planes : int
+        Slab depth (``2*halfwidth + 1``); uniform across all positions/timepoints.
+    pixel_size : float
+        Lateral spacing used for focus estimation.
+    focus_planes : dict of str to list of int
+        Per-position list of estimated focus z-planes (one per timepoint).
+    slab_starts : dict of str to list of int
+        Per-position list of clamp-shifted slab start z-indices (one per timepoint).
+    """
+
+    output_store: str
+    n_positions: int
+    n_planes: int
+    pixel_size: float
+    focus_planes: dict[str, list[int]] = field(default_factory=dict)
+    slab_starts: dict[str, list[int]] = field(default_factory=dict)
+
+
+def clamp_shift_slab(z_focus: int, z_total: int, halfwidth: int) -> slice:
+    """Return a ``slice`` of exactly ``2*halfwidth + 1`` planes centered on ``z_focus``.
+
+    Unlike :func:`dynacell.evaluation.focus.focus_slab_from_plane` (which clips at the
+    stack caps and can yield fewer planes near an edge), the whole window is
+    **shifted inward** into ``[0, z_total - width]`` so the returned slab always spans
+    ``2*halfwidth + 1`` planes. This keeps the derived zarr rectangular.
+
+    Parameters
+    ----------
+    z_focus : int
+        Estimated in-focus z-plane.
+    z_total : int
+        Number of z-planes in the source volume.
+    halfwidth : int
+        Planes on each side of the center; the slab spans ``2*halfwidth + 1``.
+
+    Returns
+    -------
+    slice
+        A z-slice of length ``2*halfwidth + 1``.
+
+    Raises
+    ------
+    ValueError
+        If ``halfwidth`` is negative, or the stack is too thin for a full slab
+        (``z_total < 2*halfwidth + 1``).
+    """
+    if halfwidth < 0:
+        raise ValueError(f"halfwidth must be >= 0, got {halfwidth}")
+    width = 2 * halfwidth + 1
+    if z_total < width:
+        raise ValueError(
+            f"stack has {z_total} planes but a halfwidth={halfwidth} slab needs {width}; "
+            "cannot clamp-shift a full slab out of a shorter stack"
+        )
+    lo = min(max(z_focus - halfwidth, 0), z_total - width)
+    return slice(lo, lo + width)
+
+
+def _custom_zattrs(node) -> dict:
+    """Return a node's custom zattrs (everything except the iohub-managed ``ome`` block)."""
+    return {k: v for k, v in dict(node.zattrs).items() if k != _OME_METADATA_KEY}
+
+
+def _split_position_name(name: str) -> tuple[str, str, str]:
+    """Split an HCS position path ``row/col/fov`` into its three components."""
+    parts = name.split("/")
+    if len(parts) != 3:
+        raise ValueError(f"expected an HCS 'row/col/fov' position path, got {name!r} ({len(parts)} parts)")
+    return parts[0], parts[1], parts[2]
+
+
+def extract_focus_slab_store(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    phase_channel: str = "Phase3D",
+    halfwidth: int = DEFAULT_HALFWIDTH,
+    limit_positions: int | None = None,
+    overwrite: bool = False,
+    pixel_size: float | None = None,
+    na_det: float = DEFAULT_NA_DET,
+    lambda_ill: float = DEFAULT_LAMBDA_ILL,
+    device: str = "cpu",
+) -> ExtractionSummary:
+    """Write a ``<name>_focus.zarr`` holding the in-focus slab of every channel.
+
+    For each position and timepoint, the focus plane is estimated on the
+    ``phase_channel`` volume with :func:`estimate_focus_plane`, then a
+    :func:`clamp_shift_slab` window of ``2*halfwidth + 1`` planes is cut from **all**
+    channels. ``omero`` and all custom zattrs are preserved.
+
+    Parameters
+    ----------
+    input_path : str or Path
+        Source 3D OME-Zarr HCS store.
+    output_path : str or Path
+        Destination focus-slab store.
+    phase_channel : str, optional
+        Channel used to estimate the focus plane (default ``"Phase3D"``).
+    halfwidth : int, optional
+        Half the slab depth; the slab spans ``2*halfwidth + 1`` planes (default 2).
+    limit_positions : int or None, optional
+        If set, only the first ``limit_positions`` positions are extracted (smoke runs).
+    overwrite : bool, optional
+        Replace an existing ``output_path`` (default False → raise if it exists).
+    pixel_size : float or None, optional
+        Lateral spacing for the focus estimator. ``None`` (default) reads the store's
+        ``position.scale[-1]``.
+    na_det, lambda_ill : float, optional
+        Detection NA and illumination wavelength for the transverse-band estimator.
+    device : str, optional
+        Torch device for the focus argmax (default ``"cpu"``).
+
+    Returns
+    -------
+    ExtractionSummary
+        Written store path, counts, and per-position focus planes / slab starts.
+
+    Raises
+    ------
+    FileExistsError
+        If ``output_path`` exists and ``overwrite`` is False.
+    ValueError
+        If ``phase_channel`` is absent, ``limit_positions < 1``, or a stack is too
+        thin for a full slab.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    if limit_positions is not None and limit_positions < 1:
+        raise ValueError(f"limit_positions must be >= 1, got {limit_positions}")
+    if output_path.exists():
+        if not overwrite:
+            raise FileExistsError(f"{output_path} already exists; pass overwrite=True to replace it")
+        shutil.rmtree(output_path)
+
+    width = 2 * halfwidth + 1
+    summary = ExtractionSummary(output_store=str(output_path), n_positions=0, n_planes=width, pixel_size=float("nan"))
+
+    with open_ome_zarr(input_path, mode="r") as src:
+        if phase_channel not in src.channel_names:
+            raise ValueError(f"phase channel {phase_channel!r} not in store channels {list(src.channel_names)}")
+        phase_idx = src.channel_names.index(phase_channel)
+        positions = list(src.positions())
+        if limit_positions is not None:
+            positions = positions[:limit_positions]
+        if not positions:
+            raise ValueError(f"{input_path} has no positions to extract")
+
+        resolved_pixel_size = float(positions[0][1].scale[-1]) if pixel_size is None else float(pixel_size)
+        summary.pixel_size = resolved_pixel_size
+        logger.info(
+            "focus estimator: channel=%s pixel_size=%g (%s) na_det=%g lambda_ill=%g midband=%s device=%s",
+            phase_channel,
+            resolved_pixel_size,
+            "store scale[-1]" if pixel_size is None else "override",
+            na_det,
+            lambda_ill,
+            MIDBAND_FRACTIONS,
+            device,
+        )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open_ome_zarr(
+            output_path, layout="hcs", mode="w-", channel_names=list(src.channel_names), version="0.5"
+        ) as dst:
+            plate_custom = _custom_zattrs(src)
+            if plate_custom:
+                dst.zattrs.update(plate_custom)
+            dst.zattrs.update(
+                {
+                    "focus_slab_extraction": {
+                        "source_store": str(input_path),
+                        "phase_channel": phase_channel,
+                        "halfwidth": halfwidth,
+                        "n_planes": width,
+                        "pixel_size": resolved_pixel_size,
+                        "na_det": na_det,
+                        "lambda_ill": lambda_ill,
+                        "midband_fractions": list(MIDBAND_FRACTIONS),
+                    }
+                }
+            )
+
+            norm_note_emitted = False
+            for name, pos in positions:
+                data = pos.data
+                t_count, _, z_total = data.shape[0], data.shape[1], data.shape[2]
+                if z_total < width:
+                    raise ValueError(
+                        f"{name}: stack has {z_total} planes but a halfwidth={halfwidth} slab needs {width}"
+                    )
+                phase_tzyx = np.asarray(data[:, phase_idx])
+                planes = [
+                    estimate_focus_plane(
+                        phase_tzyx[t],
+                        na_det=na_det,
+                        lambda_ill=lambda_ill,
+                        pixel_size=resolved_pixel_size,
+                        device=device,
+                    )
+                    for t in range(t_count)
+                ]
+                slabs = [clamp_shift_slab(p, z_total, halfwidth) for p in planes]
+                slab_stack = np.stack([np.asarray(data[t, :, slabs[t]]) for t in range(t_count)])
+                if np.isnan(slab_stack).any():
+                    raise ValueError(f"{name}: NaN encountered in extracted slab")
+
+                row, col, fov = _split_position_name(name)
+                new_pos = dst.create_position(row, col, fov)
+                chunks = (1, 1, width, slab_stack.shape[-2], slab_stack.shape[-1])
+                new_pos.create_image(
+                    "0",
+                    slab_stack,
+                    chunks=chunks,
+                    transform=[TransformationMeta(type="scale", scale=list(pos.scale))],
+                )
+                new_pos.metadata.omero = pos.metadata.omero
+                new_pos.dump_meta()
+
+                pos_custom = _custom_zattrs(pos)
+                if "normalization" in pos_custom and not norm_note_emitted:
+                    logger.warning(
+                        "copying full-stack `normalization` zattrs verbatim onto the %d-plane focus slab "
+                        "(per-FOV stats NOT recomputed over the slab); re-use is intended per plan R3",
+                        width,
+                    )
+                    norm_note_emitted = True
+                if pos_custom:
+                    new_pos.zattrs.update(pos_custom)
+
+                summary.focus_planes[name] = planes
+                summary.slab_starts[name] = [s.start for s in slabs]
+                summary.n_positions += 1
+                logger.info("wrote %s: focus planes=%s slab starts=%s", name, planes, summary.slab_starts[name])
+
+    logger.info(
+        "done: %d positions (%d planes each) -> %s", summary.n_positions, summary.n_planes, summary.output_store
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: extract an in-focus slab store from a 3D train store."""
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", required=True, type=Path, help="source 3D OME-Zarr HCS store (absolute path)")
+    ap.add_argument("--output", required=True, type=Path, help="destination <name>_focus.zarr (absolute path)")
+    ap.add_argument("--phase-channel", default="Phase3D", help="channel for focus estimation (default: Phase3D)")
+    ap.add_argument("--halfwidth", type=int, default=DEFAULT_HALFWIDTH, help="slab half-depth; slab = 2*hw+1 (def: 2)")
+    ap.add_argument("--limit-positions", type=int, default=None, help="only extract the first N positions (smoke)")
+    ap.add_argument(
+        "--pixel-size",
+        type=float,
+        default=None,
+        help="lateral spacing for the focus estimator (default: read from store scale[-1])",
+    )
+    ap.add_argument("--na-det", type=float, default=DEFAULT_NA_DET, help=f"detection NA (default: {DEFAULT_NA_DET})")
+    ap.add_argument(
+        "--lambda-ill",
+        type=float,
+        default=DEFAULT_LAMBDA_ILL,
+        help=f"illumination wavelength (def: {DEFAULT_LAMBDA_ILL})",
+    )
+    ap.add_argument("--device", default="cpu", help="torch device for the focus argmax (default: cpu)")
+    ap.add_argument("--overwrite", action="store_true", help="replace an existing output store")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    extract_focus_slab_store(
+        args.input,
+        args.output,
+        phase_channel=args.phase_channel,
+        halfwidth=args.halfwidth,
+        limit_positions=args.limit_positions,
+        overwrite=args.overwrite,
+        pixel_size=args.pixel_size,
+        na_det=args.na_det,
+        lambda_ill=args.lambda_ill,
+        device=args.device,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/extract_focus_slab_store.py
+++ b/applications/dynacell/tools/extract_focus_slab_store.py
@@ -66,14 +66,17 @@ from pathlib import Path
 import numpy as np
 from iohub.ngff import TransformationMeta, open_ome_zarr
 
-from dynacell.evaluation.focus import MIDBAND_FRACTIONS, estimate_focus_plane
+from dynacell.evaluation.focus import (
+    DEFAULT_LAMBDA_ILL,
+    DEFAULT_NA_DET,
+    MIDBAND_FRACTIONS,
+    estimate_focus_plane,
+)
 
 logger = logging.getLogger(__name__)
 
-# Estimator defaults mirroring ``dynacell.evaluation.focus.read_focus_compute_config``
-# (mantis acquisition), so the training slab and the eval slab share a focus plane.
-DEFAULT_NA_DET: float = 1.35
-DEFAULT_LAMBDA_ILL: float = 0.450
+# ``DEFAULT_NA_DET`` / ``DEFAULT_LAMBDA_ILL`` are imported from ``focus`` so the training
+# slab shares the eval estimator's acquisition constants (single source of truth).
 DEFAULT_HALFWIDTH: int = 2
 
 # zattrs key iohub manages itself (multiscales / axes / omero). Copied metadata

--- a/applications/dynacell/tools/extract_focus_slab_store_test.py
+++ b/applications/dynacell/tools/extract_focus_slab_store_test.py
@@ -1,0 +1,256 @@
+r"""Integration tests for ``extract_focus_slab_store.py``.
+
+Each test builds a tiny synthetic 3D OME-Zarr in ``tmp_path`` whose ``Phase3D``
+channel has a *known* in-focus plane (a broadband texture that is progressively
+Gaussian-blurred away from a chosen z), so the real
+:func:`dynacell.evaluation.focus.estimate_focus_plane` returns that plane. The
+extractor is then run for real (no mocks) and the written store is reopened and
+asserted against.
+
+Run (worktree, cpdino-eval env, PYTHONPATH shadowing)::
+
+    PYTHONPATH="$WT/packages/viscy-models/src:$WT/packages/viscy-utils/src:\
+$WT/packages/viscy-transforms/src:$WT/packages/viscy-data/src:$WT/applications/dynacell/src" \\
+        "$V/bin/python" -m pytest applications/dynacell/tools/extract_focus_slab_store_test.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from iohub.ngff import TransformationMeta, open_ome_zarr
+from scipy.ndimage import gaussian_filter
+
+# The tools/ directory is not a Python package; add it to sys.path so the module
+# is importable by short name (mirrors generate_grouped_eval_configs_test.py).
+_TOOLS_DIR = Path(__file__).resolve().parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from extract_focus_slab_store import (  # noqa: E402
+    clamp_shift_slab,
+    extract_focus_slab_store,
+    main,
+)
+
+_CHANNELS = ["Phase3D", "Structure"]
+_PIXEL_SIZE = 0.1494
+_Z_SCALE = 0.174
+
+
+def _focus_stack(z_total: int, y: int, x: int, z_focus: int, seed: int) -> np.ndarray:
+    """Return a ``(Z, Y, X)`` volume sharpest (max midband power) at ``z_focus``.
+
+    A single broadband texture is progressively Gaussian-blurred with sigma growing
+    with ``|z - z_focus|``, so the sharpest plane (most transverse-band power) is
+    ``z_focus`` — exactly what the waveorder focus estimator picks.
+    """
+    rng = np.random.default_rng(seed)
+    base = rng.standard_normal((y, x)).astype(np.float32)
+    vol = np.empty((z_total, y, x), dtype=np.float32)
+    for z in range(z_total):
+        sigma = 0.9 * abs(z - z_focus)
+        vol[z] = base if sigma == 0 else gaussian_filter(base, sigma=sigma)
+    return vol
+
+
+def _make_synthetic_store(
+    path: Path,
+    *,
+    z_focus_per_pos: dict[str, int],
+    t: int = 2,
+    z_total: int = 12,
+    y: int = 64,
+    x: int = 64,
+    with_normalization: bool = True,
+) -> None:
+    """Write a tiny 3D HCS OME-Zarr with a known per-position Phase3D focus plane.
+
+    ``z_focus_per_pos`` maps an HCS ``row/col/fov`` position name to its injected
+    focus z (same across timepoints). The ``Structure`` channel carries a distinct,
+    z-varying pattern so channel copying is verifiable.
+    """
+    with open_ome_zarr(path, layout="hcs", mode="w-", channel_names=_CHANNELS) as plate:
+        if with_normalization:
+            plate.zattrs.update({"normalization": {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}})
+        for seed, (name, z_focus) in enumerate(z_focus_per_pos.items()):
+            row, col, fov = name.split("/")
+            phase = np.stack([_focus_stack(z_total, y, x, z_focus, seed=seed + 100 * s) for s in range(t)])
+            # Structure: a per-z ramp so each plane is uniquely identifiable after the copy.
+            structure = np.broadcast_to(
+                np.arange(z_total, dtype=np.float32)[None, :, None, None], (t, z_total, y, x)
+            ).copy()
+            data = np.stack([phase, structure], axis=1)  # (T, C=2, Z, Y, X)
+            pos = plate.create_position(row, col, fov)
+            pos.create_image(
+                "0",
+                data,
+                chunks=(1, 1, z_total, y, x),
+                transform=[TransformationMeta(type="scale", scale=[1.0, 1.0, _Z_SCALE, _PIXEL_SIZE, _PIXEL_SIZE])],
+            )
+            if with_normalization:
+                pos.zattrs.update(
+                    {
+                        "normalization": {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}},
+                        "condition": "mock",
+                    }
+                )
+
+
+def test_clamp_shift_slab_centered_and_edges() -> None:
+    """clamp_shift_slab yields a full 2*hw+1 window, shifted inward at the caps."""
+    # Centered: window straddles z_focus.
+    assert clamp_shift_slab(6, 12, 2) == slice(4, 9)
+    # Low edge: shift the whole window to start at 0 (not a clipped, shorter slab).
+    assert clamp_shift_slab(0, 12, 2) == slice(0, 5)
+    assert clamp_shift_slab(1, 12, 2) == slice(0, 5)
+    # High edge: shift so the window ends at z_total.
+    assert clamp_shift_slab(11, 12, 2) == slice(7, 12)
+    # halfwidth=0 -> single plane at the focus.
+    assert clamp_shift_slab(5, 12, 0) == slice(5, 6)
+    # Every case spans exactly 2*hw+1 planes.
+    for zf in range(12):
+        sl = clamp_shift_slab(zf, 12, 2)
+        assert sl.stop - sl.start == 5
+
+
+def test_clamp_shift_slab_too_thin_raises() -> None:
+    """A stack shorter than the slab width cannot yield a full slab."""
+    with pytest.raises(ValueError):
+        clamp_shift_slab(1, 3, 2)  # needs 5 planes, only 3
+    with pytest.raises(ValueError):
+        clamp_shift_slab(1, 10, -1)  # negative halfwidth
+
+
+def test_output_shape_channels_and_centering(tmp_path: Path) -> None:
+    """Output is (T, C, 2*hw+1, Y, X), channels preserved, slab centered on the focus plane."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=2, z_total=12, y=64, x=64)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    assert summary.n_positions == 1
+    assert summary.n_planes == 5
+    assert summary.pixel_size == pytest.approx(_PIXEL_SIZE)
+    assert summary.focus_planes["0/0/fov0000"] == [6, 6]
+    assert summary.slab_starts["0/0/fov0000"] == [4, 4]
+
+    with open_ome_zarr(src, mode="r") as src_plate, open_ome_zarr(out, mode="r") as out_plate:
+        assert out_plate.channel_names == _CHANNELS
+        _, src_pos = next(src_plate.positions())
+        _, out_pos = next(out_plate.positions())
+        assert out_pos.data.shape == (2, 2, 5, 64, 64)
+        assert not np.isnan(np.asarray(out_pos.data)).any()
+        # Center plane (index 2 of 5, hw=2) is the source focus plane z=6, all channels.
+        np.testing.assert_array_equal(np.asarray(out_pos.data[:, :, 2]), np.asarray(src_pos.data[:, :, 6]))
+        # Structure ramp confirms the copied z-range is [4, 9).
+        np.testing.assert_array_equal(np.asarray(out_pos.data[0, 1, :, 0, 0]), np.arange(4, 9, dtype=np.float32))
+
+
+def test_clamp_shift_edge_position_still_full_depth(tmp_path: Path) -> None:
+    """A focus plane at the stack edge still yields a full 2*hw+1 slab (window shifted)."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    # Low edge (focus at z=0) and high edge (focus at z=11) in one store.
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 0, "0/0/fov0001": 11}, t=2, z_total=12)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    assert summary.focus_planes["0/0/fov0000"] == [0, 0]
+    assert summary.slab_starts["0/0/fov0000"] == [0, 0]  # shifted inward, not -2
+    assert summary.focus_planes["0/0/fov0001"] == [11, 11]
+    assert summary.slab_starts["0/0/fov0001"] == [7, 7]  # shifted inward, ends at z_total
+
+    with open_ome_zarr(out, mode="r") as out_plate:
+        for _, pos in out_plate.positions():
+            assert pos.data.shape[2] == 5  # uniform full depth despite edge focus
+            assert not np.isnan(np.asarray(pos.data)).any()
+
+
+def test_limit_positions(tmp_path: Path) -> None:
+    """--limit-positions caps the number of extracted positions."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6, "0/0/fov0001": 5, "0/0/fov0002": 4}, t=1, z_total=12)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2, limit_positions=1)
+
+    assert summary.n_positions == 1
+    with open_ome_zarr(out, mode="r") as out_plate:
+        assert len([n for n, _ in out_plate.positions()]) == 1
+
+
+def test_zattrs_and_omero_preserved(tmp_path: Path) -> None:
+    """Custom zattrs (normalization) and omero survive; provenance zattr is written."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12, with_normalization=True)
+
+    extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    with open_ome_zarr(out, mode="r") as out_plate:
+        assert dict(out_plate.zattrs).get("normalization") == {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}
+        prov = dict(out_plate.zattrs)["focus_slab_extraction"]
+        assert prov["phase_channel"] == "Phase3D"
+        assert prov["halfwidth"] == 2
+        assert prov["n_planes"] == 5
+        _, out_pos = next(out_plate.positions())
+        pos_attrs = dict(out_pos.zattrs)
+        assert pos_attrs["condition"] == "mock"
+        assert pos_attrs["normalization"] == {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}
+        assert [c.label for c in out_pos.metadata.omero.channels] == _CHANNELS
+
+
+def test_overwrite_guard(tmp_path: Path) -> None:
+    """A second run without overwrite raises; with overwrite it succeeds."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12)
+
+    extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+    with pytest.raises(FileExistsError):
+        extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+    # Overwrite succeeds and rewrites the store.
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2, overwrite=True)
+    assert summary.n_positions == 1
+
+
+def test_missing_phase_channel_raises(tmp_path: Path) -> None:
+    """A phase channel absent from the store is a hard error (not a silent skip)."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12)
+    with pytest.raises(ValueError, match="phase channel"):
+        extract_focus_slab_store(src, out, phase_channel="NotAChannel", halfwidth=2)
+
+
+def test_cli_main_smoke(tmp_path: Path) -> None:
+    """The argparse CLI runs end to end and writes a loadable focus store."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6, "0/0/fov0001": 5}, t=1, z_total=12)
+
+    rc = main(
+        [
+            "--input",
+            str(src),
+            "--output",
+            str(out),
+            "--phase-channel",
+            "Phase3D",
+            "--halfwidth",
+            "2",
+            "--limit-positions",
+            "1",
+        ]
+    )
+    assert rc == 0
+    with open_ome_zarr(out, mode="r") as out_plate:
+        names = [n for n, _ in out_plate.positions()]
+        assert names == ["0/0/fov0000"]
+        _, pos = next(out_plate.positions())
+        assert pos.data.shape[2] == 5

--- a/packages/viscy-models/src/viscy_models/unet/unet3d.py
+++ b/packages/viscy-models/src/viscy_models/unet/unet3d.py
@@ -39,9 +39,10 @@ class Unet3d(UNet3DBase):
 
     FNet-configured preset of the unified 3D U-Net base with BatchNorm,
     ReLU activations, non-residual double-conv blocks, and a convolutional
-    bottleneck.  Downsamples all three spatial dimensions.
+    bottleneck.  Downsamples Y and X, and (when ``downsample_z=True``) Z.
 
-    All spatial dimensions (Z, Y, X) must be divisible by ``2**depth``.
+    Each downsampled spatial dimension must be divisible by ``2**depth``: Y and
+    X always, and Z only when ``downsample_z=True``.
 
     Parameters
     ----------
@@ -56,8 +57,14 @@ class Unet3d(UNet3DBase):
     in_stack_depth : int or None
         Z-window size. Stored for engine compatibility
         (``example_input_array``, ``DivisiblePad``, sliding window prediction).
-        The model itself handles arbitrary Z as long as it is divisible
-        by ``2**depth``.
+        The model itself handles arbitrary Z; when ``downsample_z=True`` the Z
+        size must be divisible by ``2**depth`` (no constraint when ``False``).
+    downsample_z : bool
+        Whether to downsample the Z axis in the encoder (``True`` preserves the
+        FNet3D behavior). Set ``False`` for a Z-preserving 2D-style network
+        (stride ``(1, 2, 2)``, ``ConvTranspose3d`` kernel ``(1, 3, 3)``), which
+        is required to run at ``Z=1`` without tripping the base
+        ``D % 2**depth`` divisibility check.
     """
 
     def __init__(
@@ -67,6 +74,7 @@ class Unet3d(UNet3DBase):
         depth: int = 4,
         mult_chan: int = 32,
         in_stack_depth: int | None = None,
+        downsample_z: bool = True,
     ) -> None:
         dims = [mult_chan * (2**i) for i in range(depth + 1)]
         bottleneck = ConvBottleneck3D(dims[-1], residual=False, norm="batch", activation="relu")
@@ -76,7 +84,7 @@ class Unet3d(UNet3DBase):
             dims=dims,
             num_res_block=[1] * depth,
             bottleneck=bottleneck,
-            downsample_z=True,
+            downsample_z=downsample_z,
             residual=False,
             norm="batch",
             activation="relu",

--- a/packages/viscy-models/src/viscy_models/unet/unet3d_base.py
+++ b/packages/viscy-models/src/viscy_models/unet/unet3d_base.py
@@ -158,7 +158,15 @@ class UNet3DBase(nn.Module):
         -------
         Tensor
             Output tensor of shape ``(B, out_channels, D, H, W)``.
+
+        Raises
+        ------
+        ValueError
+            If ``x`` is not a 5D tensor, or a downsampled spatial dimension is
+            not divisible by ``2**num_blocks``.
         """
+        if x.ndim != 5:
+            raise ValueError(f"Expected 5D input (B, C, D, H, W), got {x.ndim}D.")
         for dim_name, size in zip(("D", "H", "W"), x.shape[2:]):
             if self.downsamples_z or dim_name != "D":
                 if size % self._divisor != 0:

--- a/packages/viscy-models/tests/test_unet/test_unet3d.py
+++ b/packages/viscy-models/tests/test_unet/test_unet3d.py
@@ -67,6 +67,33 @@ def test_engine_attributes():
     assert model.downsamples_z is True
 
 
+def test_downsample_z_default_preserves_fnet3d():
+    """Default downsample_z keeps the FNet3D Z-downsampling behavior."""
+    model = Unet3d(depth=4, mult_chan=32, in_stack_depth=32)
+    assert model.downsamples_z is True
+
+
+def test_downsample_z_false_z1_forward():
+    """downsample_z=False enables the FNet2D use case: a Z=1 forward runs and preserves Z.
+
+    With downsample_z=True (the FNet3D default) a Z=1 input trips the base
+    ``D % 2**depth`` divisor check; the Z-preserving path must skip that check.
+    """
+    model = Unet3d(in_channels=1, out_channels=1, depth=4, mult_chan=32, downsample_z=False)
+    assert model.downsamples_z is False
+    x = torch.randn(2, 1, 1, 64, 64)  # Y,X divisible by 2**4=16; Z=1
+    y = model(x)
+    assert y.shape == (2, 1, 1, 64, 64)
+
+
+def test_downsample_z_false_skips_z_divisor_check():
+    """With downsample_z=False, Z need not be divisible by 2**depth (only Y/X are checked)."""
+    model = Unet3d(in_channels=1, out_channels=1, depth=2, mult_chan=16, downsample_z=False)
+    x = torch.randn(1, 1, 3, 16, 16)  # Z=3 not divisible by 2^2=4, but Z is not downsampled
+    y = model(x)
+    assert y.shape == (1, 1, 3, 16, 16)
+
+
 def test_state_dict_keys():
     """State dict uses iterative encoder-decoder key structure."""
     model = Unet3d(in_channels=1, out_channels=1, depth=2, mult_chan=16)

--- a/packages/viscy-models/tests/test_unet/test_unet3d_base.py
+++ b/packages/viscy-models/tests/test_unet/test_unet3d_base.py
@@ -173,3 +173,10 @@ def test_dims_mismatch_raises():
     """len(dims) != len(num_res_block) + 1 raises ValueError."""
     with pytest.raises(ValueError, match="len\\(dims\\)"):
         _make_base(dims=(16, 32, 64), num_res_block=(1,))
+
+
+def test_forward_non_5d_input_raises():
+    """A non-5D input raises a clear ValueError, not a confusing Conv3d channel error."""
+    model = _make_base()
+    with pytest.raises(ValueError, match="Expected 5D input"):
+        model(torch.randn(2, 1, 16, 16))  # 4D: a squeezed Z dim

--- a/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
+++ b/packages/viscy-utils/src/viscy_utils/evaluation/metrics.py
@@ -171,6 +171,11 @@ def mean_average_precision(
     return map_metric.compute()
 
 
+# Floors the SSIM/CS denominators so a zero data_range (c1=c2=0) on a flat window
+# cannot produce 0/0; negligible relative to the c1/c2 stability constants otherwise.
+_SSIM_DENOM_EPS: float = 1e-8
+
+
 def _compute_ssim_and_cs_bf16(
     y_pred: torch.Tensor,
     y: torch.Tensor,
@@ -259,12 +264,33 @@ def _compute_ssim_and_cs_bf16(
     c1 = (k1 * data_range) ** 2
     c2 = (k2 * data_range) ** 2
 
-    sigma_x = mu_xx - mu_x * mu_x
-    sigma_y = mu_yy - mu_y * mu_y
-    sigma_xy = mu_xy - mu_x * mu_y
+    # Repair bf16 catastrophic cancellation in the second moments. With bf16
+    # mean / mean-of-squares convolutions, ``mu_xx - mu_x**2`` cancels badly for
+    # windows over large-magnitude inputs (e.g. z-scored FCMAE targets with a tiny
+    # iqr → normalized values in the hundreds) and can round to a slightly *negative*
+    # variance. At depth=1 (2D) each window has only ``1*H_k*W_k`` samples, so the
+    # cancellation is far more likely than at depth=15 (3D, where the extra Z samples
+    # keep the estimate stable) — a near-flat window then drives the SSIM denominator
+    # to ~0 and produces intermittent NaN loss that trains fine for a while then
+    # diverges.
+    #
+    # A variance is non-negative by definition, so clamp both diagonal terms to >=0.
+    # The covariance must then be bounded by Cauchy-Schwarz (|sigma_xy| <=
+    # sqrt(sigma_x*sigma_y)): exact fp32 recovers cs=1 on a flat window because the
+    # equally-negative sigma_x/sigma_y/sigma_xy cancel in the ratio, so clamping only
+    # the diagonal terms would leave an unbalanced negative sigma_xy and inflate |cs|
+    # to >10 on background windows. With the bound a flat window gives
+    # sigma_x=sigma_y=sigma_xy=0 -> cs = c2 / c2 = 1, matching exact fp32; on
+    # well-conditioned windows the bound is slack and both clamps are no-ops.
+    sigma_x = (mu_xx - mu_x * mu_x).clamp_min(0.0)
+    sigma_y = (mu_yy - mu_y * mu_y).clamp_min(0.0)
+    sigma_xy_bound = (sigma_x * sigma_y).sqrt()
+    sigma_xy = torch.clamp(mu_xy - mu_x * mu_y, min=-sigma_xy_bound, max=sigma_xy_bound)
 
-    contrast_sensitivity = (2 * sigma_xy + c2) / (sigma_x + sigma_y + c2)
-    ssim_full = ((2 * mu_x * mu_y + c1) / (mu_x * mu_x + mu_y * mu_y + c1)) * contrast_sensitivity
+    # ``_SSIM_DENOM_EPS`` floors the denominators so a zero data_range (→ c1=c2=0) on a
+    # flat window cannot yield 0/0; negligible vs the c1/c2 stability constants otherwise.
+    contrast_sensitivity = (2 * sigma_xy + c2) / (sigma_x + sigma_y + c2 + _SSIM_DENOM_EPS)
+    ssim_full = ((2 * mu_x * mu_y + c1) / (mu_x * mu_x + mu_y * mu_y + c1 + _SSIM_DENOM_EPS)) * contrast_sensitivity
 
     return ssim_full, contrast_sensitivity
 

--- a/packages/viscy-utils/tests/test_metrics.py
+++ b/packages/viscy-utils/tests/test_metrics.py
@@ -7,6 +7,16 @@ Covers the multi-tier numerical contract:
 - aggregate SSIM equivalence on correlated-pair inputs (closer to training)
 - gradient-flow correctness via cosine similarity and sign-flip fraction
 - output dtype invariance to input dtype
+- finiteness at zero data_range (the eps denominator floor)
+- flat-window contrast-sensitivity ≈ 1 (the Cauchy-Schwarz covariance bound)
+
+The two regression tests guard the deterministic, hardware-independent halves of
+the bf16 NaN fix. The remaining half — the negative-variance denominator collapse
+that produced intermittent NaN loss in 2D FCMAE training — is a bf16 rounding
+knife-edge (the denominator must round to exactly 0) that only surfaces over
+millions of windows across many steps and varies by GPU architecture, so it is not
+unit-reproducible; it is validated end-to-end (the exact failing fit ran clean
+after the clamp).
 """
 
 import pytest
@@ -167,3 +177,56 @@ def test_ssim_helper_dtypes(input_dtype):
 
     assert ssim_helper.dtype == torch.float32
     assert cs_helper.dtype == torch.float32
+
+
+@_skip_no_bf16
+def test_ssim_helper_finite_on_zero_data_range():
+    """Regression: a zero ``data_range`` (→ c1=c2=0) must not yield 0/0 NaN.
+
+    ``ms_ssim_25d`` recomputes ``data_range = target.max()`` per scale; a flat or
+    all-nonpositive target zeroes ``data_range`` and with it the c1/c2 stability
+    constants, so the SSIM/CS ratios become 0/0. ``clamp=True`` in the loss cannot
+    repair that — ``clamp`` bounds magnitude, not NaN — so the poisoned gradient
+    silently corrupts every weight. The ``_SSIM_DENOM_EPS`` denominator floor keeps
+    the helper finite. This case NaNs on the unfloored implementation on every device
+    (deterministic, hardware-independent).
+    """
+    kernel_1 = (1, 11, 11)
+    shape = (2, 1, 1, 64, 64)
+    y = torch.zeros(*shape, device="cuda")
+    y_pred = torch.zeros_like(y)
+
+    ssim_full, cs = _compute_ssim_and_cs_bf16(y_pred, y, kernel_size=kernel_1, data_range=y.max())
+
+    assert torch.isfinite(ssim_full).all(), "SSIM NaN/Inf at data_range=0 (denominator not floored)"
+    assert torch.isfinite(cs).all(), "contrast-sensitivity NaN/Inf at data_range=0"
+
+
+@_skip_no_bf16
+def test_ssim_helper_flat_window_contrast_is_unity():
+    """Regression: near-flat windows over large-magnitude inputs keep cs≈1.
+
+    FCMAE targets are z-scored (``NormalizeSampled``); a channel with a tiny iqr
+    (e.g. iPSC/A549 nucleus, iqr~1.8) normalizes to values in the hundreds. At
+    depth=1 (2D FCMAE) each SSIM window has only ``1*H_k*W_k`` samples, so the bf16
+    ``mu_xx - mu_x**2`` variance estimate catastrophically cancels and rounds
+    *negative* (empirically ~-100 at magnitude 150). Exact fp32 recovers cs=1 on a
+    flat window because the equally-negative sigma_x/sigma_y/sigma_xy cancel in the
+    ratio; clamping only the diagonal variances to >=0 breaks that cancellation and
+    inflates |cs| past 10 on background windows (which dominate a VS image). The
+    Cauchy-Schwarz bound on sigma_xy restores cs=1. This guards that balance — the
+    unbounded-covariance variant fails it with |cs-1| > 10, deterministically.
+    """
+    torch.manual_seed(5)
+    kernel_1 = (1, 11, 11)
+    shape = (1, 1, 1, 64, 64)
+    worst = 0.0
+    for magnitude in (150.0, 300.0):
+        y = torch.full(shape, magnitude, device="cuda") + 0.03 * torch.randn(*shape, device="cuda")
+        y_pred = torch.full(shape, magnitude, device="cuda") + 0.03 * torch.randn(*shape, device="cuda")
+        _, cs = _compute_ssim_and_cs_bf16(
+            y_pred, y, kernel_size=kernel_1, data_range=torch.tensor(magnitude, device="cuda")
+        )
+        assert torch.isfinite(cs).all()
+        worst = max(worst, (cs - 1.0).abs().max().item())
+    assert worst < 0.5, f"near-flat contrast-sensitivity deviates from 1 by {worst:.3f} (unbounded covariance?)"


### PR DESCRIPTION
Adds the eval-side plumbing to evaluate virtual-staining predictions in 2D — the precursor infrastructure for the planned 2D in-focus VS model track.

- **2D pixel metrics (FRC)** — `metrics.py` gains 2D Fourier Ring Correlation alongside the existing 3D FSC, so per-z / 2D predictions can be scored on a like-for-like resolution metric (`test_evaluation_metrics.py` extended).
- **`io.exclude_fov_names`** — `evaluate_predictions` can drop specific FOVs (matched by full name `0/0/fov0011` or leaf `fov0011`) uniformly across pred/gt/seg, so you can evaluate the finished FOVs of a partially-run predict without tripping the strict pred/gt count-alignment. Unlike `limit_positions` it does not set `partial_walk`, so deep-feature caches self-heal normally. Eval-side analog of the predict-side `exclude_fov_names` used by `--resume-predict`.
- **Test** — end-to-end coverage of the FOV-exclusion filter (both match modes) driving `evaluate_predictions` on the CPU fixture.

Base: `dynacell-v1.1`.

Tests: `test_evaluation_metrics.py` (29) and the new `test_exclude_fov_names_drops_positions` pass. Note the eval integration tests must run in the `cpdino-eval` venv (cubic 0.8.0a2) — the shared `.venv` (cubic 0.7.0) breaks the `segment_cpdino` import for the whole eval-pipeline test module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
