### PR TITLE
feat(dynacell): 2D in-focus VS model track

### DIFF
--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
@@ -10,7 +10,8 @@
 #   - z_window_size: 20 -> 1
 #   - RandWeightedCropd spatial_size [20,600,600] -> [1,600,600]
 #   - BatchedRandAffined rotate_range [3.14,0,0] -> [0,0,0],
-#     scale_range Z [0.7,1.3] -> [0,0] (no Z rotate/scale)
+#     scale_range Z [0.7,1.3] -> [1,1] (identity = no Z scale; kornia
+#     affine scale is an absolute factor, so 1.0 is the no-op, not 0)
 #   - BatchedCenterSpatialCropd roi_size [15,384,384] -> [1,384,384]
 #   - BatchedRandGaussianSmoothd sigma_z [0.25,0.75] -> [0,0]
 # XY augmentation policy (shear/scale/contrast/intensity/noise/smooth) is
@@ -37,7 +38,7 @@ data:
           prob: 0.8
           rotate_range: [0, 0, 0]
           shear_range: [0.0, 0.05, 0.05]
-          scale_range: [[0, 0], [0.5, 1.5], [0.5, 1.5]]
+          scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
       - class_path: viscy_transforms.BatchedCenterSpatialCropd
         init_args:
           keys: [source, target]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
@@ -1,0 +1,72 @@
+# FCMAE-2D (VSCyto2D-geometry FullyConvolutionalMAE) fit-time HCS data
+# hparams for the in-focus 2D benchmark track. Split out from
+# model_overlays/fcmae_vscyto2d_fit.yml so the model+trainer half there
+# stays composable by joint-dataset (BatchedConcatDataModule) leaves that
+# author their own data: block.
+#
+# Mirrors data_overlays/fcmae_vscyto3d_fit.yml but flattens all Z
+# augmentations to the cytoland 2D convention (z_window_size=1 reads the
+# offline `_focus.zarr` 5-plane slab stores; each window is one plane):
+#   - z_window_size: 20 -> 1
+#   - RandWeightedCropd spatial_size [20,600,600] -> [1,600,600]
+#   - BatchedRandAffined rotate_range [3.14,0,0] -> [0,0,0],
+#     scale_range Z [0.7,1.3] -> [0,0] (no Z rotate/scale)
+#   - BatchedCenterSpatialCropd roi_size [15,384,384] -> [1,384,384]
+#   - BatchedRandGaussianSmoothd sigma_z [0.25,0.75] -> [0,0]
+# XY augmentation policy (shear/scale/contrast/intensity/noise/smooth) is
+# kept identical to the 3D overlay.
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 32
+    num_workers: 4
+    yx_patch_size: [384, 384]
+    augmentations:
+      # CPU weighted crop on the 5-plane focus slab: spatial_size Z=1
+      # samples a single target-weighted plane per crop.
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          w_key: Structure
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+    gpu_augmentations:
+      - class_path: viscy_transforms.BatchedRandAffined
+        init_args:
+          keys: [source, target]
+          prob: 0.8
+          rotate_range: [0, 0, 0]
+          shear_range: [0.0, 0.05, 0.05]
+          scale_range: [[0, 0], [0.5, 1.5], [0.5, 1.5]]
+      - class_path: viscy_transforms.BatchedCenterSpatialCropd
+        init_args:
+          keys: [source, target]
+          roi_size: [1, 384, 384]
+      - class_path: viscy_transforms.BatchedRandAdjustContrastd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          gamma: [0.8, 1.2]
+      - class_path: viscy_transforms.BatchedRandScaleIntensityd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          factors: 0.5
+      - class_path: viscy_transforms.BatchedRandGaussianNoised
+        init_args:
+          keys: [source]
+          prob: 0.5
+          mean: 0.0
+          std: 0.3
+      - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+        init_args:
+          keys: [source]
+          prob: 0.5
+          sigma_x: [0.25, 0.75]
+          sigma_y: [0.25, 0.75]
+          sigma_z: [0, 0]
+    val_gpu_augmentations:
+      - class_path: viscy_transforms.BatchedCenterSpatialCropd
+        init_args:
+          keys: [source, target]
+          roi_size: [1, 384, 384]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
@@ -19,7 +19,12 @@
 data:
   init_args:
     z_window_size: 1
-    batch_size: 32
+    # 16 (not the 3D overlay's 32) so a single_gpu fit fits the 48 GB pool
+    # (a40|l40s|a6000): bs=32 OOMs at ~47 GB there, bs=8 uses ~half, so 16
+    # keeps ~2x headroom and constraint:null stays valid. Effective batch is
+    # deliberately not forced to match the 3D 4-GPU global batch — the 2D
+    # nets are trained to their own best on cheap hardware (plan Phase-B).
+    batch_size: 16
     num_workers: 4
     yx_patch_size: [384, 384]
     augmentations:

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fnet2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/data_overlays/fnet2d_fit.yml
@@ -1,0 +1,58 @@
+# FNet2D fit-time HCS data hparams for the in-focus 2D benchmark track.
+# Split out from model_overlays/fnet2d_fit.yml so the model+trainer half
+# there stays composable by joint-dataset (BatchedConcatDataModule)
+# leaves that author their own data: block.
+#
+# Mirrors data_overlays/fnet3d_paper_fit.yml (including the mean/std
+# Structure normalization and the 8-crops-per-FOV sampling that diverge
+# from the CellDiff/UNetViT conventions) but flattens Z to the in-focus
+# `_focus.zarr` 5-plane slab stores (z_window_size=1, each window one
+# plane):
+#   - z_window_size: 32 -> 1
+#   - RandWeightedCropd spatial_size [32,64,64] -> [1,64,64]
+#   - CenterSpatialCropd (val) roi_size [32,64,64] -> [1,64,64]
+# The YX flips are unchanged (spatial_axes 1=Y, 2=X are valid at Z=1).
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 48
+    num_workers: 8
+    yx_patch_size: [64, 64]
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Structure]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      # CPU: 8 patches per FOV (amortizes zarr decompression).
+      # batch_size=48 -> DataLoader loads 6 FOVs, each yields 8 patches = 48.
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          w_key: Structure
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    gpu_augmentations:
+      - class_path: viscy_transforms.BatchedRandFlipd
+        init_args:
+          keys: [source, target]
+          spatial_axes: [1]
+          prob: 0.5
+      - class_path: viscy_transforms.BatchedRandFlipd
+        init_args:
+          keys: [source, target]
+          spatial_axes: [2]
+          prob: 0.5
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Structure]
+          roi_size: [1, 64, 64]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
@@ -1,0 +1,57 @@
+# Shared FCMAE-2D (FullyConvolutionalMAE, pretraining=False) fit overlay
+# for the in-focus 2D benchmark track. Geometry is the published VSCyto2D
+# recipe (applications/cytoland/examples/configs/recipes/models/fcmae_2d.yml,
+# plan M5): in_stack_depth=1, stem_kernel_size=[1,2,2]. Used by both
+# fcmae_vscyto2d_scratch and fcmae_vscyto2d_pretrained leaves —
+# encoder_only + ckpt_path are set only in the pretrained leaf so init is
+# the only difference between the two (lr drops to 0.0002 there,
+# mirroring cytoland vscyto2d finetuning).
+#
+# Mirrors model_overlays/fcmae_vscyto3d_fit.yml but with 2D geometry and
+# single-GPU topology:
+#   - stem_kernel_size [5,4,4] -> [1,2,2], in_stack_depth 15 -> 1
+#   - topology ddp_4gpu -> single_gpu (2D nets are light; a Phase-B
+#     throughput decision — see plan §2d). No explicit DDPStrategy /
+#     find_unused_parameters / 3h-timeout block is needed at single-device
+#     (SingleDeviceStrategy has no DDP reducer, so FCMAE pretraining=False
+#     unused decoder/head paths are fine). If a later throughput probe
+#     switches this to DDP, re-add the fcmae_vscyto3d_fit.yml
+#     DDPStrategy(find_unused_parameters=true, timeout="3:00:00") block.
+#
+# HCS data hparams (bs=32, z=1, yx=384, flattened augs) live in
+# data_overlays/fcmae_vscyto2d_fit.yml; single-store train leaves compose
+# both, joint (BatchedConcatDataModule) leaves compose only this one and
+# author data: themselves.
+base:
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: fcmae
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      encoder_blocks: [3, 3, 9, 3]
+      encoder_drop_path_rate: 0.1
+      dims: [96, 192, 384, 768]
+      decoder_conv_blocks: 2
+      stem_kernel_size: [1, 2, 2]
+      in_stack_depth: 1
+      pretraining: false
+    loss_function:
+      class_path: viscy_utils.losses.MixedLoss
+      init_args:
+        l1_alpha: 0.5
+        l2_alpha: 0.0
+        ms_dssim_alpha: 0.5
+    lr: 0.0004
+    schedule: WarmupCosine
+    # Phase-B TODO: re-size warmup_steps to ~1 epoch once the focus-store
+    # FOV count is known (single-GPU bs=32 at z_window_size=1 emits ~5
+    # windows/FOV/T, so steps/epoch differ from the 3D 4-GPU baseline).
+    warmup_steps: 4000
+    warmup_multiplier: 1e-3
+trainer:
+  precision: 16-mixed
+  max_epochs: 200

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
@@ -18,7 +18,7 @@
 #     switches this to DDP, re-add the fcmae_vscyto3d_fit.yml
 #     DDPStrategy(find_unused_parameters=true, timeout="3:00:00") block.
 #
-# HCS data hparams (bs=32, z=1, yx=384, flattened augs) live in
+# HCS data hparams (bs=16, z=1, yx=384, flattened augs) live in
 # data_overlays/fcmae_vscyto2d_fit.yml; single-store train leaves compose
 # both, joint (BatchedConcatDataModule) leaves compose only this one and
 # author data: themselves.
@@ -48,7 +48,7 @@ model:
     lr: 0.0004
     schedule: WarmupCosine
     # Phase-B TODO: re-size warmup_steps to ~1 epoch once the focus-store
-    # FOV count is known (single-GPU bs=32 at z_window_size=1 emits ~5
+    # FOV count is known (single-GPU bs=16 at z_window_size=1 emits ~5
     # windows/FOV/T, so steps/epoch differ from the 3D 4-GPU baseline).
     warmup_steps: 4000
     warmup_multiplier: 1e-3

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
@@ -1,0 +1,49 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) predict overlay for
+# the in-focus 2D benchmark track. Mirrors fcmae_vscyto3d_predict.yml but
+# with 2D geometry.
+#
+# CRITICAL: predict rebuilds the model from THIS overlay's model_config
+# and then loads the trained weights (engine.py:308), so the full 2D
+# model_config MUST be re-declared here (in_stack_depth=1,
+# stem_kernel_size=[1,2,2]) and data.z_window_size MUST be 1 — otherwise
+# load_state_dict fails on a stem/conv shape mismatch against the 2D
+# checkpoint. Used by both fcmae_vscyto2d_pretrained and
+# fcmae_vscyto2d_scratch predict leaves — predict loads the full trained
+# checkpoint, so the pretrained-encoder warm-start path (encoder_only +
+# ckpt_path) from the fit leaf does NOT belong here.
+#
+# The 2D model predicts each z-plane of the full-Z 3D test store from its
+# own phase plane (z_window_size=1 -> one window per z; the writer keys
+# each output to its z-index, z_padding=0). 640x960 / 512x512 need no YX
+# pad (num_blocks=4 -> multiple of 16).
+base:
+  - ../../../../../../recipes/trainer/predict.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: fcmae
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      encoder_blocks: [3, 3, 9, 3]
+      encoder_drop_path_rate: 0.1
+      dims: [96, 192, 384, 768]
+      decoder_conv_blocks: 2
+      stem_kernel_size: [1, 2, 2]
+      in_stack_depth: 1
+      pretraining: false
+    loss_function:
+      class_path: viscy_utils.losses.MixedLoss
+      init_args:
+        l1_alpha: 0.5
+        l2_alpha: 0.0
+        ms_dssim_alpha: 0.5
+    predict_method: full_image
+    predict_overlap: [4, 256, 256]
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 1
+    num_workers: 0
+    yx_patch_size: [512, 512]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_fit.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_fit.yml
@@ -1,0 +1,25 @@
+# FNet2D fit overlay — model + trainer only — for the in-focus 2D
+# benchmark track. HCS data hparams (the mean/std Structure normalization
+# and 8-crops-per-FOV sampling that diverge from the CellDiff/UNetViT
+# conventions) live in data_overlays/fnet2d_fit.yml; single-store train
+# leaves compose both, joint (BatchedConcatDataModule) leaves compose only
+# this one and author data: themselves.
+#
+# Mirrors model_overlays/fnet3d_paper_fit.yml but binds the fnet2d model
+# recipe (in_stack_depth=1, downsample_z=false). FNet3D was already
+# single-GPU, so topology is unchanged. lr/schedule/loss/precision/
+# max_steps all match the 3D FNet paper baseline.
+base:
+  - ../../../../../../recipes/models/fnet2d.yml
+  - ../../../../../../recipes/trainer/fit.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+seed_everything: 0
+model:
+  init_args:
+    loss_function:
+      class_path: torch.nn.MSELoss
+    lr: 0.001
+    schedule: Constant
+trainer:
+  precision: 32-true
+  max_steps: 200000

--- a/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_predict.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/_internal/shared/model/model_overlays/fnet2d_predict.yml
@@ -1,0 +1,26 @@
+# FNet2D predict overlay for the in-focus 2D benchmark track. Binds the
+# fnet2d model recipe + predict trainer recipe, then layers predict-time
+# model hparams and data-loader settings. Predict-time normalizations and
+# data_path are leaf-owned (leaf overrides target-inherited values to
+# match each organelle's test_cropped store).
+#
+# CRITICAL: predict rebuilds the model from the fnet2d recipe's
+# model_config (in_stack_depth=1, downsample_z=false) and then loads the
+# trained weights (engine.py:308); data.z_window_size MUST be 1 so the
+# datamodule emits one window per z-plane of the full-Z 3D test store,
+# matching the Z-preserving 2D checkpoint. A z_window_size mismatch would
+# feed a multi-plane window into a Z=1 network and error.
+base:
+  - ../../../../../../recipes/models/fnet2d.yml
+  - ../../../../../../recipes/trainer/predict.yml
+  - ../../../../../../recipes/topology/single_gpu.yml
+model:
+  init_args:
+    predict_method: full_image
+    predict_overlap: [4, 256, 256]
+data:
+  init_args:
+    z_window_size: 1
+    batch_size: 1
+    num_workers: 0
+    yx_patch_size: [512, 512]

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,66 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on ER/SEC61B, in-focus 2D benchmark track,
+# A549 mantis pooled (mock + DENV + ZIKV). Paper key: VSCyto2D. Companion
+# to fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store SEC61B_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane). target_channel
+# "Structure" matches the FCMAE-2D data overlay's default augmentation
+# keys, so no augmentation override is needed. Mirror of the 3D
+# er/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on ER/SEC61B, in-focus 2D benchmark track,
+# iPSC confocal (aics-hipsc). Paper key: VSCyto2D. Companion to
+# fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# SEC61B_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure). target_channel "Structure" also
+# matches the FCMAE-2D data overlay's default augmentation keys, so no
+# augmentation override is needed. Mirror of the 3D
+# er/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on er (SEC61B) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors er/fcmae_vscyto2d_pretrained/ipsc_confocal on the
+# joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_SEC61B_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_SEC61B_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,57 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on ER/SEC61B, in-focus 2D benchmark track, A549 mantis pooled
+# (mock + DENV + ZIKV). Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store SEC61B_all_focus.zarr
+# (extracted from the 3D SEC61B_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# er/fcmae_vscyto3d_scratch/a549_mantis fit leaf. target_channel ==
+# "Structure" matches the FCMAE-2D data overlay's RandWeightedCropd keys,
+# so no augmentation override is needed here.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,65 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on ER/SEC61B, in-focus 2D benchmark track, iPSC confocal. Scratch
+# control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the
+# two leaves are identical except this one does NOT load pretrained encoder
+# weights. Mirror of the 3D er/fcmae_vscyto3d_scratch/ipsc_confocal fit
+# leaf. target_channel == "Structure" matches the FCMAE-2D data overlay's
+# RandWeightedCropd keys, so no augmentation override is needed here.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# SEC61B_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on er (SEC61B), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# er/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint train_set
+# and the 3D er/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B all-conditions in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,56 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on ER (SEC61B marker) — A549
+# mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track. Mirror of
+# the 3D er/fnet3d_paper/a549_mantis fit leaf, flattened onto the offline
+# 5-plane in-focus slab store SEC61B_all_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane). target_channel == Structure, so the fnet2d data
+# overlay's default norms/augs (already [1,64,64]) apply unchanged.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: er__a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_A549_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/er/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,63 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on ER (SEC61B marker) — AICS
+# iPSC confocal, in-focus 2D track. Mirror of the 3D
+# er/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline 5-plane
+# in-focus slab store SEC61B_focus.zarr (z_window_size=1 emits one in-focus
+# window per plane). target_channel == Structure, so the fnet2d data overlay's
+# default norms/augs (already [1,64,64]) apply unchanged.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# SEC61B.zarr. The 2D track reads SEC61B_focus.zarr instead, so the resolver
+# is disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/er_sec61b.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: er__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered SEC61B.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/er/fnet2d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/er/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on er (SEC61B) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# er/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: er
+  gene: SEC61B
+  target: er
+  target_id: er_sec61b
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: er__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_SEC61B
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/SEC61B_focus.zarr
+      # a549_mantis — pooled SEC61B in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/SEC61B_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_SEC61B
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/er/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,77 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (Membrane marker), in-focus 2D
+# benchmark track, A549 mantis pooled (mock + DENV + ZIKV). Paper key:
+# VSCyto2D. Companion to fcmae_vscyto2d_scratch — the two leaves are
+# identical except this one loads the 2D FCMAE encoder weights and drops
+# lr to 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__a549_mantis__fcmae_vscyto2d_pretrained
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr.
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,86 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (Membrane marker), in-focus 2D
+# benchmark track, iPSC confocal (aics-hipsc). Paper key: VSCyto2D.
+# Companion to fcmae_vscyto2d_scratch — the two leaves are identical
+# except this one loads the 2D FCMAE encoder weights and drops lr to
+# 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Membrane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on membrane (MEMB) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors membrane/fcmae_vscyto2d_pretrained/ipsc_confocal
+# on the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,68 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (Membrane marker), in-focus 2D benchmark track, A549 mantis
+# pooled (mock + DENV + ZIKV). Paper key: UNeXt2-2D. Scratch control for
+# the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the two leaves
+# are identical except this one does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# membrane/fcmae_vscyto3d_scratch/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__a549_mantis__fcmae_vscyto2d_scratch
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name
+# in keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the nucleus 2D leaf re-keys to Nuclei).
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (Membrane marker), in-focus 2D benchmark track, iPSC
+# confocal. Scratch control for the fcmae_vscyto2d_pretrained (VSCyto2D)
+# counterpart — the two leaves are identical except this one does NOT load
+# pretrained encoder weights. Mirror of the 3D
+# membrane/fcmae_vscyto3d_scratch/ipsc_confocal fit leaf.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Membrane).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual membrane channel name
+# in keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_Membrane
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_Membrane
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on membrane (MEMB), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# membrane/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D membrane/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl/memb all-conditions in-focus slab (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,84 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (Membrane channel)
+# — A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D membrane/fnet3d_paper/a549_mantis fit leaf, flattened onto
+# the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target). Membrane target_channel is Membrane, so we list-replace those
+# three lists here to re-key them, flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: membrane__a549_mantis__fnet2d
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr.
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Membrane]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_A549_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/membrane/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,96 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (Membrane channel)
+# — AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# membrane/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline
+# 5-plane in-focus slab store cell_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads cell_focus.zarr instead, so the resolver is
+# disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Membrane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target), so we list-replace those three lists here to re-key to Membrane,
+# flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/membrane.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: membrane__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Membrane
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Membrane]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          w_key: Membrane
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Membrane]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/membrane/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for cell.zarr
+  # mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/membrane/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on membrane (MEMB) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# membrane/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: membrane
+  gene: Membrane
+  target: membrane
+  target_id: membrane
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: membrane__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_MEMB
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Membrane
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Membrane]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        w_key: Membrane
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Membrane]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc in-focus slab store (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab store (Membrane channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_MEMB
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/membrane/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,66 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito/TOMM20, in-focus 2D benchmark track,
+# A549 mantis pooled (mock + DENV + ZIKV). Paper key: VSCyto2D. Companion
+# to fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store TOMM20_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane). target_channel
+# "Structure" matches the FCMAE-2D data overlay's default augmentation
+# keys, so no augmentation override is needed. Mirror of the 3D
+# mito/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito/TOMM20, in-focus 2D benchmark track,
+# iPSC confocal (aics-hipsc). Paper key: VSCyto2D. Companion to
+# fcmae_vscyto2d_scratch — the two leaves are identical except this one
+# loads the 2D FCMAE encoder weights and drops lr to 0.0002 (mirroring
+# cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# TOMM20_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure). target_channel "Structure" also
+# matches the FCMAE-2D data overlay's default augmentation keys, so no
+# augmentation override is needed. Mirror of the 3D
+# mito/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on mito (TOMM20) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors mito/fcmae_vscyto2d_pretrained/ipsc_confocal on
+# the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_TOMM20_ws8500
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 in-focus slab
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_TOMM20_ws8500
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,57 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito/TOMM20, in-focus 2D benchmark track, A549 mantis pooled
+# (mock + DENV + ZIKV). Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store TOMM20_all_focus.zarr
+# (extracted from the 3D TOMM20_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# mito/fcmae_vscyto3d_scratch/a549_mantis fit leaf. target_channel ==
+# "Structure" matches the FCMAE-2D data overlay's RandWeightedCropd keys,
+# so no augmentation override is needed here.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,65 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito/TOMM20, in-focus 2D benchmark track, iPSC confocal. Scratch
+# control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the
+# two leaves are identical except this one does NOT load pretrained encoder
+# weights. Mirror of the 3D mito/fcmae_vscyto3d_scratch/ipsc_confocal fit
+# leaf. target_channel == "Structure" matches the FCMAE-2D data overlay's
+# RandWeightedCropd keys, so no augmentation override is needed here.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# TOMM20_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on mito (TOMM20), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# mito/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D mito/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 all-conditions in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,56 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mitochondria (TOMM20 marker)
+# — A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D mito/fnet3d_paper/a549_mantis fit leaf, flattened onto the
+# offline 5-plane in-focus slab store TOMM20_all_focus.zarr (z_window_size=1
+# emits one in-focus window per plane). target_channel == Structure, so the
+# fnet2d data overlay's default norms/augs (already [1,64,64]) apply unchanged.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: mito__a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d/checkpoints
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set.
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_A549_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/mito/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,63 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mitochondria (TOMM20 marker)
+# — AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# mito/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline 5-plane
+# in-focus slab store TOMM20_focus.zarr (z_window_size=1 emits one in-focus
+# window per plane). target_channel == Structure, so the fnet2d data overlay's
+# default norms/augs (already [1,64,64]) apply unchanged.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# TOMM20.zarr. The 2D track reads TOMM20_focus.zarr instead, so the resolver
+# is disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Structure).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/mito_tomm20.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: mito__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered TOMM20.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Structure
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/mito/fnet2d

--- a/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/mito/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,123 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on mito (TOMM20) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# mito/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: mito
+  gene: TOMM20
+  target: mito
+  target_id: mito_tomm20
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: mito__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_TOMM20
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Structure
+  z_window_size: 1
+  # See nucleus/fnet2d/joint_*/train.yml for the rationale: joint mode does
+  # not divide batch_size by num_samples (unlike single-set), so
+  # 6 * num_samples=8 = 48 GPU samples matches single-set effective.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Structure]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        w_key: Structure
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Structure]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/TOMM20_focus.zarr
+      # a549_mantis — pooled TOMM20 in-focus slab store
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/TOMM20_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_TOMM20
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/mito/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/a549_mantis/train.yml
@@ -1,0 +1,78 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (Nuclei marker), in-focus 2D
+# benchmark track, A549 mantis pooled (mock + DENV + ZIKV). Paper key:
+# VSCyto2D. Companion to fcmae_vscyto2d_scratch — the two leaves are
+# identical except this one loads the 2D FCMAE encoder weights and drops
+# lr to 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_pretrained/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_pretrained
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_A549_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_A549_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal/train.yml
@@ -1,0 +1,86 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (Nuclei marker), in-focus 2D
+# benchmark track, iPSC confocal (aics-hipsc). Paper key: VSCyto2D.
+# Companion to fcmae_vscyto2d_scratch — the two leaves are identical
+# except this one loads the 2D FCMAE encoder weights and drops lr to
+# 0.0002 (mirroring cytoland VSCyto2D finetuning).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline — the
+# resolver hook raises on any data.init_args field co-declared with a full
+# dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Nuclei). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_pretrained/ipsc_confocal fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__ipsc_confocal__fcmae_vscyto2d_pretrained
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_iPSC_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_pretrained/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,158 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) with FCMAE-2D
+# pretrained encoder init on nucleus (NUCL) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D benchmark track.
+# Paper key: VSCyto2D. Companion to the fcmae_vscyto2d_scratch joint
+# leaf — the two are identical except this one loads the 2D FCMAE
+# encoder weights and drops lr to 0.0002 (mirroring cytoland VSCyto2D
+# finetuning). Mirrors nucleus/fcmae_vscyto2d_pretrained/ipsc_confocal
+# on the joint train_set, flattened to the 2D focus-slab geometry.
+#
+# Joint leaf: BatchedConcatDataModule with two explicit HCSDataModule
+# children (no benchmark.dataset_ref — joint leaves bypass the single-
+# dataset resolver, so both child data_paths are the offline
+# `_focus.zarr` slab stores directly). Only
+# model_overlays/fcmae_vscyto2d_fit.yml is composed; the data block is
+# authored inline because joint hparams live on the children.
+#
+# Topology: single-GPU (inherited from model_overlays/fcmae_vscyto2d_fit.yml
+# single_gpu base). z_window_size=1 reads one in-focus plane per window;
+# BatchedConcatDataModule does NOT divide batch_size by num_samples, so
+# batch_size=4 * num_samples=4 = 16 GPU samples/step, matching the
+# single-set 2D data overlay's effective 16.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_pretrained
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_pretrained
+
+model:
+  init_args:
+    # Load only the encoder from the 2D FCMAE ckpt (400 ep on HEK + A549 +
+    # BJ5a + LIVECell + CTMC phase data); decoder/head stay at fresh init.
+    # lr 0.0002 overrides the overlay's 0.0004 for pretrained finetuning.
+    encoder_only: true
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/fcmae-2d/pretrain-logs/hek-a549-bj5a-livecell-ctmc-400ep/checkpoints/last.ckpt
+    lr: 0.0002
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Pretrained_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # batch_size is NOT divided by num_samples in joint mode: 4 indices *
+  # num_samples=4 = 16 GPU samples per rank, matching the single-set 2D
+  # data overlay's effective 16.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Pretrained_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_pretrained

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/predict__a549_mantis_mock.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/predict__a549_mantis_mock.yml
@@ -1,0 +1,55 @@
+# FCMAE-2D scratch (UNeXt2-2D) predict: nucleus trained on a549_mantis
+# (dual_nucl_memb in-focus slab), predicting against a549-mantis-h2b-mock
+# test. Runs the 2D model over the full-Z 3D test store (z_window_size=1 ->
+# one window per z-plane; writer stacks per-z into a full-Z prediction
+# store). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/a549_mantis/predict__a549_mantis_mock.yml.
+#
+# A549 manifest keys nucleus by gene (`h2b`); override the iPSC-side
+# `nucleus` target_id from targets/nucleus.yml so the resolver finds the
+# h2b target on a549-mantis-h2b-mock.
+base:
+  - ../../../_internal/shared/model/predict_sets/a549_mantis_h2b_mock.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_predict.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_predict_any_gpu.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  trained_on: a549_mantis
+  predict_set: a549_mantis_h2b_mock
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_scratch__a549_mantis_h2b_mock
+  # Override the iPSC-side `nucleus` target to a549's gene-keyed `h2b`.
+  dataset_ref:
+    target: h2b
+
+model:
+  init_args:
+    # Phase-F TODO: bake the trained best checkpoint after Phase-E
+    # training (campaign policy: predict with --ckpt best).
+    ckpt_path: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch/checkpoints/last.ckpt
+
+data:
+  init_args:
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations: []
+
+trainer:
+  callbacks:
+    - class_path: viscy_utils.callbacks.prediction_writer.HCSPredictionWriter
+      init_args:
+        output_store: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto2d_scratch/a549/a549__mock/prediction.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_PRED_NUCL_A549TR_MOCK
+  run_root: /hpc/projects/virtual_staining/training/dynacell/nucleus/fcmae_vscyto2d_scratch/a549/a549__mock

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/a549_mantis/train.yml
@@ -1,0 +1,68 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (Nuclei marker), in-focus 2D benchmark track, A549 mantis
+# pooled (mock + DENV + ZIKV). Paper key: UNeXt2-2D. Scratch control for
+# the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart — the two leaves
+# are identical except this one does NOT load pretrained encoder weights.
+#
+# Reads the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (extracted from the 3D dual_nucl_memb_all.zarr; z_window_size=1 emits one
+# in-focus window per plane). Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/a549_mantis fit leaf.
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__a549_mantis__fcmae_vscyto2d_scratch
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in
+    # this train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_A549_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_A549_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml
@@ -1,0 +1,76 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (Nuclei marker), in-focus 2D benchmark track, iPSC confocal.
+# Scratch control for the fcmae_vscyto2d_pretrained (VSCyto2D) counterpart
+# — the two leaves are identical except this one does NOT load pretrained
+# encoder weights. Mirror of the 3D
+# nucleus/fcmae_vscyto3d_scratch/ipsc_confocal fit leaf.
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from
+# the manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads the offline 5-plane in-focus slab store
+# cell_focus.zarr instead, so the resolver is disabled here
+# (dataset_ref: null) and the three data fields are declared inline —
+# the resolver hook raises on any data.init_args field co-declared with a
+# full dataset_ref. source_channel/target_channel reproduce the resolver's
+# manifest output (Phase3D / Nuclei).
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__ipsc_confocal__fcmae_vscyto2d_scratch
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+# Override the FCMAE-2D data overlay's hardcoded `Structure` augmentation
+# keys (the overlay was authored for ER/Mito where target_channel ==
+# "Structure"). RandWeightedCropd needs the actual nucleus channel name in
+# keys/w_key. spatial_size + num_samples kept identical to the FCMAE-2D
+# overlay so the augmentation policy matches ER/Mito.
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 600, 600]
+          num_samples: 4
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_iPSC_Nucleus
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_Nucleus
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fcmae_vscyto2d_scratch/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,143 @@
+# FCMAE-2D (FullyConvolutionalMAE, pretraining=False) random-init baseline
+# on nucleus (NUCL), in-focus 2D benchmark track — joint ipsc_confocal +
+# a549_mantis pooled. Scratch control for the fcmae_vscyto2d_pretrained
+# (VSCyto2D) counterpart — the two leaves are identical except this one
+# does NOT load pretrained encoder weights. Mirrors
+# nucleus/fcmae_vscyto2d_scratch/ipsc_confocal/train.yml on the joint
+# train_set and the 3D nucleus/fcmae_vscyto3d_scratch/joint_* leaf.
+#
+# Joint leaf: BatchedConcatDataModule + two explicit HCSDataModule
+# children; only model_overlays/fcmae_vscyto2d_fit.yml is composed (the
+# data overlay is NOT — the data block is inlined via the &hcs_init_args
+# anchor). Both children read the offline 5-plane in-focus slab stores
+# (z_window_size=1). Single-GPU topology (from the 2D model overlay +
+# hardware_gpu_any_long), so no DDP block.
+base:
+  - ../../../_internal/shared/model/model_overlays/fcmae_vscyto2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fcmae_vscyto2d_scratch
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fcmae_vscyto2d_scratch
+
+trainer:
+  logger:
+    init_args:
+      name: FCMAE_VSCyto2D_Scratch_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 5
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # Joint mode does not divide batch_size by num_samples, so 4 * 4 = 16 GPU
+  # samples per step matches the single-set 2D overlay's effective batch
+  # (batch_size 16). Halved from the 3D joint's 8 to fit the single-GPU
+  # 48 GB pool (a40|l40s|a6000) that the 2D track targets.
+  batch_size: 4
+  num_workers: 4
+  yx_patch_size: [384, 384]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: median
+        divisor: iqr
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 600, 600]
+        num_samples: 4
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandAffined
+      init_args:
+        keys: [source, target]
+        prob: 0.8
+        rotate_range: [0, 0, 0]
+        shear_range: [0.0, 0.05, 0.05]
+        scale_range: [[1, 1], [0.5, 1.5], [0.5, 1.5]]
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+    - class_path: viscy_transforms.BatchedRandAdjustContrastd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        gamma: [0.8, 1.2]
+    - class_path: viscy_transforms.BatchedRandScaleIntensityd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        factors: 0.5
+    - class_path: viscy_transforms.BatchedRandGaussianNoised
+      init_args:
+        keys: [source]
+        prob: 0.5
+        mean: 0.0
+        std: 0.3
+    - class_path: viscy_transforms.BatchedRandGaussianSmoothd
+      init_args:
+        keys: [source]
+        prob: 0.5
+        sigma_x: [0.25, 0.75]
+        sigma_y: [0.25, 0.75]
+        sigma_z: [0, 0]
+  val_gpu_augmentations:
+    - class_path: viscy_transforms.BatchedCenterSpatialCropd
+      init_args:
+        keys: [source, target]
+        roi_size: [1, 384, 384]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc multi-marker in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl/memb all-conditions in-focus slab (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FCMAE_VSCyto2D_Scratch_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fcmae_vscyto2d_scratch

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/a549_mantis/train.yml
@@ -1,0 +1,85 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (Nuclei channel) —
+# A549 mantis-lightsheet pooled (mock + DENV + ZIKV), in-focus 2D track.
+# Mirror of the 3D nucleus/fnet3d_paper/a549_mantis fit leaf, flattened onto
+# the offline 5-plane in-focus slab store dual_nucl_memb_all_focus.zarr
+# (z_window_size=1 emits one in-focus window per plane).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target). Nucleus target_channel is Nuclei, so we list-replace those three
+# lists here to re-key them, flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/a549_mantis.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: a549_mantis
+  model_name: fnet2d
+  experiment_id: nucleus__a549_mantis__fnet2d
+
+data:
+  init_args:
+    # A549 pooled in-focus slab store + target_channel — no resolver in this
+    # train_set. Nucleus + membrane share dual_nucl_memb_all_focus.zarr
+    # (the membrane 2D leaf re-keys to Membrane).
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Nuclei]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_A549_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_A549_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/a549/nucleus/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for mmap_preload
+  # is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/ipsc_confocal/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/ipsc_confocal/train.yml
@@ -1,0 +1,96 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (Nuclei channel) —
+# AICS iPSC confocal, in-focus 2D track. Mirror of the 3D
+# nucleus/fnet3d_paper/ipsc_confocal fit leaf, flattened onto the offline
+# 5-plane in-focus slab store cell_focus.zarr (z_window_size=1 emits one
+# in-focus window per plane).
+#
+# The 3D ipsc leaf resolves data_path/source_channel/target_channel from the
+# manifest via benchmark.dataset_ref, which points at the NON-focus
+# cell.zarr. The 2D track reads cell_focus.zarr instead, so the resolver is
+# disabled here (dataset_ref: null) and the three data fields are declared
+# inline — the resolver hook raises on any data.init_args field co-declared
+# with a full dataset_ref. source_channel/target_channel reproduce the
+# resolver's manifest output (Phase3D / Nuclei).
+#
+# The fnet2d data overlay keys norm/aug/val_aug on Structure (the ER/Mito
+# target), so we list-replace those three lists here to re-key to Nuclei,
+# flattening the crops [32,64,64] -> [1,64,64].
+base:
+  - ../../../_internal/shared/model/train_sets/ipsc_confocal.yml
+  - ../../../_internal/shared/model/targets/nucleus.yml
+  - ../../../_internal/shared/model/data_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  train_set: ipsc_confocal
+  model_name: fnet2d
+  experiment_id: nucleus__ipsc_confocal__fnet2d
+  # Disable the manifest resolver: the 2D track reads the offline focus
+  # store, not the manifest-registered cell.zarr. dataset_ref: null makes
+  # the compose hook a no-op so data fields can be declared inline.
+  dataset_ref: null
+
+data:
+  init_args:
+    # iPSC in-focus slab store + channels — resolver disabled above.
+    source_channel: Phase3D
+    target_channel: Nuclei
+    data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+    normalizations:
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Phase3D]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+      - class_path: viscy_transforms.NormalizeSampled
+        init_args:
+          keys: [Nuclei]
+          level: fov_statistics
+          subtrahend: mean
+          divisor: std
+    augmentations:
+      - class_path: viscy_transforms.RandWeightedCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          w_key: Nuclei
+          spatial_size: [1, 64, 64]
+          num_samples: 8
+    val_augmentations:
+      - class_path: viscy_transforms.CenterSpatialCropd
+        init_args:
+          keys: [Phase3D, Nuclei]
+          roi_size: [1, 64, 64]
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_iPSC_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d/checkpoints
+
+launcher:
+  job_name: FNet2D_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/ipsc/nucleus/fnet2d
+  # 128G: the in-focus slab store is a 5-plane slice of the full-Z 3D store
+  # (~1/4 the Z), so the 512G headroom the 3D leaf needed for cell.zarr
+  # mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
+++ b/applications/dynacell/configs/benchmarks/virtual_staining/nucleus/fnet2d/joint_ipsc_confocal_a549_mantis/train.yml
@@ -1,0 +1,126 @@
+# FNet2D (FNet3D run Z-preserving at Z=1) fit on nucleus (NUCL) — joint
+# ipsc_confocal + a549_mantis pooled, in-focus 2D track. Mirror of the 3D
+# nucleus/fnet3d_paper/joint_* fit leaf, flattened onto the offline 5-plane
+# in-focus slab stores (z_window_size=1 emits one in-focus window per plane).
+#
+# BatchedConcatDataModule + two explicit HCSDataModule children; only
+# model_overlays/fnet2d_fit.yml is composed (the data block is authored
+# inline here, not via data_overlays). Norms + 8-crops-per-FOV diverge from
+# the CellDiff/UNetViT conventions: target channel uses mean/std (not
+# median/iqr) and val augmentations are CPU CenterSpatialCropd on the raw
+# keys. Crops flattened [32,64,64] -> [1,64,64], z_window_size 32 -> 1.
+#
+# Topology: single GPU, any model, long wall — same as the 3D FNet paper
+# baseline, kept so iPSC-only and joint runs are apples-to-apples.
+base:
+  - ../../../_internal/shared/model/model_overlays/fnet2d_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/mode_fit.yml
+  - ../../../_internal/shared/model/launcher_profiles/hardware_gpu_any_long.yml
+  - ../../../_internal/shared/model/launcher_profiles/runtime_shared.yml
+
+benchmark:
+  task: virtual_staining
+  organelle: nucleus
+  gene: Nuclei
+  target: nucleus
+  target_id: nucleus
+  train_set: joint_ipsc_confocal_a549_mantis
+  model_name: fnet2d
+  experiment_id: nucleus__joint_ipsc_confocal_a549_mantis__fnet2d
+
+trainer:
+  logger:
+    init_args:
+      name: FNet2D_JOINT_NUCL
+      save_dir: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: loss/validate
+        filename: "epoch={epoch}-step={step}-loss={loss/validate:.3f}"
+        auto_insert_metric_name: false
+        every_n_epochs: 1
+        save_top_k: 4
+        save_last: true
+        dirpath: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d/checkpoints
+
+_hcs_init_args: &hcs_init_args
+  source_channel: Phase3D
+  target_channel: Nuclei
+  z_window_size: 1
+  # batch_size in joint mode is NOT divided by RandWeightedCropd
+  # num_samples (BatchedConcatDataModule.train_dataloader uses batch_size
+  # as-is, unlike HCSDataModule.train_dataloader which divides by
+  # train_patches_per_stack). To match single-set's effective on-GPU batch
+  # of 48 (single-set's batch_size 48 / 8), use 6 here so
+  # 6 indices * 8 num_samples = 48 GPU samples.
+  batch_size: 6
+  num_workers: 8
+  yx_patch_size: [64, 64]
+  split_ratio: 0.8
+  mmap_preload: true
+  scratch_dir: /dev/shm
+  persistent_workers: true
+  normalizations:
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Phase3D]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+    - class_path: viscy_transforms.NormalizeSampled
+      init_args:
+        keys: [Nuclei]
+        level: fov_statistics
+        subtrahend: mean
+        divisor: std
+  augmentations:
+    - class_path: viscy_transforms.RandWeightedCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        w_key: Nuclei
+        spatial_size: [1, 64, 64]
+        num_samples: 8
+  gpu_augmentations:
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [1]
+        prob: 0.5
+    - class_path: viscy_transforms.BatchedRandFlipd
+      init_args:
+        keys: [source, target]
+        spatial_axes: [2]
+        prob: 0.5
+  val_augmentations:
+    - class_path: viscy_transforms.CenterSpatialCropd
+      init_args:
+        keys: [Phase3D, Nuclei]
+        roi_size: [1, 64, 64]
+
+data:
+  class_path: viscy_data.BatchedConcatDataModule
+  init_args:
+    data_modules:
+      # ipsc_confocal — aics-hipsc in-focus slab store (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/ipsc/dataset_v4/train/cell_focus.zarr
+      # a549_mantis — pooled dual nucl+memb in-focus slab store (Nuclei channel)
+      - class_path: viscy_data.hcs.HCSDataModule
+        init_args:
+          <<: *hcs_init_args
+          data_path: /hpc/projects/virtual_staining/training/dynacell/a549/mantis/train/dual_nucl_memb_all_focus.zarr
+
+launcher:
+  job_name: FNet2D_JOINT_NUCL
+  run_root: /hpc/projects/comp.micro/virtual_staining/models/dynacell/joint/nucleus/fnet2d
+  # 128G: the in-focus slab stores are 5-plane slices of the full-Z 3D
+  # stores (~1/4 the Z), so the 512G headroom the 3D joint leaf needed for
+  # dual mmap_preload is wasteful and delays scheduling.
+  sbatch:
+    mem: "128G"

--- a/applications/dynacell/configs/recipes/models/fnet2d.yml
+++ b/applications/dynacell/configs/recipes/models/fnet2d.yml
@@ -1,0 +1,23 @@
+# Model recipe: FNet2D — FNet3D recursive encoder-decoder (Ounkomol et al.
+# 2018) run Z-preserving at Z=1 for the in-focus 2D benchmark track.
+#
+# Mirrors recipes/models/fnet3d.yml but:
+#   - in_stack_depth: 1  (single in-focus plane, not the 32-plane stack)
+#   - downsample_z: false  (Z-preserving encoder: stride (1,2,2) +
+#     ConvTranspose3d k=(1,3,3)). Required so the base UNet3DBase skips the
+#     `D % 2**depth` divisor check and can run at Z=1 (see
+#     viscy_models/unet/unet3d.py downsample_z, unet3d_base.py:162-168).
+# architecture stays "FNet3D" — the dynacell registry maps it to the
+# viscy_models.Unet3d subclass (engine.py:45); FNet2D is that same net
+# with the Z axis frozen, not a distinct architecture.
+model:
+  class_path: dynacell.engine.DynacellUNet
+  init_args:
+    architecture: FNet3D
+    model_config:
+      in_channels: 1
+      out_channels: 1
+      depth: 4
+      mult_chan: 32
+      in_stack_depth: 1
+      downsample_z: false

--- a/applications/dynacell/tools/extract_focus_slab_store.py
+++ b/applications/dynacell/tools/extract_focus_slab_store.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python
+r"""Extract an in-focus slab OME-Zarr from a 3D train store (DynaCell 2D VS track).
+
+Phase A of the 2D in-focus VS model track. Given a 3D OME-Zarr train store and a
+phase channel name, this writes a ``<name>_focus.zarr`` where every position holds
+the ``2*halfwidth + 1``-plane in-focus slab of **all** channels (phase + targets),
+centered on the per-FOV/per-timepoint waveorder focus plane. A ``z_window_size=1``
+2D training run then reads the slab as ``2*halfwidth + 1`` in-focus windows per
+FOV/timepoint.
+
+Design
+------
+Focus reuse
+    The focus plane is estimated with
+    :func:`dynacell.evaluation.focus.estimate_focus_plane` (which wraps
+    ``waveorder.focus.focus_from_transverse_band`` on the ``midband`` transverse
+    band) on the ``Phase3D`` ``(Z, Y, X)`` volume per FOV/timepoint. The estimator
+    is *imported*, never reimplemented, so the training slab lands on the same
+    in-focus plane the focus-aware eval derives (train/eval cannot diverge). The
+    ``midband_fractions`` band is the module constant ``MIDBAND_FRACTIONS`` — not a
+    parameter — so it already matches the eval.
+Pixel size
+    ``na_det`` / ``lambda_ill`` / ``pixel_size`` set the transverse-band cutoff.
+    ``pixel_size`` defaults to the **store's lateral spacing** (``position.scale[-1]``)
+    rather than a hardcoded value, because iPSC stores carry a different (sometimes
+    placeholder) spacing than the A549 mantis ``0.1494`` — pass ``--pixel-size`` to
+    override when a store's recorded scale is not the physical spacing.
+Clamp-shift window
+    Unlike the eval's :func:`~dynacell.evaluation.focus.focus_slab_from_plane`
+    (which *clips* the slab at the stack caps, yielding fewer planes near an edge),
+    this tool **clamp-shifts** the whole window inward into ``[hw, Z-1-hw]`` so every
+    FOV/timepoint yields a uniform ``2*hw+1`` depth. That keeps the derived zarr
+    rectangular and the ``SlidingWindowDataset`` window count uniform per FOV.
+Channels & zattrs
+    Every channel is copied at the per-timepoint slab z-range. The ``omero``
+    rendering metadata and all custom position/plate zattrs (``normalization``,
+    provenance, condition, ...) are preserved verbatim. The source ``normalization``
+    stats are **full-stack** (per-FOV over all Z); they are copied as-is (not
+    recomputed over the thin slab) and a log line notes this — per-FOV
+    ``NormalizeSampled`` stats are close enough on the in-focus band that re-use is
+    the intended behavior.
+
+Layout is zarr v3 / OME-Zarr v0.5 end to end via :func:`iohub.open_ome_zarr`.
+
+Usage::
+
+    python applications/dynacell/tools/extract_focus_slab_store.py \\
+        --input  /hpc/.../a549/mantis/train/dual_nucl_memb_all.zarr \\
+        --output /hpc/.../a549/mantis/train/dual_nucl_memb_all_focus.zarr \\
+        --phase-channel Phase3D --halfwidth 2
+
+Importing this module pulls in ``dynacell.evaluation.focus`` (cubic + waveorder at
+import), so run it in the dynacell-eval env, not the bare ``.venv``. The focus
+argmax itself runs on CPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+from iohub.ngff import TransformationMeta, open_ome_zarr
+
+from dynacell.evaluation.focus import MIDBAND_FRACTIONS, estimate_focus_plane
+
+logger = logging.getLogger(__name__)
+
+# Estimator defaults mirroring ``dynacell.evaluation.focus.read_focus_compute_config``
+# (mantis acquisition), so the training slab and the eval slab share a focus plane.
+DEFAULT_NA_DET: float = 1.35
+DEFAULT_LAMBDA_ILL: float = 0.450
+DEFAULT_HALFWIDTH: int = 2
+
+# zattrs key iohub manages itself (multiscales / axes / omero). Copied metadata
+# must never clobber it, so it is excluded from the verbatim zattr copy.
+_OME_METADATA_KEY: str = "ome"
+
+
+@dataclass
+class ExtractionSummary:
+    """Result of an :func:`extract_focus_slab_store` run.
+
+    Attributes
+    ----------
+    output_store : str
+        Absolute path of the written focus-slab store.
+    n_positions : int
+        Number of positions written.
+    n_planes : int
+        Slab depth (``2*halfwidth + 1``); uniform across all positions/timepoints.
+    pixel_size : float
+        Lateral spacing used for focus estimation.
+    focus_planes : dict of str to list of int
+        Per-position list of estimated focus z-planes (one per timepoint).
+    slab_starts : dict of str to list of int
+        Per-position list of clamp-shifted slab start z-indices (one per timepoint).
+    """
+
+    output_store: str
+    n_positions: int
+    n_planes: int
+    pixel_size: float
+    focus_planes: dict[str, list[int]] = field(default_factory=dict)
+    slab_starts: dict[str, list[int]] = field(default_factory=dict)
+
+
+def clamp_shift_slab(z_focus: int, z_total: int, halfwidth: int) -> slice:
+    """Return a ``slice`` of exactly ``2*halfwidth + 1`` planes centered on ``z_focus``.
+
+    Unlike :func:`dynacell.evaluation.focus.focus_slab_from_plane` (which clips at the
+    stack caps and can yield fewer planes near an edge), the whole window is
+    **shifted inward** into ``[0, z_total - width]`` so the returned slab always spans
+    ``2*halfwidth + 1`` planes. This keeps the derived zarr rectangular.
+
+    Parameters
+    ----------
+    z_focus : int
+        Estimated in-focus z-plane.
+    z_total : int
+        Number of z-planes in the source volume.
+    halfwidth : int
+        Planes on each side of the center; the slab spans ``2*halfwidth + 1``.
+
+    Returns
+    -------
+    slice
+        A z-slice of length ``2*halfwidth + 1``.
+
+    Raises
+    ------
+    ValueError
+        If ``halfwidth`` is negative, or the stack is too thin for a full slab
+        (``z_total < 2*halfwidth + 1``).
+    """
+    if halfwidth < 0:
+        raise ValueError(f"halfwidth must be >= 0, got {halfwidth}")
+    width = 2 * halfwidth + 1
+    if z_total < width:
+        raise ValueError(
+            f"stack has {z_total} planes but a halfwidth={halfwidth} slab needs {width}; "
+            "cannot clamp-shift a full slab out of a shorter stack"
+        )
+    lo = min(max(z_focus - halfwidth, 0), z_total - width)
+    return slice(lo, lo + width)
+
+
+def _custom_zattrs(node) -> dict:
+    """Return a node's custom zattrs (everything except the iohub-managed ``ome`` block)."""
+    return {k: v for k, v in dict(node.zattrs).items() if k != _OME_METADATA_KEY}
+
+
+def _split_position_name(name: str) -> tuple[str, str, str]:
+    """Split an HCS position path ``row/col/fov`` into its three components."""
+    parts = name.split("/")
+    if len(parts) != 3:
+        raise ValueError(f"expected an HCS 'row/col/fov' position path, got {name!r} ({len(parts)} parts)")
+    return parts[0], parts[1], parts[2]
+
+
+def extract_focus_slab_store(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    phase_channel: str = "Phase3D",
+    halfwidth: int = DEFAULT_HALFWIDTH,
+    limit_positions: int | None = None,
+    overwrite: bool = False,
+    pixel_size: float | None = None,
+    na_det: float = DEFAULT_NA_DET,
+    lambda_ill: float = DEFAULT_LAMBDA_ILL,
+    device: str = "cpu",
+) -> ExtractionSummary:
+    """Write a ``<name>_focus.zarr`` holding the in-focus slab of every channel.
+
+    For each position and timepoint, the focus plane is estimated on the
+    ``phase_channel`` volume with :func:`estimate_focus_plane`, then a
+    :func:`clamp_shift_slab` window of ``2*halfwidth + 1`` planes is cut from **all**
+    channels. ``omero`` and all custom zattrs are preserved.
+
+    Parameters
+    ----------
+    input_path : str or Path
+        Source 3D OME-Zarr HCS store.
+    output_path : str or Path
+        Destination focus-slab store.
+    phase_channel : str, optional
+        Channel used to estimate the focus plane (default ``"Phase3D"``).
+    halfwidth : int, optional
+        Half the slab depth; the slab spans ``2*halfwidth + 1`` planes (default 2).
+    limit_positions : int or None, optional
+        If set, only the first ``limit_positions`` positions are extracted (smoke runs).
+    overwrite : bool, optional
+        Replace an existing ``output_path`` (default False → raise if it exists).
+    pixel_size : float or None, optional
+        Lateral spacing for the focus estimator. ``None`` (default) reads the store's
+        ``position.scale[-1]``.
+    na_det, lambda_ill : float, optional
+        Detection NA and illumination wavelength for the transverse-band estimator.
+    device : str, optional
+        Torch device for the focus argmax (default ``"cpu"``).
+
+    Returns
+    -------
+    ExtractionSummary
+        Written store path, counts, and per-position focus planes / slab starts.
+
+    Raises
+    ------
+    FileExistsError
+        If ``output_path`` exists and ``overwrite`` is False.
+    ValueError
+        If ``phase_channel`` is absent, ``limit_positions < 1``, or a stack is too
+        thin for a full slab.
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+    if limit_positions is not None and limit_positions < 1:
+        raise ValueError(f"limit_positions must be >= 1, got {limit_positions}")
+    if output_path.exists():
+        if not overwrite:
+            raise FileExistsError(f"{output_path} already exists; pass overwrite=True to replace it")
+        shutil.rmtree(output_path)
+
+    width = 2 * halfwidth + 1
+    summary = ExtractionSummary(output_store=str(output_path), n_positions=0, n_planes=width, pixel_size=float("nan"))
+
+    with open_ome_zarr(input_path, mode="r") as src:
+        if phase_channel not in src.channel_names:
+            raise ValueError(f"phase channel {phase_channel!r} not in store channels {list(src.channel_names)}")
+        phase_idx = src.channel_names.index(phase_channel)
+        positions = list(src.positions())
+        if limit_positions is not None:
+            positions = positions[:limit_positions]
+        if not positions:
+            raise ValueError(f"{input_path} has no positions to extract")
+
+        resolved_pixel_size = float(positions[0][1].scale[-1]) if pixel_size is None else float(pixel_size)
+        summary.pixel_size = resolved_pixel_size
+        logger.info(
+            "focus estimator: channel=%s pixel_size=%g (%s) na_det=%g lambda_ill=%g midband=%s device=%s",
+            phase_channel,
+            resolved_pixel_size,
+            "store scale[-1]" if pixel_size is None else "override",
+            na_det,
+            lambda_ill,
+            MIDBAND_FRACTIONS,
+            device,
+        )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open_ome_zarr(output_path, layout="hcs", mode="w-", channel_names=list(src.channel_names)) as dst:
+            plate_custom = _custom_zattrs(src)
+            if plate_custom:
+                dst.zattrs.update(plate_custom)
+            dst.zattrs.update(
+                {
+                    "focus_slab_extraction": {
+                        "source_store": str(input_path),
+                        "phase_channel": phase_channel,
+                        "halfwidth": halfwidth,
+                        "n_planes": width,
+                        "pixel_size": resolved_pixel_size,
+                        "na_det": na_det,
+                        "lambda_ill": lambda_ill,
+                        "midband_fractions": list(MIDBAND_FRACTIONS),
+                    }
+                }
+            )
+
+            norm_note_emitted = False
+            for name, pos in positions:
+                data = pos.data
+                t_count, _, z_total = data.shape[0], data.shape[1], data.shape[2]
+                if z_total < width:
+                    raise ValueError(
+                        f"{name}: stack has {z_total} planes but a halfwidth={halfwidth} slab needs {width}"
+                    )
+                phase_tzyx = np.asarray(data[:, phase_idx])
+                planes = [
+                    estimate_focus_plane(
+                        phase_tzyx[t],
+                        na_det=na_det,
+                        lambda_ill=lambda_ill,
+                        pixel_size=resolved_pixel_size,
+                        device=device,
+                    )
+                    for t in range(t_count)
+                ]
+                slabs = [clamp_shift_slab(p, z_total, halfwidth) for p in planes]
+                slab_stack = np.stack([np.asarray(data[t, :, slabs[t]]) for t in range(t_count)])
+                if np.isnan(slab_stack).any():
+                    raise ValueError(f"{name}: NaN encountered in extracted slab")
+
+                row, col, fov = _split_position_name(name)
+                new_pos = dst.create_position(row, col, fov)
+                chunks = (1, 1, width, slab_stack.shape[-2], slab_stack.shape[-1])
+                new_pos.create_image(
+                    "0",
+                    slab_stack,
+                    chunks=chunks,
+                    transform=[TransformationMeta(type="scale", scale=list(pos.scale))],
+                )
+                new_pos.metadata.omero = pos.metadata.omero
+                new_pos.dump_meta()
+
+                pos_custom = _custom_zattrs(pos)
+                if "normalization" in pos_custom and not norm_note_emitted:
+                    logger.warning(
+                        "copying full-stack `normalization` zattrs verbatim onto the %d-plane focus slab "
+                        "(per-FOV stats NOT recomputed over the slab); re-use is intended per plan R3",
+                        width,
+                    )
+                    norm_note_emitted = True
+                if pos_custom:
+                    new_pos.zattrs.update(pos_custom)
+
+                summary.focus_planes[name] = planes
+                summary.slab_starts[name] = [s.start for s in slabs]
+                summary.n_positions += 1
+                logger.info("wrote %s: focus planes=%s slab starts=%s", name, planes, summary.slab_starts[name])
+
+    logger.info(
+        "done: %d positions (%d planes each) -> %s", summary.n_positions, summary.n_planes, summary.output_store
+    )
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: extract an in-focus slab store from a 3D train store."""
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", required=True, type=Path, help="source 3D OME-Zarr HCS store (absolute path)")
+    ap.add_argument("--output", required=True, type=Path, help="destination <name>_focus.zarr (absolute path)")
+    ap.add_argument("--phase-channel", default="Phase3D", help="channel for focus estimation (default: Phase3D)")
+    ap.add_argument("--halfwidth", type=int, default=DEFAULT_HALFWIDTH, help="slab half-depth; slab = 2*hw+1 (def: 2)")
+    ap.add_argument("--limit-positions", type=int, default=None, help="only extract the first N positions (smoke)")
+    ap.add_argument(
+        "--pixel-size",
+        type=float,
+        default=None,
+        help="lateral spacing for the focus estimator (default: read from store scale[-1])",
+    )
+    ap.add_argument("--na-det", type=float, default=DEFAULT_NA_DET, help=f"detection NA (default: {DEFAULT_NA_DET})")
+    ap.add_argument(
+        "--lambda-ill",
+        type=float,
+        default=DEFAULT_LAMBDA_ILL,
+        help=f"illumination wavelength (def: {DEFAULT_LAMBDA_ILL})",
+    )
+    ap.add_argument("--device", default="cpu", help="torch device for the focus argmax (default: cpu)")
+    ap.add_argument("--overwrite", action="store_true", help="replace an existing output store")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    extract_focus_slab_store(
+        args.input,
+        args.output,
+        phase_channel=args.phase_channel,
+        halfwidth=args.halfwidth,
+        limit_positions=args.limit_positions,
+        overwrite=args.overwrite,
+        pixel_size=args.pixel_size,
+        na_det=args.na_det,
+        lambda_ill=args.lambda_ill,
+        device=args.device,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/applications/dynacell/tools/extract_focus_slab_store.py
+++ b/applications/dynacell/tools/extract_focus_slab_store.py
@@ -253,7 +253,9 @@ def extract_focus_slab_store(
         )
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open_ome_zarr(output_path, layout="hcs", mode="w-", channel_names=list(src.channel_names)) as dst:
+        with open_ome_zarr(
+            output_path, layout="hcs", mode="w-", channel_names=list(src.channel_names), version="0.5"
+        ) as dst:
             plate_custom = _custom_zattrs(src)
             if plate_custom:
                 dst.zattrs.update(plate_custom)

--- a/applications/dynacell/tools/extract_focus_slab_store_test.py
+++ b/applications/dynacell/tools/extract_focus_slab_store_test.py
@@ -1,0 +1,256 @@
+r"""Integration tests for ``extract_focus_slab_store.py``.
+
+Each test builds a tiny synthetic 3D OME-Zarr in ``tmp_path`` whose ``Phase3D``
+channel has a *known* in-focus plane (a broadband texture that is progressively
+Gaussian-blurred away from a chosen z), so the real
+:func:`dynacell.evaluation.focus.estimate_focus_plane` returns that plane. The
+extractor is then run for real (no mocks) and the written store is reopened and
+asserted against.
+
+Run (worktree, cpdino-eval env, PYTHONPATH shadowing)::
+
+    PYTHONPATH="$WT/packages/viscy-models/src:$WT/packages/viscy-utils/src:\
+$WT/packages/viscy-transforms/src:$WT/packages/viscy-data/src:$WT/applications/dynacell/src" \\
+        "$V/bin/python" -m pytest applications/dynacell/tools/extract_focus_slab_store_test.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from iohub.ngff import TransformationMeta, open_ome_zarr
+from scipy.ndimage import gaussian_filter
+
+# The tools/ directory is not a Python package; add it to sys.path so the module
+# is importable by short name (mirrors generate_grouped_eval_configs_test.py).
+_TOOLS_DIR = Path(__file__).resolve().parent
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from extract_focus_slab_store import (  # noqa: E402
+    clamp_shift_slab,
+    extract_focus_slab_store,
+    main,
+)
+
+_CHANNELS = ["Phase3D", "Structure"]
+_PIXEL_SIZE = 0.1494
+_Z_SCALE = 0.174
+
+
+def _focus_stack(z_total: int, y: int, x: int, z_focus: int, seed: int) -> np.ndarray:
+    """Return a ``(Z, Y, X)`` volume sharpest (max midband power) at ``z_focus``.
+
+    A single broadband texture is progressively Gaussian-blurred with sigma growing
+    with ``|z - z_focus|``, so the sharpest plane (most transverse-band power) is
+    ``z_focus`` — exactly what the waveorder focus estimator picks.
+    """
+    rng = np.random.default_rng(seed)
+    base = rng.standard_normal((y, x)).astype(np.float32)
+    vol = np.empty((z_total, y, x), dtype=np.float32)
+    for z in range(z_total):
+        sigma = 0.9 * abs(z - z_focus)
+        vol[z] = base if sigma == 0 else gaussian_filter(base, sigma=sigma)
+    return vol
+
+
+def _make_synthetic_store(
+    path: Path,
+    *,
+    z_focus_per_pos: dict[str, int],
+    t: int = 2,
+    z_total: int = 12,
+    y: int = 64,
+    x: int = 64,
+    with_normalization: bool = True,
+) -> None:
+    """Write a tiny 3D HCS OME-Zarr with a known per-position Phase3D focus plane.
+
+    ``z_focus_per_pos`` maps an HCS ``row/col/fov`` position name to its injected
+    focus z (same across timepoints). The ``Structure`` channel carries a distinct,
+    z-varying pattern so channel copying is verifiable.
+    """
+    with open_ome_zarr(path, layout="hcs", mode="w-", channel_names=_CHANNELS) as plate:
+        if with_normalization:
+            plate.zattrs.update({"normalization": {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}})
+        for seed, (name, z_focus) in enumerate(z_focus_per_pos.items()):
+            row, col, fov = name.split("/")
+            phase = np.stack([_focus_stack(z_total, y, x, z_focus, seed=seed + 100 * s) for s in range(t)])
+            # Structure: a per-z ramp so each plane is uniquely identifiable after the copy.
+            structure = np.broadcast_to(
+                np.arange(z_total, dtype=np.float32)[None, :, None, None], (t, z_total, y, x)
+            ).copy()
+            data = np.stack([phase, structure], axis=1)  # (T, C=2, Z, Y, X)
+            pos = plate.create_position(row, col, fov)
+            pos.create_image(
+                "0",
+                data,
+                chunks=(1, 1, z_total, y, x),
+                transform=[TransformationMeta(type="scale", scale=[1.0, 1.0, _Z_SCALE, _PIXEL_SIZE, _PIXEL_SIZE])],
+            )
+            if with_normalization:
+                pos.zattrs.update(
+                    {
+                        "normalization": {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}},
+                        "condition": "mock",
+                    }
+                )
+
+
+def test_clamp_shift_slab_centered_and_edges() -> None:
+    """clamp_shift_slab yields a full 2*hw+1 window, shifted inward at the caps."""
+    # Centered: window straddles z_focus.
+    assert clamp_shift_slab(6, 12, 2) == slice(4, 9)
+    # Low edge: shift the whole window to start at 0 (not a clipped, shorter slab).
+    assert clamp_shift_slab(0, 12, 2) == slice(0, 5)
+    assert clamp_shift_slab(1, 12, 2) == slice(0, 5)
+    # High edge: shift so the window ends at z_total.
+    assert clamp_shift_slab(11, 12, 2) == slice(7, 12)
+    # halfwidth=0 -> single plane at the focus.
+    assert clamp_shift_slab(5, 12, 0) == slice(5, 6)
+    # Every case spans exactly 2*hw+1 planes.
+    for zf in range(12):
+        sl = clamp_shift_slab(zf, 12, 2)
+        assert sl.stop - sl.start == 5
+
+
+def test_clamp_shift_slab_too_thin_raises() -> None:
+    """A stack shorter than the slab width cannot yield a full slab."""
+    with pytest.raises(ValueError):
+        clamp_shift_slab(1, 3, 2)  # needs 5 planes, only 3
+    with pytest.raises(ValueError):
+        clamp_shift_slab(1, 10, -1)  # negative halfwidth
+
+
+def test_output_shape_channels_and_centering(tmp_path: Path) -> None:
+    """Output is (T, C, 2*hw+1, Y, X), channels preserved, slab centered on the focus plane."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=2, z_total=12, y=64, x=64)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    assert summary.n_positions == 1
+    assert summary.n_planes == 5
+    assert summary.pixel_size == pytest.approx(_PIXEL_SIZE)
+    assert summary.focus_planes["0/0/fov0000"] == [6, 6]
+    assert summary.slab_starts["0/0/fov0000"] == [4, 4]
+
+    with open_ome_zarr(src, mode="r") as src_plate, open_ome_zarr(out, mode="r") as out_plate:
+        assert out_plate.channel_names == _CHANNELS
+        _, src_pos = next(src_plate.positions())
+        _, out_pos = next(out_plate.positions())
+        assert out_pos.data.shape == (2, 2, 5, 64, 64)
+        assert not np.isnan(np.asarray(out_pos.data)).any()
+        # Center plane (index 2 of 5, hw=2) is the source focus plane z=6, all channels.
+        np.testing.assert_array_equal(np.asarray(out_pos.data[:, :, 2]), np.asarray(src_pos.data[:, :, 6]))
+        # Structure ramp confirms the copied z-range is [4, 9).
+        np.testing.assert_array_equal(np.asarray(out_pos.data[0, 1, :, 0, 0]), np.arange(4, 9, dtype=np.float32))
+
+
+def test_clamp_shift_edge_position_still_full_depth(tmp_path: Path) -> None:
+    """A focus plane at the stack edge still yields a full 2*hw+1 slab (window shifted)."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    # Low edge (focus at z=0) and high edge (focus at z=11) in one store.
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 0, "0/0/fov0001": 11}, t=2, z_total=12)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    assert summary.focus_planes["0/0/fov0000"] == [0, 0]
+    assert summary.slab_starts["0/0/fov0000"] == [0, 0]  # shifted inward, not -2
+    assert summary.focus_planes["0/0/fov0001"] == [11, 11]
+    assert summary.slab_starts["0/0/fov0001"] == [7, 7]  # shifted inward, ends at z_total
+
+    with open_ome_zarr(out, mode="r") as out_plate:
+        for _, pos in out_plate.positions():
+            assert pos.data.shape[2] == 5  # uniform full depth despite edge focus
+            assert not np.isnan(np.asarray(pos.data)).any()
+
+
+def test_limit_positions(tmp_path: Path) -> None:
+    """--limit-positions caps the number of extracted positions."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6, "0/0/fov0001": 5, "0/0/fov0002": 4}, t=1, z_total=12)
+
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2, limit_positions=1)
+
+    assert summary.n_positions == 1
+    with open_ome_zarr(out, mode="r") as out_plate:
+        assert len([n for n, _ in out_plate.positions()]) == 1
+
+
+def test_zattrs_and_omero_preserved(tmp_path: Path) -> None:
+    """Custom zattrs (normalization) and omero survive; provenance zattr is written."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12, with_normalization=True)
+
+    extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+
+    with open_ome_zarr(out, mode="r") as out_plate:
+        assert dict(out_plate.zattrs).get("normalization") == {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}
+        prov = dict(out_plate.zattrs)["focus_slab_extraction"]
+        assert prov["phase_channel"] == "Phase3D"
+        assert prov["halfwidth"] == 2
+        assert prov["n_planes"] == 5
+        _, out_pos = next(out_plate.positions())
+        pos_attrs = dict(out_pos.zattrs)
+        assert pos_attrs["condition"] == "mock"
+        assert pos_attrs["normalization"] == {"Phase3D": {"fov_statistics": {"mean": 0.0, "std": 1.0}}}
+        assert [c.label for c in out_pos.metadata.omero.channels] == _CHANNELS
+
+
+def test_overwrite_guard(tmp_path: Path) -> None:
+    """A second run without overwrite raises; with overwrite it succeeds."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12)
+
+    extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+    with pytest.raises(FileExistsError):
+        extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2)
+    # Overwrite succeeds and rewrites the store.
+    summary = extract_focus_slab_store(src, out, phase_channel="Phase3D", halfwidth=2, overwrite=True)
+    assert summary.n_positions == 1
+
+
+def test_missing_phase_channel_raises(tmp_path: Path) -> None:
+    """A phase channel absent from the store is a hard error (not a silent skip)."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6}, t=1, z_total=12)
+    with pytest.raises(ValueError, match="phase channel"):
+        extract_focus_slab_store(src, out, phase_channel="NotAChannel", halfwidth=2)
+
+
+def test_cli_main_smoke(tmp_path: Path) -> None:
+    """The argparse CLI runs end to end and writes a loadable focus store."""
+    src = tmp_path / "src.zarr"
+    out = tmp_path / "src_focus.zarr"
+    _make_synthetic_store(src, z_focus_per_pos={"0/0/fov0000": 6, "0/0/fov0001": 5}, t=1, z_total=12)
+
+    rc = main(
+        [
+            "--input",
+            str(src),
+            "--output",
+            str(out),
+            "--phase-channel",
+            "Phase3D",
+            "--halfwidth",
+            "2",
+            "--limit-positions",
+            "1",
+        ]
+    )
+    assert rc == 0
+    with open_ome_zarr(out, mode="r") as out_plate:
+        names = [n for n, _ in out_plate.positions()]
+        assert names == ["0/0/fov0000"]
+        _, pos = next(out_plate.positions())
+        assert pos.data.shape[2] == 5

--- a/packages/viscy-models/src/viscy_models/unet/unet3d.py
+++ b/packages/viscy-models/src/viscy_models/unet/unet3d.py
@@ -58,6 +58,12 @@ class Unet3d(UNet3DBase):
         (``example_input_array``, ``DivisiblePad``, sliding window prediction).
         The model itself handles arbitrary Z as long as it is divisible
         by ``2**depth``.
+    downsample_z : bool
+        Whether to downsample the Z axis in the encoder (``True`` preserves the
+        FNet3D behavior). Set ``False`` for a Z-preserving 2D-style network
+        (stride ``(1, 2, 2)``, ``ConvTranspose3d`` kernel ``(1, 3, 3)``), which
+        is required to run at ``Z=1`` without tripping the base ``D % 16``
+        divisor check.
     """
 
     def __init__(
@@ -67,6 +73,7 @@ class Unet3d(UNet3DBase):
         depth: int = 4,
         mult_chan: int = 32,
         in_stack_depth: int | None = None,
+        downsample_z: bool = True,
     ) -> None:
         dims = [mult_chan * (2**i) for i in range(depth + 1)]
         bottleneck = ConvBottleneck3D(dims[-1], residual=False, norm="batch", activation="relu")
@@ -76,7 +83,7 @@ class Unet3d(UNet3DBase):
             dims=dims,
             num_res_block=[1] * depth,
             bottleneck=bottleneck,
-            downsample_z=True,
+            downsample_z=downsample_z,
             residual=False,
             norm="batch",
             activation="relu",

--- a/packages/viscy-models/src/viscy_models/unet/unet3d.py
+++ b/packages/viscy-models/src/viscy_models/unet/unet3d.py
@@ -39,9 +39,10 @@ class Unet3d(UNet3DBase):
 
     FNet-configured preset of the unified 3D U-Net base with BatchNorm,
     ReLU activations, non-residual double-conv blocks, and a convolutional
-    bottleneck.  Downsamples all three spatial dimensions.
+    bottleneck.  Downsamples Y and X, and (when ``downsample_z=True``) Z.
 
-    All spatial dimensions (Z, Y, X) must be divisible by ``2**depth``.
+    Each downsampled spatial dimension must be divisible by ``2**depth``: Y and
+    X always, and Z only when ``downsample_z=True``.
 
     Parameters
     ----------
@@ -56,14 +57,14 @@ class Unet3d(UNet3DBase):
     in_stack_depth : int or None
         Z-window size. Stored for engine compatibility
         (``example_input_array``, ``DivisiblePad``, sliding window prediction).
-        The model itself handles arbitrary Z as long as it is divisible
-        by ``2**depth``.
+        The model itself handles arbitrary Z; when ``downsample_z=True`` the Z
+        size must be divisible by ``2**depth`` (no constraint when ``False``).
     downsample_z : bool
         Whether to downsample the Z axis in the encoder (``True`` preserves the
         FNet3D behavior). Set ``False`` for a Z-preserving 2D-style network
         (stride ``(1, 2, 2)``, ``ConvTranspose3d`` kernel ``(1, 3, 3)``), which
-        is required to run at ``Z=1`` without tripping the base ``D % 16``
-        divisor check.
+        is required to run at ``Z=1`` without tripping the base
+        ``D % 2**depth`` divisibility check.
     """
 
     def __init__(

--- a/packages/viscy-models/src/viscy_models/unet/unet3d_base.py
+++ b/packages/viscy-models/src/viscy_models/unet/unet3d_base.py
@@ -158,7 +158,15 @@ class UNet3DBase(nn.Module):
         -------
         Tensor
             Output tensor of shape ``(B, out_channels, D, H, W)``.
+
+        Raises
+        ------
+        ValueError
+            If ``x`` is not a 5D tensor, or a downsampled spatial dimension is
+            not divisible by ``2**num_blocks``.
         """
+        if x.ndim != 5:
+            raise ValueError(f"Expected 5D input (B, C, D, H, W), got {x.ndim}D.")
         for dim_name, size in zip(("D", "H", "W"), x.shape[2:]):
             if self.downsamples_z or dim_name != "D":
                 if size % self._divisor != 0:

--- a/packages/viscy-models/tests/test_unet/test_unet3d.py
+++ b/packages/viscy-models/tests/test_unet/test_unet3d.py
@@ -67,6 +67,33 @@ def test_engine_attributes():
     assert model.downsamples_z is True
 
 
+def test_downsample_z_default_preserves_fnet3d():
+    """Default downsample_z keeps the FNet3D Z-downsampling behavior."""
+    model = Unet3d(depth=4, mult_chan=32, in_stack_depth=32)
+    assert model.downsamples_z is True
+
+
+def test_downsample_z_false_z1_forward():
+    """downsample_z=False enables the FNet2D use case: a Z=1 forward runs and preserves Z.
+
+    With downsample_z=True (the FNet3D default) a Z=1 input trips the base
+    ``D % 2**depth`` divisor check; the Z-preserving path must skip that check.
+    """
+    model = Unet3d(in_channels=1, out_channels=1, depth=4, mult_chan=32, downsample_z=False)
+    assert model.downsamples_z is False
+    x = torch.randn(2, 1, 1, 64, 64)  # Y,X divisible by 2**4=16; Z=1
+    y = model(x)
+    assert y.shape == (2, 1, 1, 64, 64)
+
+
+def test_downsample_z_false_skips_z_divisor_check():
+    """With downsample_z=False, Z need not be divisible by 2**depth (only Y/X are checked)."""
+    model = Unet3d(in_channels=1, out_channels=1, depth=2, mult_chan=16, downsample_z=False)
+    x = torch.randn(1, 1, 3, 16, 16)  # Z=3 not divisible by 2^2=4, but Z is not downsampled
+    y = model(x)
+    assert y.shape == (1, 1, 3, 16, 16)
+
+
 def test_state_dict_keys():
     """State dict uses iterative encoder-decoder key structure."""
     model = Unet3d(in_channels=1, out_channels=1, depth=2, mult_chan=16)

--- a/packages/viscy-models/tests/test_unet/test_unet3d_base.py
+++ b/packages/viscy-models/tests/test_unet/test_unet3d_base.py
@@ -173,3 +173,10 @@ def test_dims_mismatch_raises():
     """len(dims) != len(num_res_block) + 1 raises ValueError."""
     with pytest.raises(ValueError, match="len\\(dims\\)"):
         _make_base(dims=(16, 32, 64), num_res_block=(1,))
+
+
+def test_forward_non_5d_input_raises():
+    """A non-5D input raises a clear ValueError, not a confusing Conv3d channel error."""
+    model = _make_base()
+    with pytest.raises(ValueError, match="Expected 5D input"):
+        model(torch.randn(2, 1, 16, 16))  # 4D: a squeezed Z dim


### PR DESCRIPTION
Adds the **2D in-focus virtual-staining model track** to the DynaCell benchmark — models trained on the in-focus slice extracted from the 3D data, for a 2D-vs-3D comparison. Stacks on #484 (the eval-side 2D plumbing: FRC + `exclude_fov_names`).

## Scope
3 models × 3 train_sets × 4 organelles = **36 fit leaves**:
- `fcmae_vscyto2d_scratch` (UNeXt2-2D, random init)
- `fcmae_vscyto2d_pretrained` (VSCyto2D, FCMAE-pretrained encoder init, lr 2e-4)
- `fnet2d` (FNet with `downsample_z=false`, Z-preserving)

2D geometry: `in_stack_depth=1`, `stem_kernel_size=[1,2,2]`, `z_window_size=1`. In-focus data = offline 5-plane `_focus.zarr` slab stores (waveorder-phase focus on Phase3D), extracted from the campaign's 3D train stores.

## Commits
- `5d2671b8` expose `downsample_z` on `Unet3d` (Z-preserving FNet2D; +tests)
- `ce22258a` offline focus-slab store extractor (`extract_focus_slab_store.py` +tests)
- `eb68a45d` 2D config overlays (fcmae_vscyto2d + fnet2d, fit + predict)
- `98398330` nucleus/a549 smoke fit+predict leaves (exemplar)
- `b7a1a454` **fix**: identity Z scale in FCMAE-2D affine (kornia scale factor 0 → singular-matrix crash)
- `f701de71` **fix**: single-GPU batch 32→16 to fit the 48 GB pool (keeps 2D fits off scarce Hopper)
- `3cc012ab` / `eef10cbb` / `ff982afc` the 36 fit leaves (scratch / pretrained / fnet2d)

## Verification
All 36 leaves render clean via `submit_benchmark_job.py --print-resolved-config` (correct 2D geometry, `_focus.zarr` data paths, per-organelle target channels). The nucleus/a549 FCMAE-2D config trained end-to-end in a 1-epoch smoke fit (both overlay bugs above were found + fixed there).

## Not in this PR
Phase E (training the 36 fits), Phase F/G (predict + register + re-eval — gated behind training + the campaign's Phase 10). Predict leaves (144) trail training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aLSCR6RRyUwjHXzF2RAKg